### PR TITLE
release stuck keys

### DIFF
--- a/src/backend/producer/wayland.rs
+++ b/src/backend/producer/wayland.rs
@@ -568,6 +568,7 @@ impl EventProducer for WaylandEventProducer {
     }
 
     fn release(&mut self) {
+        log::debug!("releasing pointer");
         let inner = self.0.get_mut();
         inner.state.ungrab();
         inner.flush_events();

--- a/src/client.rs
+++ b/src/client.rs
@@ -66,7 +66,7 @@ pub struct Client {
     pub pos: Position,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ClientEvent {
     Create(ClientHandle, Position),
     Destroy(ClientHandle),

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashSet,
     fmt::Display,
     net::{IpAddr, SocketAddr},
-    time::Instant,
 };
 
 use serde::{Deserialize, Serialize};
@@ -57,10 +56,6 @@ pub struct Client {
     /// This way any event consumer / producer backend does not
     /// need to know anything about a client other than its handle.
     pub handle: ClientHandle,
-    /// `active` address of the client, used to send data to.
-    /// This should generally be the socket address where data
-    /// was last received from.
-    pub active_addr: Option<SocketAddr>,
     /// all socket addresses associated with a particular client
     /// e.g. Laptops usually have at least an ethernet and a wifi port
     /// which have different ip addresses
@@ -81,11 +76,18 @@ pub type ClientHandle = u32;
 
 #[derive(Debug, Clone)]
 pub struct ClientState {
+    /// information about the client
     pub client: Client,
+    /// events should be sent to and received from the client
     pub active: bool,
-    pub last_ping: Option<Instant>,
-    pub last_seen: Option<Instant>,
-    pub last_replied: Option<Instant>,
+    /// `active` address of the client, used to send data to.
+    /// This should generally be the socket address where data
+    /// was last received from.
+    pub active_addr: Option<SocketAddr>,
+    /// tracks whether or not the client is responding to pings
+    pub alive: bool,
+    /// keys currently pressed by this client
+    pub pressed_keys: HashSet<u32>,
 }
 
 pub struct ClientManager {
@@ -114,9 +116,6 @@ impl ClientManager {
         // get a new client_handle
         let handle = self.free_id();
 
-        // we dont know, which IP is initially active
-        let active_addr = None;
-
         // store fix ip addresses
         let fix_ips = ips.iter().cloned().collect();
 
@@ -128,7 +127,6 @@ impl ClientManager {
             hostname,
             fix_ips,
             handle,
-            active_addr,
             addrs,
             port,
             pos,
@@ -137,10 +135,10 @@ impl ClientManager {
         // client was never seen, nor pinged
         let client_state = ClientState {
             client,
-            last_ping: None,
-            last_seen: None,
-            last_replied: None,
             active: false,
+            active_addr: None,
+            alive: false,
+            pressed_keys: HashSet::new(),
         };
 
         if handle as usize >= self.clients.len() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -66,6 +66,9 @@ pub enum Event {
     /// response to a ping event: this event signals that a client
     /// is still alive but must otherwise be ignored
     Pong(),
+    /// explicit disconnect request. The client will no longer
+    /// send events until the next Enter event. All of its keys should be released.
+    Disconnect(),
 }
 
 impl Display for PointerEvent {
@@ -121,6 +124,7 @@ impl Display for Event {
             Event::Leave() => write!(f, "leave"),
             Event::Ping() => write!(f, "ping"),
             Event::Pong() => write!(f, "pong"),
+            Event::Disconnect() => write!(f, "disconnect"),
         }
     }
 }
@@ -134,6 +138,7 @@ impl Event {
             Self::Leave() => EventType::Leave,
             Self::Ping() => EventType::Ping,
             Self::Pong() => EventType::Pong,
+            Self::Disconnect() => EventType::Disconnect,
         }
     }
 }
@@ -175,6 +180,7 @@ enum EventType {
     Leave,
     Ping,
     Pong,
+    Disconnect,
 }
 
 impl TryFrom<u8> for PointerEventType {
@@ -217,6 +223,7 @@ impl From<&Event> for Vec<u8> {
             Event::Leave() => vec![],
             Event::Ping() => vec![],
             Event::Pong() => vec![],
+            Event::Disconnect() => vec![],
         };
         [event_id, event_data].concat()
     }
@@ -246,6 +253,7 @@ impl TryFrom<Vec<u8>> for Event {
             i if i == (EventType::Leave as u8) => Ok(Event::Leave()),
             i if i == (EventType::Ping as u8) => Ok(Event::Ping()),
             i if i == (EventType::Pong as u8) => Ok(Event::Pong()),
+            i if i == (EventType::Disconnect as u8) => Ok(Event::Disconnect()),
             _ => Err(anyhow!(ProtocolError {
                 msg: format!("invalid event_id {}", event_id),
             })),

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use std::{
     error::Error,
     fmt::{self, Display},
@@ -177,15 +178,15 @@ enum EventType {
 }
 
 impl TryFrom<u8> for PointerEventType {
-    type Error = Box<dyn Error>;
+    type Error = anyhow::Error;
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self> {
         match value {
             x if x == Self::Motion as u8 => Ok(Self::Motion),
             x if x == Self::Button as u8 => Ok(Self::Button),
             x if x == Self::Axis as u8 => Ok(Self::Axis),
             x if x == Self::Frame as u8 => Ok(Self::Frame),
-            _ => Err(Box::new(ProtocolError {
+            _ => Err(anyhow!(ProtocolError {
                 msg: format!("invalid pointer event type {}", value),
             })),
         }
@@ -193,13 +194,13 @@ impl TryFrom<u8> for PointerEventType {
 }
 
 impl TryFrom<u8> for KeyboardEventType {
-    type Error = Box<dyn Error>;
+    type Error = anyhow::Error;
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self> {
         match value {
             x if x == Self::Key as u8 => Ok(Self::Key),
             x if x == Self::Modifiers as u8 => Ok(Self::Modifiers),
-            _ => Err(Box::new(ProtocolError {
+            _ => Err(anyhow!(ProtocolError {
                 msg: format!("invalid keyboard event type {}", value),
             })),
         }
@@ -234,9 +235,9 @@ impl fmt::Display for ProtocolError {
 impl Error for ProtocolError {}
 
 impl TryFrom<Vec<u8>> for Event {
-    type Error = Box<dyn Error>;
+    type Error = anyhow::Error;
 
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(value: Vec<u8>) -> Result<Self> {
         let event_id = u8::from_be_bytes(value[..1].try_into()?);
         match event_id {
             i if i == (EventType::Pointer as u8) => Ok(Event::Pointer(value.try_into()?)),
@@ -245,7 +246,7 @@ impl TryFrom<Vec<u8>> for Event {
             i if i == (EventType::Leave as u8) => Ok(Event::Leave()),
             i if i == (EventType::Ping as u8) => Ok(Event::Ping()),
             i if i == (EventType::Pong as u8) => Ok(Event::Pong()),
-            _ => Err(Box::new(ProtocolError {
+            _ => Err(anyhow!(ProtocolError {
                 msg: format!("invalid event_id {}", event_id),
             })),
         }
@@ -291,9 +292,9 @@ impl From<&PointerEvent> for Vec<u8> {
 }
 
 impl TryFrom<Vec<u8>> for PointerEvent {
-    type Error = Box<dyn Error>;
+    type Error = anyhow::Error;
 
-    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(data: Vec<u8>) -> Result<Self> {
         match data.get(1) {
             Some(id) => {
                 let event_type = match id.to_owned().try_into() {
@@ -305,7 +306,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let time = match data.get(2..6) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 2".into(),
                                 }))
                             }
@@ -313,7 +314,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let relative_x = match data.get(6..14) {
                             Some(d) => f64::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 8 Bytes at index 6".into(),
                                 }))
                             }
@@ -321,7 +322,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let relative_y = match data.get(14..22) {
                             Some(d) => f64::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 8 Bytes at index 14".into(),
                                 }))
                             }
@@ -336,7 +337,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let time = match data.get(2..6) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 2".into(),
                                 }))
                             }
@@ -344,7 +345,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let button = match data.get(6..10) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 10".into(),
                                 }))
                             }
@@ -352,7 +353,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let state = match data.get(10..14) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 14".into(),
                                 }))
                             }
@@ -367,7 +368,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let time = match data.get(2..6) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 2".into(),
                                 }))
                             }
@@ -375,7 +376,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let axis = match data.get(6) {
                             Some(d) => *d,
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 1 Byte at index 6".into(),
                                 }));
                             }
