### PR TITLE
nix: Add aarch64-darwin package and devshell

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -3,8 +3,14 @@ name: Binary Cache
 on: [push, pull_request, workflow_dispatch]
 jobs:
   nix:
+    strategy:
+      matrix:
+       os: 
+        - ubuntu-latest
+        - macos-latest
+        - macos-14
     name: "Build"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }} 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -20,5 +26,15 @@ jobs:
         name: lan-mouse
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    - name: Build lan-mouse
-      run: nix build --print-build-logs
+    - name: Build lan-mouse (x86_64-linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: nix build --print-build-logs --show-trace .#packages.x86_64-linux.lan-mouse
+
+    - name: Build lan-mouse (x86_64-darwin)
+      if: matrix.os == 'macos-latest'
+      run: nix build --print-build-logs --show-trace .#packages.x86_64-darwin.lan-mouse
+
+    - name: Build lan-mouse (aarch64-darwin)
+      if: matrix.os == 'macos-14'
+      run: nix build --print-build-logs --show-trace .#packages.aarch64-darwin.lan-mouse
+

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,8 @@
   }: let
     inherit (nixpkgs) lib;
     genSystems = lib.genAttrs [
+      "aarch64-darwin"
+      "x86_64-darwin"
       "x86_64-linux"
     ];
     pkgsFor = system:
@@ -49,6 +51,8 @@
           gtk4
           libadwaita
           xorg.libXtst
+        ] ++ lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk_11_0.frameworks.CoreGraphics
         ];
 
         RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage {
     gtk4
     libadwaita
     xorg.libXtst
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.CoreGraphics
   ];
 
   src = builtins.path {


### PR DESCRIPTION
Enable building and developing using nix on aarch64-darwin

It should be possible to just add `x86_64-darwin` to systems as well, however i don't have machine to test it on hand