### PR TITLE
update build.rs with optional git command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,13 @@ fn main() {
         .arg("--dirty")
         .arg("--tags")
         .output()
-        .unwrap();
-
-    let git_describe = String::from_utf8(git_describe.stdout).unwrap();
+        .map(|output| String::from_utf8(output.stdout).ok())
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            println!("cargo:warning=Failed to get git describe");
+            String::from("unknown")
+        });
+    let git_describe = git_describe.trim().to_string();
     println!("cargo::rustc-env=GIT_DESCRIBE={git_describe}");
 }


### PR DESCRIPTION
```bash
lan-mouse>    Compiling unicode-normalization v0.1.24
lan-mouse>    Compiling wayland-scanner v0.31.5
lan-mouse> error: failed to run custom build command for `lan-mouse v0.10.0 (/build/source)`
lan-mouse> Caused by:
lan-mouse>   process didn't exit successfully: `/build/source/target/release/build/lan-mouse-3fcd86e7a392a2f6/build-script-build` (exit status: 101)
lan-mouse>   --- stderr
lan-mouse>   thread 'main' panicked at build.rs:11:10:
lan-mouse>   called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
lan-mouse>   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
lan-mouse> warning: build failed, waiting for other jobs to finish...
error: builder for '/nix/store/5adj7bizg9s4y0b7xh5n7264q1m71xbz-lan-mouse-0.10.0.drv' failed with exit code 101
error: 1 dependencies of derivation '/nix/store/v2mdrv08bi5233axwzp6hbwn8wp9bcjd-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/qpmdpp7vmpgh6p106z71dq7gh6knqchw-nixos-system-zeus-25.05.20241119.23e89b7.drv' failed to build
make: *** [Makefile:10: switch] Error 1
```

well, I think it is better not to assume that every computer has a git command installed

