### PR TITLE
fix: remote key-up on triggered release

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -362,7 +362,13 @@ impl CaptureTask {
     }
 
     async fn release_capture(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
-        self.active_client.take();
+        // If we have an active client, notify them we're leaving
+        if let Some(handle) = self.active_client.take() {
+            log::info!("sending Leave event to client {handle}");
+            if let Err(e) = self.conn.send(ProtoEvent::Leave(0), handle).await {
+                log::warn!("failed to send Leave to client {handle}: {e}");
+            }
+        }
         capture.release().await
     }
 }


### PR DESCRIPTION
Fixes #369.  Issue was that on using a hotkey to trigger remote release (need to do this on a wayland lock screen to return cursor/focus to my main computer), I bound release to Meta+z and the Meta key would be left down/stuck on the remote machine.

Steps to repro:
1. set release_bind in config using some modifier (meta+z is what I used)
2. attempt to release focus from a remote computer with this binding
3. modifier key ends up stuck/down

NOTE: I'm an old developer but pretty new to rust.  This is a pretty small PR but if there's anything you'd like changed, just let me know