### PR TITLE
nix: enable creating config file via home-manager

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -34,6 +34,9 @@ enable lan-mouse
     enable = true;
     # systemd = false;
     # package = inputs.lan-mouse.packages.${pkgs.stdenv.hostPlatform.system}.default
+    # Optional configuration in nix syntax, see config.toml for available options
+    # settings = { };
+    };
   };
 }
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -7,6 +7,7 @@ self: {
 with lib; let
   cfg = config.programs.lan-mouse;
   defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  tomlFormat = pkgs.formats.toml {};
 in {
   options.programs.lan-mouse = with types; {
     enable = mkEnableOption "Whether or not to enable lan-mouse.";
@@ -24,6 +25,17 @@ in {
       type = types.bool;
       default = pkgs.stdenv.isLinux;
       description = "Whether to enable to systemd service for lan-mouse.";
+    };
+    settings = lib.mkOption {
+      inherit (tomlFormat) type;
+      default = {};
+      example = builtins.fromTOML (builtins.readFile (self + /config.toml));
+      description = ''
+        Optional configuration written to {file}`$XDG_CONFIG_HOME/lan-mouse/config.toml`.
+
+        See <https://github.com/feschber/lan-mouse/> for
+        available options and documentation.
+      '';
     };
   };
 
@@ -46,5 +58,9 @@ in {
     home.packages = [
       cfg.package
     ];
+
+    xdg.configFile."lan-mouse/config.toml" = lib.mkIf (cfg.settings != {}) {
+      source = tomlFormat.generate "config.toml" cfg.settings;
+    };
   };
 }


### PR DESCRIPTION
In order to have a completely declarative setup using nix