### PR TITLE
ignore every event except Enter in receiving mode

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -11,7 +11,7 @@ pub const BTN_MIDDLE: u32 = 0x112;
 pub const BTN_BACK: u32 = 0x113;
 pub const BTN_FORWARD: u32 = 0x114;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum PointerEvent {
     Motion {
         time: u32,
@@ -31,7 +31,7 @@ pub enum PointerEvent {
     Frame {},
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum KeyboardEvent {
     Key {
         time: u32,
@@ -46,7 +46,7 @@ pub enum KeyboardEvent {
     },
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Event {
     /// pointer event (motion / button / axis)
     Pointer(PointerEvent),

--- a/src/server.rs
+++ b/src/server.rs
@@ -824,6 +824,11 @@ impl Server {
                 start_timer = true;
                 log::trace!("STATE ===> AwaitingLeave");
                 enter = true;
+            } else {
+                // ignore any potential events in receiving mode
+                if self.state.get() == State::Receiving && e != Event::Disconnect() {
+                    return Ok(());
+                }
             }
 
             (client_state.active_addr, enter, start_timer)


### PR DESCRIPTION
Some compositors still send keyevents to the layer-shell window until it is unfocused which causes unwanted behaviour.