### PR TITLE
fix parent class types in key_row widget

### DIFF
--- a/lan-mouse-gtk/src/key_row.rs
+++ b/lan-mouse-gtk/src/key_row.rs
@@ -8,7 +8,7 @@ use super::KeyObject;
 
 glib::wrapper! {
     pub struct KeyRow(ObjectSubclass<imp::KeyRow>)
-    @extends gtk::ListBoxRow, gtk::Widget, adw::PreferencesRow, adw::ExpanderRow,
+    @extends gtk::ListBoxRow, gtk::Widget, adw::PreferencesRow, adw::ActionRow,
     @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 


### PR DESCRIPTION
closes #294