@@ -383,7 +384,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                         let value = match data.get(7..15) {
                             Some(d) => f64::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 8 Bytes at index 7".into(),
                                 }));
                             }
@@ -393,7 +394,7 @@ impl TryFrom<Vec<u8>> for PointerEvent {
                     PointerEventType::Frame => Ok(Self::Frame {}),
                 }
             }
-            None => Err(Box::new(ProtocolError {
+            None => Err(anyhow!(ProtocolError {
                 msg: "Expected an element at index 0".into(),
             })),
         }
@@ -434,9 +435,9 @@ impl From<&KeyboardEvent> for Vec<u8> {
 }
 
 impl TryFrom<Vec<u8>> for KeyboardEvent {
-    type Error = Box<dyn Error>;
+    type Error = anyhow::Error;
 
-    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(data: Vec<u8>) -> Result<Self> {
         match data.get(1) {
             Some(id) => {
                 let event_type = match id.to_owned().try_into() {
@@ -448,7 +449,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let time = match data.get(2..6) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 6".into(),
                                 }))
                             }
@@ -456,7 +457,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let key = match data.get(6..10) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 10".into(),
                                 }))
                             }
@@ -464,7 +465,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let state = match data.get(10) {
                             Some(d) => *d,
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 1 Bytes at index 14".into(),
                                 }))
                             }
