### PR TITLE
WIP: MacOS input consistency, request for comment

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,15 @@
 # example configuration
 
 # configure release bind
-release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
+release_bind = ["KeyA", "KeyS", "KeyD", "KeyF"]
 
 # optional port (defaults to 4242)
 port = 4242
+
+# linear mouse acceleration
+mouse_mod = 1.0
+# invert scrolling direction
+invert_scroll = false
 
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -9,19 +9,21 @@ repository = "https://github.com/feschber/lan-mouse"
 [dependencies]
 async-trait = "0.1.80"
 futures = "0.3.28"
+float-derive = "0.1.0"
 log = "0.4.22"
 input-event = { path = "../input-event", version = "0.3.0" }
 thiserror = "2.0.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = [
-    "io-util",
-    "io-std",
-    "macros",
-    "net",
-    "process",
-    "rt",
-    "sync",
-    "signal",
-    "time"
+  "io-util",
+  "io-std",
+  "macros",
+  "net",
+  "process",
+  "rt",
+  "sync",
+  "signal",
+  "time",
 ] }
 once_cell = "1.19.0"
 
@@ -29,19 +31,19 @@ once_cell = "1.19.0"
 bitflags = "2.6.0"
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.32.1", features = [
-    "client",
-    "staging",
-    "unstable",
+  "client",
+  "staging",
+  "unstable",
 ], optional = true }
 wayland-protocols-wlr = { version = "0.3.1", features = [
-    "client",
+  "client",
 ], optional = true }
 wayland-protocols-misc = { version = "0.3.1", features = [
-    "client",
+  "client",
 ], optional = true }
 x11 = { version = "2.21.0", features = ["xlib", "xtest"], optional = true }
 ashpd = { version = "0.11.0", default-features = false, features = [
-    "tokio",
+  "tokio",
 ], optional = true }
 reis = { version = "0.5.0", features = ["tokio"], optional = true }
 
@@ -52,22 +54,22 @@ keycode = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.2", features = [
-    "Win32_System_LibraryLoader",
-    "Win32_System_Threading",
-    "Win32_Foundation",
-    "Win32_Graphics",
-    "Win32_Graphics_Gdi",
-    "Win32_UI_Input_KeyboardAndMouse",
-    "Win32_UI_WindowsAndMessaging",
+  "Win32_System_LibraryLoader",
+  "Win32_System_Threading",
+  "Win32_Foundation",
+  "Win32_Graphics",
+  "Win32_Graphics_Gdi",
+  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_WindowsAndMessaging",
 ] }
 
 [features]
 default = ["wlroots", "x11", "remote_desktop_portal", "libei"]
 wlroots = [
-    "dep:wayland-client",
-    "dep:wayland-protocols",
-    "dep:wayland-protocols-wlr",
-    "dep:wayland-protocols-misc",
+  "dep:wayland-client",
+  "dep:wayland-protocols",
+  "dep:wayland-protocols-wlr",
+  "dep:wayland-protocols-misc",
 ]
 x11 = ["dep:x11"]
 remote_desktop_portal = ["dep:ashpd"]

--- a/lan-mouse-ipc/Cargo.toml
+++ b/lan-mouse-ipc/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/feschber/lan-mouse"
 
 [dependencies]
+float-derive = "0.1.0"
 futures = "0.3.30"
 log = "0.4.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -14,3 +15,5 @@ serde_json = "1.0.107"
 thiserror = "2.0.0"
 tokio = { version = "1.32.0", features = ["net", "io-util", "time"] }
 tokio-stream = { version = "0.1.15", features = ["io-util"] }
