### PR TITLE
macos: add keyboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
+name = "arraydeque"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ffd3d69bd89910509a5d31d1f1353f38ccffdd116dd0099bbd6627f7bd8ad8"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +412,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.42",
@@ -540,7 +555,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.42",
@@ -961,7 +976,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72793962ceece3863c2965d7f10c8786323b17c7adea75a515809fa20ab799a5"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-crate 2.0.1",
  "proc-macro-error",
  "proc-macro2",
@@ -1106,6 +1121,15 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1225,6 +1249,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "keycode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07873c3182aec8a0eb1a5a4e7b197d42e9d167ba78497a6ee932a82d94673ed"
+dependencies = [
+ "arraydeque",
+ "arrayvec",
+ "bitflags 1.3.2",
+ "keycode_macro",
+]
+
+[[package]]
+name = "keycode_macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e521ea802f5b3c7194e169d75cab431b0ff08d022f2b6047b08754b4988b89df"
+dependencies = [
+ "anyhow",
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "lan-mouse"
 version = "0.5.1"
 dependencies = [
@@ -1239,6 +1287,7 @@ dependencies = [
  "futures-core",
  "glib-build-tools",
  "gtk4",
+ "keycode",
  "libadwaita",
  "libc",
  "log",
@@ -1420,6 +1469,12 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num_cpus"
@@ -1959,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.4.1",
  "pkg-config",
  "toml",
  "version-compare",
@@ -2217,6 +2272,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clap = { version="4.4.11", features = ["derive"] }
 gtk = { package = "gtk4", version = "0.7.2", features = ["v4_2"], optional = true }
 adw = { package = "libadwaita", version = "0.5.2", features = ["v1_1"], optional = true }
 async-channel = { version = "2.1.1", optional = true }
+keycode = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.148"

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ input capture (to send events *to* other clients) on different operating systems
 | Wayland (Gnome)           | :heavy_check_mark:       | WIP                                  |
 | X11                       | :heavy_check_mark:       | WIP                                  |
 | Windows                   | :heavy_check_mark:       | WIP                                  |
-| MacOS                     | ( :heavy_check_mark: )   | WIP                                  |
-
-Keycode translation is not yet implemented so on MacOS only mouse emulation works as of right now.
+| MacOS                     | :heavy_check_mark:       | WIP                                  |
 
 > [!Important]
 > If you are using [Wayfire](https://github.com/WayfireWM/wayfire), make sure to use a recent version (must be newer than October 23rd) and **add `shortcuts-inhibit` to the list of plugins in your wayfire config!**

--- a/src/backend/consumer/macos.rs
+++ b/src/backend/consumer/macos.rs
@@ -97,14 +97,7 @@ impl MacOSConsumer {
 }
 
 fn key_event(event_source: CGEventSource, key: u16, state: u8) {
-    let event = match CGEvent::new_keyboard_event(
-        event_source,
-        key,
-        match state {
-            1 => true,
-            _ => false,
-        },
-    ) {
+    let event = match CGEvent::new_keyboard_event(event_source, key, state != 0) {
         Ok(e) => e,
         Err(_) => {
             log::warn!("unable to create key event");


### PR DESCRIPTION
`keycode` is doing all the heavy lifting here.

I encountered some odd behaviour with Caps lock (which I've mapped to Control) getting stuck, but keys appear to be translated properly otherwise.