### PR TITLE
Add link to Synergy (open source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Focus lies on performance and a clean, manageable implementation that can easily
 
 ***blazingly fast™*** because it's written in rust.
 
-For an alternative (with slightly different goals) you may check out [Input Leap](https://github.com/input-leap).
+For an alternative (with slightly different goals) you may check out [Synergy 1 Community Edition](https://github.com/symless/synergy) or [Input Leap](https://github.com/input-leap) (Synergy fork).
 
 
 > [!WARNING]


### PR DESCRIPTION
Hey @feschber, I admire and respect the work you're doing with Lan Mouse. It's a great project. As a nod to the potential collaboration between our projects, perhaps you could mention [Synergy 1 Community Edition](https://github.com/symless/synergy) (the original ancestor of the Input Leap fork) which is still in development (as it's the open source core of Synergy 3). I am happy to reciprocate a link to Lan Mouse in the Synergy readme.