### PR TITLE
Fix parsing TOML key 'position' and values

### DIFF
--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -59,15 +59,12 @@ pub enum IpcError {
 pub const DEFAULT_PORT: u16 = 4242;
 
 #[derive(Debug, Default, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Position {
     #[default]
-    #[serde(rename = "left")]
     Left,
-    #[serde(rename = "right")]
     Right,
-    #[serde(rename = "top")]
     Top,
-    #[serde(rename = "bottom")]
     Bottom,
 }
 

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -61,9 +61,13 @@ pub const DEFAULT_PORT: u16 = 4242;
 #[derive(Debug, Default, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Position {
     #[default]
+    #[serde(rename = "left")]
     Left,
+    #[serde(rename = "right")]
     Right,
+    #[serde(rename = "top")]
     Top,
+    #[serde(rename = "bottom")]
     Bottom,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,7 @@ struct TomlClient {
     host_name: Option<String>,
     ips: Option<Vec<IpAddr>>,
     port: Option<u16>,
+    #[serde(rename = "position")]
     pos: Option<Position>,
     activate_on_startup: Option<bool>,
     enter_hook: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,8 +61,7 @@ struct TomlClient {
     host_name: Option<String>,
     ips: Option<Vec<IpAddr>>,
     port: Option<u16>,
-    #[serde(rename = "position")]
-    pos: Option<Position>,
+    position: Option<Position>,
     activate_on_startup: Option<bool>,
     enter_hook: Option<String>,
 }
@@ -263,7 +262,7 @@ impl From<TomlClient> for ConfigClient {
         let hostname = toml.hostname;
         let ips = HashSet::from_iter(toml.ips.into_iter().flatten());
         let port = toml.port.unwrap_or(DEFAULT_PORT);
-        let pos = toml.pos.unwrap_or_default();
+        let pos = toml.position.unwrap_or_default();
         Self {
             ips,
             hostname,


### PR DESCRIPTION
Just fix parsing TOML position and its values
```toml
[[clients]]
position = "bottom" # It doesn't work now so I fix it
```