### PR TITLE
Implemented mouse config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.toml]
+indent_style        = space
+indent_size         = 4

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,15 @@
 # example configuration
 
 # configure release bind
-release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
+release_bind = ["KeyA", "KeyS", "KeyD", "KeyF"]
 
 # optional port (defaults to 4242)
 port = 4242
+
+# linear mouse acceleration
+mouse_mod = 1.0
+# invert scrolling direction
+invert_scroll = false
 
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ release_bind = ["KeyA", "KeyS", "KeyD", "KeyF"]
 # optional port (defaults to 4242)
 port = 4242
 
+[input]
 # linear mouse acceleration
 mouse_sensitivity = 1.0
 # invert scrolling direction

--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ release_bind = ["KeyA", "KeyS", "KeyD", "KeyF"]
 port = 4242
 
 # linear mouse acceleration
-mouse_mod = 1.0
+mouse_sensitivity = 1.0
 # invert scrolling direction
 invert_scroll = false
 

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -15,15 +15,15 @@ input-event = { path = "../input-event", version = "0.3.0" }
 thiserror = "2.0.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = [
-  "io-util",
-  "io-std",
-  "macros",
-  "net",
-  "process",
-  "rt",
-  "sync",
-  "signal",
-  "time",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "sync",
+    "signal",
+    "time",
 ] }
 once_cell = "1.19.0"
 
@@ -31,19 +31,19 @@ once_cell = "1.19.0"
 bitflags = "2.6.0"
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.32.1", features = [
-  "client",
-  "staging",
-  "unstable",
+    "client",
+    "staging",
+    "unstable",
 ], optional = true }
 wayland-protocols-wlr = { version = "0.3.1", features = [
-  "client",
+    "client",
 ], optional = true }
 wayland-protocols-misc = { version = "0.3.1", features = [
-  "client",
+    "client",
 ], optional = true }
 x11 = { version = "2.21.0", features = ["xlib", "xtest"], optional = true }
 ashpd = { version = "0.11.0", default-features = false, features = [
-  "tokio",
+    "tokio",
 ], optional = true }
 reis = { version = "0.5.0", features = ["tokio"], optional = true }
 
@@ -54,22 +54,22 @@ keycode = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.2", features = [
-  "Win32_System_LibraryLoader",
-  "Win32_System_Threading",
-  "Win32_Foundation",
-  "Win32_Graphics",
-  "Win32_Graphics_Gdi",
-  "Win32_UI_Input_KeyboardAndMouse",
-  "Win32_UI_WindowsAndMessaging",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
+    "Win32_Foundation",
+    "Win32_Graphics",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [features]
 default = ["wlroots", "x11", "remote_desktop_portal", "libei"]
 wlroots = [
-  "dep:wayland-client",
-  "dep:wayland-protocols",
-  "dep:wayland-protocols-wlr",
-  "dep:wayland-protocols-misc",
+    "dep:wayland-client",
+    "dep:wayland-protocols",
+    "dep:wayland-protocols-wlr",
+    "dep:wayland-protocols-misc",
 ]
 x11 = ["dep:x11"]
 remote_desktop_portal = ["dep:ashpd"]

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -9,19 +9,21 @@ repository = "https://github.com/feschber/lan-mouse"
 [dependencies]
 async-trait = "0.1.80"
 futures = "0.3.28"
+float-derive = "0.1.0"
 log = "0.4.22"
 input-event = { path = "../input-event", version = "0.3.0" }
 thiserror = "2.0.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = [
-    "io-util",
-    "io-std",
-    "macros",
-    "net",
-    "process",
-    "rt",
-    "sync",
-    "signal",
-    "time"
+  "io-util",
+  "io-std",
+  "macros",
+  "net",
+  "process",
+  "rt",
+  "sync",
+  "signal",
+  "time",
 ] }
 once_cell = "1.19.0"
 
@@ -29,19 +31,19 @@ once_cell = "1.19.0"
 bitflags = "2.6.0"
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.32.1", features = [
-    "client",
-    "staging",
-    "unstable",
+  "client",
+  "staging",
+  "unstable",
 ], optional = true }
 wayland-protocols-wlr = { version = "0.3.1", features = [
-    "client",
+  "client",
 ], optional = true }
 wayland-protocols-misc = { version = "0.3.1", features = [
-    "client",
+  "client",
 ], optional = true }
 x11 = { version = "2.21.0", features = ["xlib", "xtest"], optional = true }
 ashpd = { version = "0.11.0", default-features = false, features = [
-    "tokio",
+  "tokio",
 ], optional = true }
 reis = { version = "0.5.0", features = ["tokio"], optional = true }
 
