### PR TITLE
add leave event to make entering a client more reliable

### DIFF
--- a/src/backend/consumer/macos.rs
+++ b/src/backend/consumer/macos.rs
@@ -209,9 +209,7 @@ impl EventConsumer for MacOSConsumer {
                 }
                 KeyboardEvent::Modifiers { .. } => {}
             },
-            Event::Release() => {}
-            Event::Ping() => {}
-            Event::Pong() => {}
+            _ => ()
         }
     }
 

--- a/src/backend/producer/wayland.rs
+++ b/src/backend/producer/wayland.rs
@@ -662,7 +662,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for State {
                     .iter()
                     .find(|(w, _c)| w.surface == surface)
                     .unwrap();
-                app.pending_events.push_back((*client, Event::Release()));
+                app.pending_events.push_back((*client, Event::Enter()));
             }
             wl_pointer::Event::Leave { .. } => {
                 app.ungrab();


### PR DESCRIPTION
Instead of relying on release events not getting lost, every event now signals the opponent
to release its pointer grab.

There is one case that requires a Leave event:

Consider a Sending client A and receiving Client B.

If B enters the dead-zone of client A, it will send an enter event towards A but before
A receives the Release event, it may still send additional events towards B that should not cause
B to immediately revert to Receiving state again.

Therefore B puts itself into `AwaitingLeave` state until it receives a Leave event coming from A.
A responds to the Enter event coming from B with a leave event, to signify that it will no longer
send any events and releases it's pointer.

To guard against packet loss of the leave events, B sends additional enter events while it is in `AwaitingLeave`
mode until it receives a Leave event at some point.

This is still not resilient against possible packet reordering in UDP but in the (rare) case where a leave event arrives before some other event coming from A, the user would simply need to move the pointer into the dead-zone again.