### PR TITLE
nix: Add macOS launchd service to hm-module module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -23,7 +23,12 @@ in {
     systemd = mkOption {
       type = types.bool;
       default = pkgs.stdenv.isLinux;
-      description = "Whether to enable to systemd service for lan-mouse.";
+      description = "Whether to enable to systemd service for lan-mouse on linux.";
+    };
+    launchd = mkOption {
+      type = types.bool;
+      default = pkgs.stdenv.isDarwin;
+      description = "Whether to enable to launchd service for lan-mouse on macOS.";
     };
   };
 
@@ -41,6 +46,17 @@ in {
         (lib.mkIf config.wayland.windowManager.hyprland.systemd.enable "hyprland-session.target")
         (lib.mkIf config.wayland.windowManager.sway.systemd.enable "sway-session.target")
       ];
+    };
+
+    launchd.agents.lan-mouse = lib.mkIf cfg.launchd {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          "${cfg.package}/bin/lan-mouse"
+          "--daemon"
+        ];
+        KeepAlive = true;
+      };
     };
 
     home.packages = [


### PR DESCRIPTION
Home manager has the possibility to run macOS launchd services. These are automatically disabled when running on linux.