@@ -52,22 +54,22 @@ keycode = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.2", features = [
-    "Win32_System_LibraryLoader",
-    "Win32_System_Threading",
-    "Win32_Foundation",
-    "Win32_Graphics",
-    "Win32_Graphics_Gdi",
-    "Win32_UI_Input_KeyboardAndMouse",
-    "Win32_UI_WindowsAndMessaging",
+  "Win32_System_LibraryLoader",
+  "Win32_System_Threading",
+  "Win32_Foundation",
+  "Win32_Graphics",
+  "Win32_Graphics_Gdi",
+  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_WindowsAndMessaging",
 ] }
 
 [features]
 default = ["wlroots", "x11", "remote_desktop_portal", "libei"]
 wlroots = [
-    "dep:wayland-client",
-    "dep:wayland-protocols",
-    "dep:wayland-protocols-wlr",
-    "dep:wayland-protocols-misc",
+  "dep:wayland-client",
+  "dep:wayland-protocols",
+  "dep:wayland-protocols-wlr",
+  "dep:wayland-protocols-misc",
 ]
 x11 = ["dep:x11"]
 remote_desktop_portal = ["dep:ashpd"]

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -9,11 +9,9 @@ repository = "https://github.com/feschber/lan-mouse"
 [dependencies]
 async-trait = "0.1.80"
 futures = "0.3.28"
-float-derive = "0.1.0"
 log = "0.4.22"
 input-event = { path = "../input-event", version = "0.3.0" }
 thiserror = "2.0.0"
-serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = [
     "io-util",
     "io-std",

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -72,14 +72,14 @@ impl Display for Backend {
 #[derive(Clone, Copy, Debug)]
 pub struct InputConfig {
     pub invert_scroll: bool,
-    pub mouse_mod: f64,
+    pub mouse_sensitivity: f64,
 }
 
 impl InputConfig {
-    pub fn new(invert_scroll: bool, mouse_mod: f64) -> Self {
+    pub fn new(invert_scroll: bool, mouse_sensitivity: f64) -> Self {
         InputConfig {
             invert_scroll,
-            mouse_mod,
+            mouse_sensitivity,
         }
     }
 }
@@ -176,8 +176,8 @@ impl InputEmulation {
             Event::Pointer(PointerEvent::Motion { time, dx, dy }) => {
                 // apply mouse mod
                 let (dx, dy) = (
-                    dx * self.input_config.mouse_mod,
-                    dy * self.input_config.mouse_mod,
+                    dx * self.input_config.mouse_sensitivity,
+                    dy * self.input_config.mouse_sensitivity,
                 );
                 let event = Event::Pointer(PointerEvent::Motion { time, dx, dy });
                 self.emulation.consume(event, handle).await?;

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -1,12 +1,10 @@
 use async_trait::async_trait;
-use float_derive::FloatEq;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
 };
 
 use input_event::{Event, KeyboardEvent, PointerEvent};
-use serde::{Deserialize, Serialize};
 
 pub use self::error::{EmulationCreationError, EmulationError, InputEmulationError};
 
@@ -71,10 +69,19 @@ impl Display for Backend {
     }
 }
 
-#[derive(Clone, Copy, Debug, FloatEq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug)]
 pub struct InputConfig {
     pub invert_scroll: bool,
     pub mouse_mod: f64,
+}
+
+impl InputConfig {
+    pub fn new(invert_scroll: bool, mouse_mod: f64) -> Self {
+        InputConfig {
+            invert_scroll,
+            mouse_mod,
+        }
+    }
 }
 
 pub struct InputEmulation {

--- a/lan-mouse-cli/src/lib.rs
+++ b/lan-mouse-cli/src/lib.rs
@@ -18,7 +18,7 @@ pub enum CliError {
     Ipc(#[from] IpcError),
 }
 
-#[derive(Parser, Clone, Debug, PartialEq, Eq)]
+#[derive(Parser, Clone, Debug)]
 #[command(name = "lan-mouse-cli", about = "LanMouse CLI interface")]
 pub struct CliArgs {
     #[command(subcommand)]
@@ -37,7 +37,7 @@ struct Client {
     enter_hook: Option<String>,
 }
 
-#[derive(Clone, Subcommand, Debug, PartialEq, Eq)]
+#[derive(Clone, Subcommand, Debug)]
 enum CliSubcommand {
     /// add a new client
     AddClient(Client),
@@ -56,6 +56,13 @@ enum CliSubcommand {
     },
     /// change port
     SetPort { id: ClientHandle, port: u16 },
+    /// invert scrolling
+    SetScrollingInversion {
+        #[clap(short, long)]
+        invert_scroll: bool,
+    },
+    /// set mouse mod
+    SetMouseMod { mouse_mod: f64 },
     /// set position
     SetPosition { id: ClientHandle, pos: Position },
     /// set ips
@@ -139,6 +146,14 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
         }
         CliSubcommand::SetPort { id, port } => {
             tx.request(FrontendRequest::UpdatePort(id, port)).await?
+        }
+        CliSubcommand::SetScrollingInversion { invert_scroll } => {
+            tx.request(FrontendRequest::UpdateScrollingInversion(invert_scroll))
+                .await?
+        }
+        CliSubcommand::SetMouseMod { mouse_mod } => {
+            tx.request(FrontendRequest::UpdateMouseMod(mouse_mod))
+                .await?
         }
         CliSubcommand::SetPosition { id, pos } => {
             tx.request(FrontendRequest::UpdatePosition(id, pos)).await?

--- a/lan-mouse-cli/src/lib.rs
+++ b/lan-mouse-cli/src/lib.rs
@@ -56,13 +56,13 @@ enum CliSubcommand {
     },
     /// change port
     SetPort { id: ClientHandle, port: u16 },
-    /// invert scrolling
-    SetScrollingInversion {
+    /// invert scrolling direction
+    InvertScrolling {
         #[clap(short, long)]
         invert_scroll: bool,
     },
-    /// set mouse mod
-    SetMouseMod { mouse_mod: f64 },
+    /// set mouse mouse sensitivity
+    SetMouseSensitivity { mouse_sensitivity: f64 },
     /// set position
     SetPosition { id: ClientHandle, pos: Position },
     /// set ips
@@ -147,12 +147,12 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
         CliSubcommand::SetPort { id, port } => {
             tx.request(FrontendRequest::UpdatePort(id, port)).await?
         }
-        CliSubcommand::SetScrollingInversion { invert_scroll } => {
+        CliSubcommand::InvertScrolling { invert_scroll } => {
             tx.request(FrontendRequest::UpdateScrollingInversion(invert_scroll))
                 .await?
         }
-        CliSubcommand::SetMouseMod { mouse_mod } => {
-            tx.request(FrontendRequest::UpdateMouseMod(mouse_mod))
+        CliSubcommand::SetMouseSensitivity { mouse_sensitivity } => {
+            tx.request(FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity))
                 .await?
         }
         CliSubcommand::SetPosition { id, pos } => {

--- a/lan-mouse-ipc/Cargo.toml
+++ b/lan-mouse-ipc/Cargo.toml
@@ -7,7 +7,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/feschber/lan-mouse"
 
 [dependencies]
-float-derive = "0.1.0"
 futures = "0.3.30"
 log = "0.4.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -15,5 +14,3 @@ serde_json = "1.0.107"
 thiserror = "2.0.0"
 tokio = { version = "1.32.0", features = ["net", "io-util", "time"] }
 tokio-stream = { version = "0.1.15", features = ["io-util"] }
-
-input-emulation = { path = "../input-emulation", version = "0.3.0", default-features = false }

--- a/lan-mouse-ipc/Cargo.toml
+++ b/lan-mouse-ipc/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/feschber/lan-mouse"
 
 [dependencies]
+float-derive = "0.1.0"
 futures = "0.3.30"
 log = "0.4.22"
 serde = { version = "1.0", features = ["derive"] }
@@ -14,3 +15,5 @@ serde_json = "1.0.107"
 thiserror = "2.0.0"
 tokio = { version = "1.32.0", features = ["net", "io-util", "time"] }
 tokio-stream = { version = "0.1.15", features = ["io-util"] }
+
+input-emulation = { path = "../input-emulation", version = "0.3.0", default-features = false }

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -253,9 +253,9 @@ pub enum FrontendRequest {
     RemoveAuthorizedKey(String),
     /// change the hook command
     UpdateEnterHook(u64, Option<String>),
-    /// update the input post-processing settings (invert-scroll, mouse_mod)
+    /// update the input post-processing settings (invert-scroll, mouse_sensitivity)
     UpdateScrollingInversion(bool),
-    UpdateMouseMod(f64),
+    UpdateMouseSensitivity(f64),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -1,4 +1,3 @@
-use float_derive::FloatEq;
 use std::{
     collections::{HashMap, HashSet},
     env::VarError,
@@ -16,8 +15,6 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-
-use input_emulation::InputConfig;
 
 mod connect;
 mod connect_async;
@@ -222,7 +219,7 @@ pub enum FrontendEvent {
     ConnectionAttempt { fingerprint: String },
 }
 
-#[derive(Debug, FloatEq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FrontendRequest {
     /// activate/deactivate client
     Activate(ClientHandle, bool),
@@ -257,7 +254,8 @@ pub enum FrontendRequest {
     /// change the hook command
     UpdateEnterHook(u64, Option<String>),
     /// update the input post-processing settings (invert-scroll, mouse_mod)
-    UpdateInputConfig(InputConfig),
+    UpdateScrollingInversion(bool),
+    UpdateMouseMod(f64),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -1,3 +1,4 @@
+use float_derive::FloatEq;
 use std::{
     collections::{HashMap, HashSet},
     env::VarError,
@@ -15,6 +16,8 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+
+use input_emulation::InputConfig;
 
 mod connect;
 mod connect_async;
@@ -219,7 +222,7 @@ pub enum FrontendEvent {
     ConnectionAttempt { fingerprint: String },
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, FloatEq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum FrontendRequest {
     /// activate/deactivate client
     Activate(ClientHandle, bool),
@@ -253,6 +256,8 @@ pub enum FrontendRequest {
     RemoveAuthorizedKey(String),
     /// change the hook command
     UpdateEnterHook(u64, Option<String>),
+    /// update the input post-processing settings (invert-scroll, mouse_mod)
+    UpdateInputConfig(InputConfig),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::{collections::HashSet, io};
 use thiserror::Error;
 use toml;
 
+use input_emulation::InputConfig;
 use lan_mouse_cli::CliArgs;
 use lan_mouse_ipc::{DEFAULT_PORT, Position};
 
@@ -50,6 +51,8 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    mouse_mod: Option<f64>,
+    invert_scroll: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -363,6 +366,22 @@ impl Config {
             .port
             .or(self.config_toml.as_ref().and_then(|c| c.port))
             .unwrap_or(DEFAULT_PORT)
+    }
+
+    pub fn input_config(&self) -> InputConfig {
+        InputConfig {
+            invert_scroll: self
+                .config_toml
+                .as_ref()
+                .and_then(|c| c.invert_scroll)
+                .unwrap_or(false),
+
+            mouse_mod: self
+                .config_toml
+                .as_ref()
+                .and_then(|c| c.mouse_mod)
+                .unwrap_or(1.0),
+        }
     }
 
     /// list of configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,6 @@ use std::{collections::HashSet, io};
 use thiserror::Error;
 use toml;
 
-use input_emulation::InputConfig;
 use lan_mouse_cli::CliArgs;
 use lan_mouse_ipc::{DEFAULT_PORT, Position};
 
@@ -104,7 +103,7 @@ struct Args {
     command: Option<Command>,
 }
 
-#[derive(Subcommand, Clone, Debug, Eq, PartialEq)]
+#[derive(Subcommand, Clone, Debug)]
 pub enum Command {
     /// test input emulation
     TestEmulation(TestEmulationArgs),
@@ -368,20 +367,18 @@ impl Config {
             .unwrap_or(DEFAULT_PORT)
     }
 
-    pub fn input_config(&self) -> InputConfig {
-        InputConfig {
-            invert_scroll: self
-                .config_toml
-                .as_ref()
-                .and_then(|c| c.invert_scroll)
-                .unwrap_or(false),
+    pub fn invert_scroll(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.invert_scroll)
+            .unwrap_or(false)
+    }
 
-            mouse_mod: self
-                .config_toml
-                .as_ref()
-                .and_then(|c| c.mouse_mod)
-                .unwrap_or(1.0),
-        }
+    pub fn mouse_mod(&self) -> f64 {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.mouse_mod)
+            .unwrap_or(1.0)
     }
 
     /// list of configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,11 +50,17 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
-    mouse_sensitivity: Option<f64>,
-    invert_scroll: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
+    input: InputConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct InputConfig {
+    // TODO: implement scroll_sensitivity and mouse_acceleration
+    invert_scroll: Option<bool>,
+    mouse_sensitivity: Option<f64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -370,14 +376,14 @@ impl Config {
     pub fn invert_scroll(&self) -> bool {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.invert_scroll)
+            .and_then(|c| c.input.invert_scroll)
             .unwrap_or(false)
     }
 
     pub fn mouse_sensitivity(&self) -> f64 {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.mouse_sensitivity)
+            .and_then(|c| c.input.mouse_sensitivity)
             .unwrap_or(1.0)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
-    mouse_mod: Option<f64>,
+    mouse_sensitivity: Option<f64>,
     invert_scroll: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
@@ -374,10 +374,10 @@ impl Config {
             .unwrap_or(false)
     }
 
-    pub fn mouse_mod(&self) -> f64 {
+    pub fn mouse_sensitivity(&self) -> f64 {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.mouse_mod)
+            .and_then(|c| c.mouse_sensitivity)
             .unwrap_or(1.0)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ struct ConfigToml {
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
-    input_post_processing: InputConfig,
+    input_post_processing: Option<InputConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -376,14 +376,16 @@ impl Config {
     pub fn invert_scroll(&self) -> bool {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.input_post_processing.invert_scroll)
+            .and_then(|c| c.input_post_processing.as_ref())
+            .and_then(|i| i.invert_scroll)
             .unwrap_or(false)
     }
 
     pub fn mouse_sensitivity(&self) -> f64 {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.input_post_processing.mouse_sensitivity)
+            .and_then(|c| c.input_post_processing.as_ref())
+            .and_then(|i| i.mouse_sensitivity)
             .unwrap_or(1.0)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ struct ConfigToml {
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
-    input: InputConfig,
+    input_post_processing: InputConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -376,14 +376,14 @@ impl Config {
     pub fn invert_scroll(&self) -> bool {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.input.invert_scroll)
+            .and_then(|c| c.input_post_processing.invert_scroll)
             .unwrap_or(false)
     }
 
     pub fn mouse_sensitivity(&self) -> f64 {
         self.config_toml
             .as_ref()
-            .and_then(|c| c.input.mouse_sensitivity)
+            .and_then(|c| c.input_post_processing.mouse_sensitivity)
             .unwrap_or(1.0)
     }
 

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -60,7 +60,7 @@ enum EmulationRequest {
     ChangePort(u16),
     Terminate,
     UpdateScrollingInversion(bool),
-    UpdateMouseMod(f64),
+    UpdateMouseSensitivity(f64),
 }
 
 impl Emulation {
@@ -71,7 +71,7 @@ impl Emulation {
     ) -> Self {
         let input_config = InputConfig {
             invert_scroll: input_config.0,
-            mouse_mod: input_config.1,
+            mouse_sensitivity: input_config.1,
         };
         let emulation_proxy = EmulationProxy::new(backend, input_config);
         let (request_tx, request_rx) = channel();
@@ -114,9 +114,9 @@ impl Emulation {
             .expect("channel closed")
     }
 
-    pub(crate) fn request_mouse_mod_change(&self, mouse_mod: f64) {
+    pub(crate) fn request_mouse_sensitivity_change(&self, mouse_sensitivity: f64) {
         self.request_tx
-            .send(EmulationRequest::UpdateMouseMod(mouse_mod))
+            .send(EmulationRequest::UpdateMouseSensitivity(mouse_sensitivity))
             .expect("channel closed")
     }
 
@@ -192,7 +192,7 @@ impl ListenTask {
                     // notify the other end that we hit a barrier (should release capture)
                     EmulationRequest::Release(addr) => self.listener.reply(addr, ProtoEvent::Leave(0)).await,
                     EmulationRequest::UpdateScrollingInversion(invert_scroll) => self.emulation_proxy.input_config.invert_scroll = invert_scroll,
-                    EmulationRequest::UpdateMouseMod(mouse_mod) => self.emulation_proxy.input_config.mouse_mod = mouse_mod,
+                    EmulationRequest::UpdateMouseSensitivity(mouse_sensitivity) => self.emulation_proxy.input_config.mouse_sensitivity = mouse_sensitivity,
                     EmulationRequest::ChangePort(port) => {
                         self.listener.request_port_change(port);
                         let result = self.listener.port_changed().await;

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use clap::Args;
-use input_emulation::{InputEmulation, InputEmulationError};
+use input_emulation::{InputConfig, InputEmulation, InputEmulationError};
 use input_event::{Event, PointerEvent};
 use std::f64::consts::PI;
 use std::time::{Duration, Instant};
@@ -22,7 +22,8 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     log::info!("running input emulation test");
 
     let backend = config.emulation_backend().map(|b| b.into());
-    let mut emulation = InputEmulation::new(backend).await?;
+    let input_config: InputConfig = config.input_config();
+    let mut emulation = InputEmulation::new(backend, input_config).await?;
     emulation.create(0).await;
 
     let start = Instant::now();

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -24,7 +24,7 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     let backend = config.emulation_backend().map(|b| b.into());
     let input_config: InputConfig = InputConfig {
         invert_scroll: config.invert_scroll(),
-        mouse_mod: config.mouse_mod(),
+        mouse_sensitivity: config.mouse_sensitivity(),
     };
     let mut emulation = InputEmulation::new(backend, input_config).await?;
     emulation.create(0).await;

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -22,7 +22,10 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     log::info!("running input emulation test");
 
     let backend = config.emulation_backend().map(|b| b.into());
-    let input_config: InputConfig = config.input_config();
+    let input_config: InputConfig = InputConfig {
+        invert_scroll: config.invert_scroll(),
+        mouse_mod: config.mouse_mod(),
+    };
     let mut emulation = InputEmulation::new(backend, input_config).await?;
     emulation.create(0).await;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -207,7 +207,9 @@ impl Service {
             FrontendRequest::UpdateScrollingInversion(invert_scroll) => {
                 self.update_scrolling_inversion(invert_scroll)
             }
-            FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity) => self.update_mouse_sensitivity(mouse_sensitivity),
+            FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity) => {
+                self.update_mouse_sensitivity(mouse_sensitivity)
+            }
         }
     }
 
@@ -524,7 +526,8 @@ impl Service {
     }
 
     fn update_mouse_sensitivity(&mut self, mouse_sensitivity: f64) {
-        self.emulation.request_mouse_sensitivity_change(mouse_sensitivity);
+        self.emulation
+            .request_mouse_sensitivity_change(mouse_sensitivity);
     }
 
     fn spawn_hook_command(&self, handle: ClientHandle) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -118,7 +118,7 @@ impl Service {
         let emulation = Emulation::new(
             emulation_backend,
             listener,
-            (config.invert_scroll(), config.mouse_mod()),
+            (config.invert_scroll(), config.mouse_sensitivity()),
         );
 
         // create dns resolver
@@ -207,7 +207,7 @@ impl Service {
             FrontendRequest::UpdateScrollingInversion(invert_scroll) => {
                 self.update_scrolling_inversion(invert_scroll)
             }
-            FrontendRequest::UpdateMouseMod(mouse_mod) => self.update_mouse_mod(mouse_mod),
+            FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity) => self.update_mouse_sensitivity(mouse_sensitivity),
         }
     }
 
@@ -523,8 +523,8 @@ impl Service {
         self.emulation.request_scrolling_inversion(invert_scroll);
     }
 
-    fn update_mouse_mod(&mut self, mouse_mod: f64) {
-        self.emulation.request_mouse_mod_change(mouse_mod);
+    fn update_mouse_sensitivity(&mut self, mouse_sensitivity: f64) {
+        self.emulation.request_mouse_sensitivity_change(mouse_sensitivity);
     }
 
     fn spawn_hook_command(&self, handle: ClientHandle) {


### PR DESCRIPTION
Add two options:
mouse_mod - sets a linear acceleration for the emulated mouse
invert_scroll - inverts the scrolling direction for the emulated mouse

Hopefully it helps to make the pointer more consistent across multiple devices.

Previously discussed in #339