+
+input-emulation = { path = "../input-emulation", version = "0.3.0", default-features = false }

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -1,3 +1,4 @@
+use float_derive::FloatEq;
 use std::{
     collections::{HashMap, HashSet},
     env::VarError,
@@ -15,6 +16,8 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+
+use input_emulation::InputConfig;
 
 mod connect;
 mod connect_async;
@@ -219,7 +222,7 @@ pub enum FrontendEvent {
     ConnectionAttempt { fingerprint: String },
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, FloatEq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum FrontendRequest {
     /// activate/deactivate client
     Activate(ClientHandle, bool),
@@ -253,6 +256,8 @@ pub enum FrontendRequest {
     RemoveAuthorizedKey(String),
     /// change the hook command
     UpdateEnterHook(u64, Option<String>),
+    /// update the input post-processing settings (invert-scroll, mouse_mod)
+    UpdateInputConfig(InputConfig),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::{collections::HashSet, io};
 use thiserror::Error;
 use toml;
 
+use input_emulation::InputConfig;
 use lan_mouse_cli::CliArgs;
 use lan_mouse_ipc::{Position, DEFAULT_PORT};
 
@@ -367,18 +368,20 @@ impl Config {
             .unwrap_or(DEFAULT_PORT)
     }
 
-    pub fn mouse_mod(&self) -> f64 {
-        self.config_toml
-            .as_ref()
-            .and_then(|c| c.mouse_mod)
-            .unwrap_or(1.0)
-    }
+    pub fn input_config(&self) -> InputConfig {
+        InputConfig {
+            invert_scroll: self
+                .config_toml
+                .as_ref()
+                .and_then(|c| c.invert_scroll)
+                .unwrap_or(false),
 
-    pub fn invert_scroll(&self) -> bool {
-        self.config_toml
-            .as_ref()
-            .and_then(|c| c.invert_scroll)
-            .unwrap_or(false)
+            mouse_mod: self
+                .config_toml
+                .as_ref()
+                .and_then(|c| c.mouse_mod)
+                .unwrap_or(1.0),
+        }
     }
 
     /// list of configured clients

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -1,6 +1,6 @@
 use crate::listen::{LanMouseListener, ListenEvent, ListenerCreationError};
 use futures::StreamExt;
-use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError};
+use input_emulation::{EmulationHandle, InputConfig, InputEmulation, InputEmulationError};
 use input_event::Event;
 use lan_mouse_proto::{Position, ProtoEvent};
 use local_channel::mpsc::{channel, Receiver, Sender};
@@ -59,14 +59,16 @@ enum EmulationRequest {
     Release(SocketAddr),
     ChangePort(u16),
     Terminate,
+    UpdateInputConfig(InputConfig),
 }
 
 impl Emulation {
     pub(crate) fn new(
         backend: Option<input_emulation::Backend>,
         listener: LanMouseListener,
+        input_config: InputConfig,
     ) -> Self {
-        let emulation_proxy = EmulationProxy::new(backend);
+        let emulation_proxy = EmulationProxy::new(backend, input_config);
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_task = ListenTask {
@@ -98,6 +100,12 @@ impl Emulation {
     pub(crate) fn request_port_change(&self, port: u16) {
         self.request_tx
             .send(EmulationRequest::ChangePort(port))
+            .expect("channel closed")
+    }
+
+    pub(crate) fn request_input_config_upate(&self, input_config: InputConfig) {
+        self.request_tx
+            .send(EmulationRequest::UpdateInputConfig(input_config))
             .expect("channel closed")
     }
 
@@ -172,6 +180,7 @@ impl ListenTask {
                     EmulationRequest::Reenable => self.emulation_proxy.reenable(),
                     // notify the other end that we hit a barrier (should release capture)
                     EmulationRequest::Release(addr) => self.listener.reply(addr, ProtoEvent::Leave(0)).await,
+                    EmulationRequest::UpdateInputConfig(input_config) => self.emulation_proxy.input_config = input_config,
                     EmulationRequest::ChangePort(port) => {
                         self.listener.request_port_change(port);
                         let result = self.listener.port_changed().await;
@@ -206,6 +215,7 @@ pub(crate) struct EmulationProxy {
     request_tx: Sender<ProxyRequest>,
     event_rx: Receiver<EmulationEvent>,
     task: JoinHandle<()>,
+    input_config: InputConfig,
 }
 
 enum ProxyRequest {
@@ -216,7 +226,7 @@ enum ProxyRequest {
 }
 
 impl EmulationProxy {
-    fn new(backend: Option<input_emulation::Backend>) -> Self {
+    fn new(backend: Option<input_emulation::Backend>, input_config: InputConfig) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_active = Rc::new(Cell::new(false));
@@ -228,6 +238,7 @@ impl EmulationProxy {
             event_tx,
             handles: Default::default(),
             next_id: 0,
+            input_config,
         };
         let task = spawn_local(emulation_task.run());
         Self {
@@ -236,6 +247,7 @@ impl EmulationProxy {
             request_tx,
             task,
             event_rx,
+            input_config,
         }
     }
 
@@ -287,6 +299,7 @@ struct EmulationTask {
     event_tx: Sender<EmulationEvent>,
     handles: HashMap<SocketAddr, EmulationHandle>,
     next_id: EmulationHandle,
+    input_config: InputConfig,
 }
 
 impl EmulationTask {
@@ -313,7 +326,7 @@ impl EmulationTask {
     async fn do_emulation(&mut self) -> Result<(), InputEmulationError> {
         log::info!("creating input emulation ...");
         let mut emulation = tokio::select! {
-            r = InputEmulation::new(self.backend) => r?,
+            r = InputEmulation::new(self.backend, self.input_config) => r?,
             // allow termination event while requesting input emulation
             _ = wait_for_termination(&mut self.request_rx) => return Ok(()),
         };

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use clap::Args;
-use input_emulation::{InputEmulation, InputEmulationError};
+use input_emulation::{InputConfig, InputEmulation, InputEmulationError};
 use input_event::{Event, PointerEvent};
 use std::f64::consts::PI;
 use std::time::{Duration, Instant};
@@ -22,7 +22,8 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     log::info!("running input emulation test");
 
     let backend = config.emulation_backend().map(|b| b.into());
-    let mut emulation = InputEmulation::new(backend).await?;
+    let input_config: InputConfig = config.input_config();
+    let mut emulation = InputEmulation::new(backend, input_config).await?;
     emulation.create(0).await;
 
     let start = Instant::now();


### PR DESCRIPTION
Hello! 
I noticed a huge input inconsistency when going from Sway -> MacOS:
1) The inverted scrolling (despite natural scrolling being disabled in MacOS) 
2) Mouse sensitivity being extremely low (despite both systems using the exact same resolution)


I'm not a Rust developer, so I don't know what would be the best way to approach it - these are just tiny changes that made my systems feel consistent. 
Ideally, the issue is somehow related to DPI and reading the system config, but I propose adding two new config options:
1) mouse_mod - a float value that the actual relative movement gets multiplied by on a given client
2) invert_scroll - a simple flag that inverts the scrolling direction so that you can make it consistent across platforms.

Right now the input-emulation is split away from the config, so I couldn't figure out a way to add these options without excessive coupling. Any comments are welcome.