### PR TITLE
Add time to wlroots discrete scroll event emulation

### DIFF
--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::io;
 use std::os::fd::{AsFd, OwnedFd};
+use std::time::{SystemTime, UNIX_EPOCH};
 use wayland_client::backend::WaylandError;
 use wayland_client::WEnum;
 
@@ -177,6 +178,11 @@ struct VirtualInput {
 
 impl VirtualInput {
     fn consume_event(&self, event: Event) -> Result<(), ()> {
+        let now: u32 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u32;
+
         match event {
             Event::Pointer(e) => {
                 match e {
@@ -197,7 +203,7 @@ impl VirtualInput {
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         let axis: Axis = (axis as u32).try_into()?;
                         self.pointer
-                            .axis_discrete(0, axis, value as f64 / 6., value / 120);
+                            .axis_discrete(now, axis, value as f64 / 6., value / 120);
                         self.pointer.frame();
                     }
                 }


### PR DESCRIPTION
It seems that some WLRoots compositors want the timestamp in the Discrete/120 scroll event.

Might resolve https://github.com/feschber/lan-mouse/issues/239

- Add current time as miliiseconds to scroll event emulation