### PR TITLE
Wlroots modifier emulation support

### DIFF
--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.32.0", features = [
 once_cell = "1.19.0"
 
 [target.'cfg(all(unix, not(target_os="macos")))'.dependencies]
+bitflags = "2.6.0"
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.32.1", features = [
     "client",
@@ -42,6 +43,8 @@ ashpd = { version = "0.10", default-features = false, features = [
     "tokio",
 ], optional = true }
 reis = { version = "0.4", features = ["tokio"], optional = true }
+keycode = "0.4.0"
+
 
 [target.'cfg(target_os="macos")'.dependencies]
 bitflags = "2.6.0"

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -43,7 +43,6 @@ ashpd = { version = "0.10", default-features = false, features = [
     "tokio",
 ], optional = true }
 reis = { version = "0.4", features = ["tokio"], optional = true }
-keycode = "0.4.0"
 
 
 [target.'cfg(target_os="macos")'.dependencies]

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -44,7 +44,6 @@ ashpd = { version = "0.10", default-features = false, features = [
 ], optional = true }
 reis = { version = "0.4", features = ["tokio"], optional = true }
 
-
 [target.'cfg(target_os="macos")'.dependencies]
 bitflags = "2.6.0"
 core-graphics = { version = "0.24.0", features = ["highsierra"] }


### PR DESCRIPTION
Fixes https://github.com/feschber/lan-mouse/issues/204

## Change Summary:

### WLRoots Emulation
- Internally track modifier state via `VirtualInput.modifiers`
  - On `KeyboardEvent::Key`: If key matches modifiers, either depress or toggle respective mod
  - On `KeyboardEvent::Modifiers`: Set internal modifiers state to match the event
- Add current time to discrete scroll event (Fixes scrolling)