### PR TITLE
Update Nix Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
           xorg.libX11
           gtk4
           libadwaita
+          librsvg
           xorg.libXtst
         ] ++ lib.optionals stdenv.isDarwin [
           darwin.apple_sdk_11_0.frameworks.CoreGraphics

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     inherit (nixpkgs) lib;
     genSystems = lib.genAttrs [
       "aarch64-darwin"
+      "aarch64-linux"
       "x86_64-darwin"
       "x86_64-linux"
     ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,6 +14,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = with pkgs; [
     pkg-config
     cmake
+    makeWrapper
     buildPackages.gtk4
   ];
 
@@ -35,6 +36,12 @@ rustPlatform.buildRustPackage {
 
   # Set Environment Variables
   RUST_BACKTRACE = "full";
+
+  # Needed to enable support for SVG icons in GTK
+  postInstall = ''
+    wrapProgram "$out/bin/lan-mouse" \
+      --set GDK_PIXBUF_MODULE_FILE ${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+  '';
 
   meta = with lib; {
     description = "Lan Mouse is a mouse and keyboard sharing software";


### PR DESCRIPTION
- Add support for `aarch64-linux`
- Add `librsvg` to enable support for SVG icons in GTK