### PR TITLE
Extract package name and version from Cargo.toml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710806803,
-        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "lastModified": 1716293225,
+        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710987136,
-        "narHash": "sha256-Q8GRdlAIKZ8tJUXrbcRO1pA33AdoPfTUirsSnmGQnOU=",
+        "lastModified": 1716257780,
+        "narHash": "sha256-R+NjvJzKEkTVCmdrKRfPE4liX/KMGVqGUwwS5H8ET8A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "97596b54ac34ad8184ca1eef44b1ec2e5c2b5f9e",
+        "rev": "4e5e3d2c5c9b2721bd266f9e43c14e96811b89d2",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,10 +2,14 @@
   rustPlatform,
   lib,
   pkgs,
-}:
+}: let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+in
 rustPlatform.buildRustPackage {
-  pname = "lan-mouse";
-  version = "0.7.0";
+  pname = pname;
+  version = version;
 
   nativeBuildInputs = with pkgs; [
     pkg-config
@@ -23,7 +27,7 @@ rustPlatform.buildRustPackage {
   ];
 
   src = builtins.path {
-    name = "lan-mouse";
+    name = pname;
     path = lib.cleanSource ../.;
   };
 
@@ -38,7 +42,7 @@ rustPlatform.buildRustPackage {
       Lan Mouse is a mouse and keyboard sharing software similar to universal-control on Apple devices. It allows for using multiple pcs with a single set of mouse and keyboard. This is also known as a Software KVM switch.
       The primary target is Wayland on Linux but Windows and MacOS and Linux on Xorg have partial support as well (see below for more details).
     '';
-    mainProgram = "lan-mouse";
+    mainProgram = pname;
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Extract package name and version from Cargo.toml

- Use builtins.readFile to read Cargo.toml contents.
- Parse TOML content with builtins.fromTOML to extract `package.name` and `package.version`.
- Apply extracted values to set pname and version in the Nix build derivation.
