### PR TITLE
Fix Error handling in layershell producer

### DIFF
--- a/src/backend/producer/dummy.rs
+++ b/src/backend/producer/dummy.rs
@@ -24,9 +24,13 @@ impl Default for DummyProducer {
 }
 
 impl EventProducer for DummyProducer {
-    fn notify(&mut self, _: ClientEvent) {}
+    fn notify(&mut self, _event: ClientEvent) -> io::Result<()> {
+        Ok(())
+    }
 
-    fn release(&mut self) {}
+    fn release(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl Stream for DummyProducer {

--- a/src/backend/producer/libei.rs
+++ b/src/backend/producer/libei.rs
@@ -3,7 +3,11 @@ use std::{io, task::Poll};
 
 use futures_core::Stream;
 
-use crate::{client::ClientHandle, event::Event, producer::EventProducer};
+use crate::{
+    client::{ClientEvent, ClientHandle},
+    event::Event,
+    producer::EventProducer,
+};
 
 pub struct LibeiProducer {}
 
@@ -14,9 +18,13 @@ impl LibeiProducer {
 }
 
 impl EventProducer for LibeiProducer {
-    fn notify(&mut self, _event: crate::client::ClientEvent) {}
+    fn notify(&mut self, _event: ClientEvent) -> io::Result<()> {
+        Ok(())
+    }
 
-    fn release(&mut self) {}
+    fn release(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl Stream for LibeiProducer {

--- a/src/backend/producer/macos.rs
+++ b/src/backend/producer/macos.rs
@@ -23,7 +23,11 @@ impl Stream for MacOSProducer {
 }
 
 impl EventProducer for MacOSProducer {
-    fn notify(&mut self, _event: ClientEvent) {}
+    fn notify(&mut self, _event: ClientEvent) -> io::Result<()> {
+        Ok(())
+    }
 
-    fn release(&mut self) {}
+    fn release(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }

--- a/src/backend/producer/windows.rs
+++ b/src/backend/producer/windows.rs
@@ -12,9 +12,13 @@ use crate::{
 pub struct WindowsProducer {}
 
 impl EventProducer for WindowsProducer {
-    fn notify(&mut self, _: ClientEvent) {}
+    fn notify(&mut self, _event: ClientEvent) -> io::Result<()> {
+        Ok(())
+    }
 
-    fn release(&mut self) {}
+    fn release(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl WindowsProducer {

--- a/src/backend/producer/x11.rs
+++ b/src/backend/producer/x11.rs
@@ -18,9 +18,13 @@ impl X11Producer {
 }
 
 impl EventProducer for X11Producer {
-    fn notify(&mut self, _: ClientEvent) {}
+    fn notify(&mut self, _event: ClientEvent) -> io::Result<()> {
+        Ok(())
+    }
 
-    fn release(&mut self) {}
+    fn release(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl Stream for X11Producer {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -54,8 +54,8 @@ pub async fn create() -> Box<dyn EventProducer> {
 
 pub trait EventProducer: Stream<Item = io::Result<(ClientHandle, Event)>> + Unpin {
     /// notify event producer of configuration changes
-    fn notify(&mut self, event: ClientEvent);
+    fn notify(&mut self, event: ClientEvent) -> io::Result<()>;
 
     /// release mouse
-    fn release(&mut self);
+    fn release(&mut self) -> io::Result<()>;
 }


### PR DESCRIPTION
previous error handling resulted in a softlock when the connection to the compositor was lost