@@ -475,7 +476,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let mods_depressed = match data.get(2..6) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 6".into(),
                                 }))
                             }
@@ -483,7 +484,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let mods_latched = match data.get(6..10) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 10".into(),
                                 }))
                             }
@@ -491,7 +492,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let mods_locked = match data.get(10..14) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 14".into(),
                                 }))
                             }
@@ -499,7 +500,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                         let group = match data.get(14..18) {
                             Some(d) => u32::from_be_bytes(d.try_into()?),
                             None => {
-                                return Err(Box::new(ProtocolError {
+                                return Err(anyhow!(ProtocolError {
                                     msg: "Expected 4 Bytes at index 18".into(),
                                 }))
                             }
@@ -513,7 +514,7 @@ impl TryFrom<Vec<u8>> for KeyboardEvent {
                     }
                 }
             }
-            None => Err(Box::new(ProtocolError {
+            None => Err(anyhow!(ProtocolError {
                 msg: "Expected an element at index 0".into(),
             })),
         }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -108,6 +108,7 @@ pub enum FrontendNotify {
     NotifyClientDelete(ClientHandle),
     /// new port, reason of failure (if failed)
     NotifyPortChange(u16, Option<String>),
+    /// Client State, active
     Enumerate(Vec<(Client, bool)>),
     NotifyError(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,9 @@ fn run_service(config: &Config) -> Result<()> {
     runtime.block_on(LocalSet::new().run_until(async {
         // run main loop
         log::info!("Press Ctrl+Alt+Shift+Super to release the mouse");
-        Server::run(config).await?;
+
+        let server = Server::new(config);
+        server.run(config).await?;
 
         log::debug!("service exiting");
         anyhow::Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn run_service(config: &Config) -> Result<()> {
         log::info!("Press Ctrl+Alt+Shift+Super to release the mouse");
 
         let server = Server::new(config);
-        server.run(config).await?;
+        server.run().await?;
 
         log::debug!("service exiting");
         anyhow::Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -381,7 +381,7 @@ impl Server {
                     if receiving {
                         log::debug!("waiting {MAX_RESPONSE_TIME:?} for response from client with pressed keys ...");
                     } else {
-                        log::debug!("waiting {MAX_RESPONSE_TIME:?} for client to respond ...");
+                        log::debug!("state: {:?} => waiting {MAX_RESPONSE_TIME:?} for client to respond ...", server.state.get());
                     }
 
                     tokio::time::sleep(MAX_RESPONSE_TIME).await;
@@ -806,7 +806,7 @@ impl Server {
 
             // if we just entered the client we want to send additional enter events until
             // we get a leave event
-            if let State::Receiving | State::AwaitingLeave = self.state.get() {
+            if let Event::Enter() = e {
                 self.state.replace(State::AwaitingLeave);
                 self.active_client.replace(Some(client_state.client.handle));
                 log::trace!("Active client => {}", client_state.client.handle);

--- a/src/server.rs
+++ b/src/server.rs
@@ -446,11 +446,11 @@ impl Server {
             }
         });
 
+        reaper.await?;
+
         let _ = consumer_notify_tx.send(ConsumerEvent::Terminate).await;
         let _ = producer_notify_tx.send(ProducerEvent::Terminate).await;
         let _ = frontend_tx.send(FrontendEvent::Shutdown()).await;
-
-        reaper.await?;
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -451,7 +451,7 @@ impl Server {
         let _ = producer_notify_tx.send(ProducerEvent::Terminate).await;
         let _ = frontend_tx.send(FrontendEvent::Shutdown()).await;
 
-        let (a,b,c) = tokio::join!(producer_task, consumer_task, frontend_task);
+        let (a, b, c) = tokio::join!(producer_task, consumer_task, frontend_task);
         a??;
         b??;
         c??;

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,7 @@ use crate::{
     consumer::EventConsumer,
     dns,
     frontend::{self, FrontendEvent, FrontendListener, FrontendNotify},
-    producer::EventProducer,
+    producer::EventProducer, scancode,
 };
 use crate::{
     consumer,
@@ -918,7 +918,11 @@ impl Server {
                 state: 0,
             });
             consumer.consume(event, client).await;
+            if let Ok(key) = scancode::Linux::try_from(key) {
+                log::debug!("releasing stuck key: {key:?}");
+            }
         }
+
         let modifiers_event = KeyboardEvent::Modifiers {
             mods_depressed: 0,
             mods_latched: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,8 @@ use crate::{
     consumer::EventConsumer,
     dns,
     frontend::{self, FrontendEvent, FrontendListener, FrontendNotify},
-    producer::EventProducer, scancode,
+    producer::EventProducer,
+    scancode,
 };
 use crate::{
     consumer,
@@ -929,7 +930,9 @@ impl Server {
             mods_locked: 0,
             group: 0,
         };
-        consumer.consume(Event::Keyboard(modifiers_event), client).await;
+        consumer
+            .consume(Event::Keyboard(modifiers_event), client)
+            .await;
     }
 
     async fn enumerate(&self, frontend: &mut FrontendListener) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,7 +96,7 @@ impl Server {
         }
     }
 
-    pub async fn run(&self, config: &Config) -> anyhow::Result<()> {
+    pub async fn run(&self) -> anyhow::Result<()> {
         // create frontend communication adapter
         let mut frontend = match FrontendListener::new().await {
             Some(Err(e)) => return Err(e),
@@ -258,7 +258,7 @@ impl Server {
         });
 
         // bind the udp socket
-        let listen_addr = SocketAddr::new("0.0.0.0".parse().unwrap(), config.port);
+        let listen_addr = SocketAddr::new("0.0.0.0".parse().unwrap(), self.port.get());
         let mut socket = UdpSocket::bind(listen_addr).await?;
         // udp task
         let udp_task = tokio::task::spawn_local(async move {


### PR DESCRIPTION
This fixes an issue with KDE's implementation of the remote desktop portal backend.
KDE does not correctly release keys when a remote desktop session is closed while keys are still pressed.

This causes them to be stuck until kwin is restarted.

This workaround remembers all pressed keys and releases them when lan-mouse exits or a device enters the screen.

closes #15 