### PR TITLE
feat: windows service for uac+login support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,8 @@ dependencies = [
  "toml",
  "webrtc-dtls",
  "webrtc-util",
+ "windows",
+ "windows-service",
 ]
 
 [[package]]
@@ -3859,6 +3861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags 2.9.1",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,24 @@ sha2 = "0.10.8"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.148"
 
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.7.0"
+windows = { version = "0.61.2", features = [
+    "Win32_Security",
+    "Win32_System_Services",
+    "Win32_System_Registry",
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_EventLog",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+    "Win32_System_RemoteDesktop",
+    "Win32_System_Environment",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Console",
+] }
+
 [features]
 default = [
     "gtk",

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -59,6 +59,9 @@ windows = { version = "0.61.2", features = [
     "Win32_Graphics_Gdi",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_System_StationsAndDesktops",
+    "Win32_System_RemoteDesktop",
+    "Win32_Security",
 ] }
 
 [features]

--- a/input-emulation/Cargo.toml
+++ b/input-emulation/Cargo.toml
@@ -61,6 +61,7 @@ windows = { version = "0.61.2", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_StationsAndDesktops",
     "Win32_System_RemoteDesktop",
+    "Win32_System_Shutdown",
     "Win32_Security",
 ] }
 

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -119,7 +119,7 @@ impl WindowsEmulation {
 }
 
 /// Send input with desktop switching to handle UAC prompts and other secure desktops.
-/// When running in a user session (spawned by the watchdog service), this allows
+/// When running in a user session (spawned by the Windows service), this allows
 /// input injection on the Secure Desktop (UAC prompts) by temporarily switching
 /// to the current input desktop.
 fn send_input_safe(input: INPUT) {

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -8,6 +8,11 @@ use async_trait::async_trait;
 use std::ops::BitOrAssign;
 use std::time::Duration;
 use tokio::task::AbortHandle;
+use windows::Win32::System::StationsAndDesktops::{
+    CloseDesktop, DESKTOP_ACCESS_FLAGS, DESKTOP_CONTROL_FLAGS, GetThreadDesktop, OpenInputDesktop,
+    SetThreadDesktop,
+};
+use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE,
     MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
@@ -18,11 +23,6 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT_0, KEYEVENTF_EXTENDEDKEY, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, SendInput,
 };
 use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
-use windows::Win32::System::StationsAndDesktops::{
-    CloseDesktop, GetThreadDesktop, OpenInputDesktop, SetThreadDesktop, DESKTOP_ACCESS_FLAGS,
-    DESKTOP_CONTROL_FLAGS,
-};
-use windows::Win32::System::Threading::GetCurrentThreadId;
 
 use super::{Emulation, EmulationHandle};
 
@@ -333,8 +333,7 @@ fn lock_workstation() {
 
         // Fallback for Session 0: disconnect the active console session.
         use windows::Win32::System::RemoteDesktop::{
-            WTSDisconnectSession, WTSGetActiveConsoleSessionId,
-            WTS_CURRENT_SERVER_HANDLE,
+            WTS_CURRENT_SERVER_HANDLE, WTSDisconnectSession, WTSGetActiveConsoleSessionId,
         };
         let session_id = WTSGetActiveConsoleSessionId();
         if WTSDisconnectSession(Some(WTS_CURRENT_SERVER_HANDLE), session_id, true).is_err() {

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -61,7 +61,6 @@ impl WindowsEmulation {
 #[async_trait]
 impl Emulation for WindowsEmulation {
     async fn consume(&mut self, event: Event, _: EmulationHandle) -> Result<(), EmulationError> {
-        log::trace!("[WindowsEmulation] consuming event: {:?}", event);
         match event {
             Event::Pointer(pointer_event) => match pointer_event {
                 PointerEvent::Motion { time: _, dx, dy } => {

--- a/run.ps1
+++ b/run.ps1
@@ -123,7 +123,7 @@ try {
 
         Write-Host "`nDeployment complete!" -ForegroundColor Green
         Write-Host "`nTailing service log (Ctrl+C to stop)..." -ForegroundColor Cyan
-        Get-Content -Wait -Tail 20 "C:\ProgramData\lan-mouse\watchdog.log"
+        Get-Content -Wait -Tail 20 "C:\ProgramData\lan-mouse\winsvc.log"
     } elseif ($Direct) {
         Write-Host "`nRunning lan-mouse directly..." -ForegroundColor Cyan
         $ServiceExe = Join-Path $SvcDir "lan-mouse.exe"

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,137 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Build and run lan-mouse (as service or directly)
+.DESCRIPTION
+    Optionally builds lan-mouse in debug mode, stops any running service, copies binaries to target/svc/,
+    then either starts the Windows service or runs the executable directly.
+.PARAMETER Build
+    Build lan-mouse before deployment
+.PARAMETER Service
+    Start the lan-mouse Windows service after deployment
+.PARAMETER Direct
+    Run ./target/svc/lan-mouse.exe directly (not as a service)
+.PARAMETER Install
+    If specified with -Service, registers the service via 'lan-mouse install' before starting
+.PARAMETER Clean
+    Truncate all log files in C:\ProgramData\lan-mouse\ before starting
+.EXAMPLE
+    .\run.ps1 -Build -Service
+    .\run.ps1 -Build -Service -Install
+    .\run.ps1 -Build -Direct
+    .\run.ps1 -Direct
+    .\run.ps1 -Clean -Service
+#>
+
+param(
+    [switch]$Build,
+    [switch]$Service,
+    [switch]$Direct,
+    [switch]$Install,
+    [switch]$Clean
+)
+
+if (-not $Service -and -not $Direct) {
+    Write-Host "Error: You must specify either -Service or -Direct" -ForegroundColor Red
+    Write-Host "  -Service  Start the lan-mouse Windows service"
+    Write-Host "  -Direct   Run the executable directly"
+    exit 1
+}
+
+if ($Service -and $Direct) {
+    Write-Host "Error: Cannot specify both -Service and -Direct" -ForegroundColor Red
+    exit 1
+}
+
+$ErrorActionPreference = "Stop"
+
+# Change to repository root
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $ScriptDir
+
+try {
+    if ($Build) {
+        Write-Host "Building lan-mouse (debug, no default features)..." -ForegroundColor Cyan
+        cargo build --no-default-features
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    Write-Host "`nStopping lan-mouse service..." -ForegroundColor Cyan
+    $svcInfo = Get-Service -Name "lan-mouse" -ErrorAction SilentlyContinue
+    if ($svcInfo -and $svcInfo.Status -eq "Running") {
+        try {
+            Stop-Service -Name "lan-mouse" -Force -ErrorAction Stop
+            Write-Host "Service stopped" -ForegroundColor Green
+        } catch {
+            Write-Host "Stop-Service failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "Attempting to kill lan-mouse process..." -ForegroundColor Yellow
+            $proc = Get-Process -Name "lan-mouse" -ErrorAction SilentlyContinue
+            if ($proc) {
+                $proc | Stop-Process -Force
+                Write-Host "Process killed" -ForegroundColor Green
+            } else {
+                Write-Host "No lan-mouse process found" -ForegroundColor Yellow
+            }
+        }
+    } elseif ($svcInfo) {
+        Write-Host "Service exists but not running (status: $($svcInfo.Status))" -ForegroundColor Yellow
+        # Still check for orphan process
+        $proc = Get-Process -Name "lan-mouse" -ErrorAction SilentlyContinue
+        if ($proc) {
+            Write-Host "Found orphan lan-mouse process, killing..." -ForegroundColor Yellow
+            $proc | Stop-Process -Force
+            Write-Host "Process killed" -ForegroundColor Green
+        }
+    } else {
+        Write-Host "Service not registered (will install if -Install is used)" -ForegroundColor Yellow
+    }
+
+    Write-Host "`nCopying binaries to target/svc/..." -ForegroundColor Cyan
+    $SvcDir = Join-Path $ScriptDir "target\svc"
+    if (-not (Test-Path $SvcDir)) {
+        New-Item -ItemType Directory -Path $SvcDir | Out-Null
+    }
+
+    Copy-Item -Path "target\debug\*" -Destination $SvcDir -Recurse -Force
+    Write-Host "Binaries copied" -ForegroundColor Green
+
+    if ($Clean) {
+        Write-Host "`nTruncating log files in C:\ProgramData\lan-mouse\..." -ForegroundColor Cyan
+        $LogDir = "C:\ProgramData\lan-mouse"
+        Get-ChildItem -Path $LogDir -Filter "*.log" -ErrorAction SilentlyContinue | ForEach-Object {
+            Clear-Content -Path $_.FullName -ErrorAction SilentlyContinue
+            Write-Host "  Truncated: $($_.Name)" -ForegroundColor Gray
+        }
+    }
+
+    if ($Service) {
+        if ($Install) {
+            Write-Host "`nInstalling service..." -ForegroundColor Cyan
+            $ServiceExe = Join-Path $SvcDir "lan-mouse.exe"
+            & $ServiceExe install
+            if ($LASTEXITCODE -ne 0) {
+                throw "Service installation failed with exit code $LASTEXITCODE"
+            }
+            Write-Host "Service installed" -ForegroundColor Green
+        }
+
+        Write-Host "`nStarting lan-mouse service..." -ForegroundColor Cyan
+        Start-Service -Name "lan-mouse"
+        Write-Host "Service started" -ForegroundColor Green
+
+        Write-Host "`nDeployment complete!" -ForegroundColor Green
+        Write-Host "`nTailing service log (Ctrl+C to stop)..." -ForegroundColor Cyan
+        Get-Content -Wait -Tail 20 "C:\ProgramData\lan-mouse\watchdog.log"
+    } elseif ($Direct) {
+        Write-Host "`nRunning lan-mouse directly..." -ForegroundColor Cyan
+        $ServiceExe = Join-Path $SvcDir "lan-mouse.exe"
+        & $ServiceExe
+    }
+} catch {
+    Write-Host "`nError: $_" -ForegroundColor Red
+    exit 1
+} finally {
+    Pop-Location
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ fn default_path() -> Result<PathBuf, VarError> {
     #[cfg(not(unix))]
     let default_path = {
         #[cfg(windows)]
-        if crate::is_service() {
+        if crate::is_windows_service() {
             "C:\\ProgramData\\lan-mouse\\".to_string()
         } else {
             let app_data =
@@ -329,7 +329,7 @@ impl Config {
     fn from_args(args: Args) -> Result<Self, ConfigError> {
         #[cfg(windows)]
         if matches!(args.command, Some(Command::WinSvc)) {
-            crate::set_is_service(true);
+            crate::set_is_windows_service(true);
         }
 
         // --config <file> overrules default location

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,9 +131,10 @@ pub enum Command {
     /// Query service status
     #[cfg(windows)]
     Status,
-    /// Run as watchdog service (internal - spawns session daemons)
+    /// Run as Windows service (internal - spawns session daemons)
     #[cfg(windows)]
-    Watchdog,
+    #[command(hide = true)]
+    WinSvc,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -327,6 +327,11 @@ impl Config {
     }
 
     fn from_args(args: Args) -> Result<Self, ConfigError> {
+        #[cfg(windows)]
+        if matches!(args.command, Some(Command::WinSvc)) {
+            crate::set_is_service(true);
+        }
+
         // --config <file> overrules default location
         let config_path = args
             .config

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -148,7 +148,9 @@ impl ListenTask {
                                 self.emulation_proxy.remove(addr);
                                 self.listener.reply(addr, ProtoEvent::Ack(0)).await;
                             }
-                            ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
+                            ProtoEvent::Input(input_event) => {
+                                self.emulation_proxy.consume(input_event, addr);
+                            }
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
                             _ => {}
                         }
@@ -256,6 +258,8 @@ impl EmulationProxy {
             self.request_tx
                 .send(ProxyRequest::Input(event, addr))
                 .expect("channel closed");
+        } else {
+            log::warn!("emulation inactive, dropping event: {:?}", event);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,20 @@ mod emulation;
 pub mod emulation_test;
 mod listen;
 pub mod service;
+#[cfg(windows)]
+pub mod windows;
+#[cfg(windows)]
+pub mod windows_service;
+
+#[cfg(windows)]
+static IS_SERVICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(windows)]
+pub fn set_is_service(is_service: bool) {
+    IS_SERVICE.store(is_service, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(windows)]
+pub fn is_service() -> bool {
+    IS_SERVICE.load(std::sync::atomic::Ordering::SeqCst)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ pub mod windows;
 pub mod windows_service;
 
 #[cfg(windows)]
-static IS_WINDOWS_SERVICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static IS_WINDOWS_SERVICE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 #[cfg(windows)]
 pub fn set_is_windows_service(is_service: bool) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@ pub mod windows;
 pub mod windows_service;
 
 #[cfg(windows)]
-static IS_SERVICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static IS_WINDOWS_SERVICE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 #[cfg(windows)]
-pub fn set_is_service(is_service: bool) {
-    IS_SERVICE.store(is_service, std::sync::atomic::Ordering::SeqCst);
+pub fn set_is_windows_service(is_service: bool) {
+    IS_WINDOWS_SERVICE.store(is_service, std::sync::atomic::Ordering::SeqCst);
 }
 
 #[cfg(windows)]
-pub fn is_service() -> bool {
-    IS_SERVICE.load(std::sync::atomic::Ordering::SeqCst)
+pub fn is_windows_service() -> bool {
+    IS_WINDOWS_SERVICE.load(std::sync::atomic::Ordering::SeqCst)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn main() {
 fn init_logging(_command: &Option<Command>) {
     let env = Env::default().filter_or("LAN_MOUSE_LOG_LEVEL", "info");
 
+    // On Windows, log to a file only for the background daemon (no console)
+    // or the Windows service. All other cases (GTK app, CLI, terminal daemon)
+    // log to stderr via the default init below.
     #[cfg(windows)]
     {
         use windows::Win32::System::Console::GetConsoleWindow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,10 @@ use lan_mouse_ipc::{IpcError, IpcListenerCreationError};
 use std::{
     future::Future,
     io,
-    process::{self, Child},
+    process::{self},
 };
+#[cfg(feature = "gtk")]
+use std::process::Child;
 use thiserror::Error;
 use tokio::task::LocalSet;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,24 +114,23 @@ fn run(config: Config, command: Option<Command>) -> Result<(), LanMouseError> {
             #[cfg(windows)]
             Command::Install => {
                 lan_mouse::windows::install()
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                    .map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::Uninstall => {
                 lan_mouse::windows::uninstall()
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                    .map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::Status => {
                 lan_mouse::windows_service::service_status()
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                    .map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::WinSvc => {
                 // This starts the Windows service dispatcher
                 lan_mouse::windows_service::run_dispatch().map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
+                    io::Error::other(
                         format!("Failed to start service dispatcher: {e}"),
                     )
                 })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,26 +113,21 @@ fn run(config: Config, command: Option<Command>) -> Result<(), LanMouseError> {
             },
             #[cfg(windows)]
             Command::Install => {
-                lan_mouse::windows::install()
-                    .map_err(io::Error::other)?;
+                lan_mouse::windows::install().map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::Uninstall => {
-                lan_mouse::windows::uninstall()
-                    .map_err(io::Error::other)?;
+                lan_mouse::windows::uninstall().map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::Status => {
-                lan_mouse::windows_service::service_status()
-                    .map_err(io::Error::other)?;
+                lan_mouse::windows_service::service_status().map_err(io::Error::other)?;
             }
             #[cfg(windows)]
             Command::WinSvc => {
                 // This starts the Windows service dispatcher
                 lan_mouse::windows_service::run_dispatch().map_err(|e| {
-                    io::Error::other(
-                        format!("Failed to start service dispatcher: {e}"),
-                    )
+                    io::Error::other(format!("Failed to start service dispatcher: {e}"))
                 })?;
             }
         },

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,213 @@
+//! Windows-specific platform support: install/uninstall commands.
+//!
+//! This module handles registering lan-mouse as a Windows service (watchdog architecture)
+//! and related setup tasks like config/cert migration and firewall rules.
+
+use log::info;
+use std::process::Command;
+use windows::Win32::System::Services::{
+    OpenSCManagerW, CreateServiceW, OpenServiceW, DeleteService, StartServiceW,
+    ControlService, SC_MANAGER_ALL_ACCESS, SERVICE_ALL_ACCESS, SERVICE_WIN32_OWN_PROCESS,
+    SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, SERVICE_CONTROL_STOP,
+    ChangeServiceConfig2W, SERVICE_CONFIG_DESCRIPTION, SERVICE_DESCRIPTIONW,
+};
+use windows::Win32::System::Registry::{
+    RegCreateKeyExW, RegSetValueExW, RegCloseKey, HKEY_LOCAL_MACHINE, REG_SZ, HKEY,
+    REG_OPTION_NON_VOLATILE, KEY_WRITE, REG_DWORD,
+};
+use windows::core::{HSTRING, PWSTR};
+use lan_mouse_ipc::DEFAULT_PORT;
+use std::os::windows::ffi::OsStrExt;
+
+/// Install lan-mouse as a Windows service (watchdog mode).
+///
+/// This registers the service with SCM, copies config/cert to ProgramData,
+/// adds a firewall rule, and starts the service.
+pub fn install() -> Result<(), String> {
+    unsafe {
+        let scm = OpenSCManagerW(None, None, SC_MANAGER_ALL_ACCESS)
+            .map_err(|e| format!("Failed to open SCM: {}", e))?;
+
+        let exe_path = std::env::current_exe()
+            .map_err(|e| format!("Failed to get current exe path: {}", e))?;
+        
+        // Add "watchdog" argument to the service command line
+        let exe_path_str = exe_path.to_str().ok_or("Invalid exe path")?;
+        let cmd_line = format!("\"{}\" watchdog", exe_path_str);
+        let cmd_line_h = HSTRING::from(cmd_line);
+
+        let service_name = HSTRING::from("lan-mouse");
+        let display_name = HSTRING::from("Lan Mouse");
+
+        let service = CreateServiceW(
+            scm,
+            &service_name,
+            &display_name,
+            SERVICE_ALL_ACCESS,
+            SERVICE_WIN32_OWN_PROCESS,
+            SERVICE_AUTO_START,
+            SERVICE_ERROR_NORMAL,
+            &cmd_line_h,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ).map_err(|e| format!("Failed to create service: {}", e))?;
+
+        info!("Service installed successfully");
+
+        // Copy config to ProgramData
+        let program_data = std::path::Path::new("C:\\ProgramData\\lan-mouse");
+        let _ = std::fs::create_dir_all(program_data);
+        let dst_config = program_data.join("config.toml");
+        
+        if !dst_config.exists() {
+             if let Ok(app_data) = std::env::var("LOCALAPPDATA") {
+                 let src_config = std::path::Path::new(&app_data).join("lan-mouse").join("config.toml");
+                 if src_config.exists() {
+                     let _ = std::fs::copy(src_config, dst_config);
+                 }
+             }
+        }
+
+        // Copy certificate (lan-mouse.pem) from user's LOCALAPPDATA if present
+        let dst_cert = program_data.join("lan-mouse.pem");
+        if !dst_cert.exists() {
+            if let Ok(app_data) = std::env::var("LOCALAPPDATA") {
+                let src_cert = std::path::Path::new(&app_data).join("lan-mouse").join("lan-mouse.pem");
+                if src_cert.exists() {
+                    match std::fs::copy(&src_cert, &dst_cert) {
+                        Ok(_) => info!("Copied user certificate to ProgramData: {:?}", dst_cert),
+                        Err(e) => log::warn!("Failed to copy certificate to ProgramData: {}", e),
+                    }
+                }
+            }
+        }
+
+        // Create Windows Firewall rule to allow incoming connections on DEFAULT_PORT
+        // Use netsh advfirewall to add a rule for domain and private profiles (not Public)
+        let port = DEFAULT_PORT.to_string();
+        let rule_name = format!("Lan Mouse ({})", port);
+        let netsh_args: Vec<String> = vec![
+            "advfirewall".to_string(),
+            "firewall".to_string(),
+            "add".to_string(),
+            "rule".to_string(),
+            format!("name={}", rule_name),
+            "dir=in".to_string(),
+            "action=allow".to_string(),
+            "protocol=TCP".to_string(),
+            format!("localport={}", port),
+            "profile=domain,private".to_string(),
+            "enable=yes".to_string(),
+        ];
+
+        // Run netsh; don't fail install if firewall command fails, just log
+        match Command::new("netsh").args(&netsh_args).output() {
+            Ok(output) => {
+                if output.status.success() {
+                    info!("Firewall rule added: {}", rule_name);
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    log::warn!("Failed to add firewall rule (netsh returned non-zero): {}", stderr);
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to execute netsh to add firewall rule: {}", e);
+            }
+        }
+
+        // Register event source
+        let sub_key = HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
+        let mut h_key = HKEY::default();
+        if RegCreateKeyExW(
+            HKEY_LOCAL_MACHINE,
+            &sub_key,
+            Some(0),
+            None,
+            REG_OPTION_NON_VOLATILE,
+            KEY_WRITE,
+            None,
+            &mut h_key,
+            None,
+        ).is_ok() {
+            let path_wide: Vec<u16> = exe_path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+            let _ = RegSetValueExW(
+                h_key,
+                &HSTRING::from("EventMessageFile"),
+                Some(0),
+                REG_SZ,
+                Some(std::slice::from_raw_parts(path_wide.as_ptr() as *const u8, path_wide.len() * 2)),
+            );
+            let types_supported = 7u32;
+            let _ = RegSetValueExW(
+                h_key,
+                &HSTRING::from("TypesSupported"),
+                Some(0),
+                REG_DWORD,
+                Some(std::slice::from_raw_parts(&types_supported as *const u32 as *const u8, 4)),
+            );
+            let _ = RegCloseKey(h_key);
+        }
+
+        // Try to set service description using ChangeServiceConfig2W (preferred)
+        let description = "Lan Mouse - share mouse and keyboard across local networks";
+        let mut desc_wide: Vec<u16> = description.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut svc_desc = SERVICE_DESCRIPTIONW {
+            lpDescription: PWSTR(desc_wide.as_mut_ptr()),
+        };
+
+        let desc_ptr = &mut svc_desc as *mut _ as *const std::ffi::c_void;
+        // Some Windows versions or environments may not support ChangeServiceConfig2W
+        // Treat failure to set the description as non-fatal: log and continue.
+        match ChangeServiceConfig2W(service, SERVICE_CONFIG_DESCRIPTION, Some(desc_ptr)) {
+            Ok(_) => info!("Service description set via ChangeServiceConfig2W"),
+            Err(e) => log::warn!("ChangeServiceConfig2W failed (continuing): {}", e),
+        }
+
+        if let Err(e) = StartServiceW(service, None) {
+            log::warn!("Failed to start service after installation: {}", e);
+        } else {
+            info!("Service started");
+        }
+
+        Ok(())
+    }
+}
+
+/// Uninstall the lan-mouse Windows service.
+///
+/// Stops the service if running, removes service registration, and cleans up
+/// registry entries.
+pub fn uninstall() -> Result<(), String> {
+    unsafe {
+        let scm = OpenSCManagerW(None, None, SC_MANAGER_ALL_ACCESS)
+            .map_err(|e| format!("Failed to open SCM: {}", e))?;
+
+        let service_name = HSTRING::from("lan-mouse");
+        let service = match OpenServiceW(scm, &service_name, SERVICE_ALL_ACCESS) {
+            Ok(s) => s,
+            Err(e) => {
+                // Check if the service doesn't exist (error code 1060)
+                let hresult = e.code();
+                if hresult.0 == -2147024908i32 {  // 1060 in HRESULT format (ERROR_SERVICE_DOES_NOT_EXIST)
+                    return Ok(());
+                }
+                return Err(format!("Failed to open service: {}", e));
+            }
+        };
+
+        let mut status = windows::Win32::System::Services::SERVICE_STATUS::default();
+        let _ = ControlService(service, SERVICE_CONTROL_STOP, &mut status);
+
+        DeleteService(service).map_err(|e| format!("Failed to delete service: {}", e))?;
+
+        // Cleanup event source registry
+        let sub_key = HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
+        let _ = windows::Win32::System::Registry::RegDeleteKeyW(HKEY_LOCAL_MACHINE, &sub_key);
+
+        info!("Service uninstalled successfully");
+        Ok(())
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -3,21 +3,21 @@
 //! This module handles registering lan-mouse as a Windows service
 //! and related setup tasks like config/cert migration and firewall rules.
 
+use lan_mouse_ipc::DEFAULT_PORT;
 use log::info;
+use std::os::windows::ffi::OsStrExt;
 use std::process::Command;
-use windows::Win32::System::Services::{
-    OpenSCManagerW, CreateServiceW, OpenServiceW, DeleteService, StartServiceW,
-    ControlService, SC_MANAGER_ALL_ACCESS, SERVICE_ALL_ACCESS, SERVICE_WIN32_OWN_PROCESS,
-    SERVICE_AUTO_START, SERVICE_ERROR_NORMAL, SERVICE_CONTROL_STOP,
-    ChangeServiceConfig2W, SERVICE_CONFIG_DESCRIPTION, SERVICE_DESCRIPTIONW,
-};
 use windows::Win32::System::Registry::{
-    RegCreateKeyExW, RegSetValueExW, RegCloseKey, HKEY_LOCAL_MACHINE, REG_SZ, HKEY,
-    REG_OPTION_NON_VOLATILE, KEY_WRITE, REG_DWORD,
+    HKEY, HKEY_LOCAL_MACHINE, KEY_WRITE, REG_DWORD, REG_OPTION_NON_VOLATILE, REG_SZ, RegCloseKey,
+    RegCreateKeyExW, RegSetValueExW,
+};
+use windows::Win32::System::Services::{
+    ChangeServiceConfig2W, ControlService, CreateServiceW, DeleteService, OpenSCManagerW,
+    OpenServiceW, SC_MANAGER_ALL_ACCESS, SERVICE_ALL_ACCESS, SERVICE_AUTO_START,
+    SERVICE_CONFIG_DESCRIPTION, SERVICE_CONTROL_STOP, SERVICE_DESCRIPTIONW, SERVICE_ERROR_NORMAL,
+    SERVICE_WIN32_OWN_PROCESS, StartServiceW,
 };
 use windows::core::{HSTRING, PWSTR};
-use lan_mouse_ipc::DEFAULT_PORT;
-use std::os::windows::ffi::OsStrExt;
 
 /// Install lan-mouse as a Windows service.
 pub fn install() -> Result<(), String> {
@@ -27,7 +27,7 @@ pub fn install() -> Result<(), String> {
 
         let exe_path = std::env::current_exe()
             .map_err(|e| format!("Failed to get current exe path: {}", e))?;
-        
+
         // Add "win-svc" argument to the service command line
         let exe_path_str = exe_path.to_str().ok_or("Invalid exe path")?;
         let cmd_line = format!("\"{}\" win-svc", exe_path_str);
@@ -50,7 +50,8 @@ pub fn install() -> Result<(), String> {
             None,
             None,
             None,
-        ).map_err(|e| format!("Failed to create service: {}", e))?;
+        )
+        .map_err(|e| format!("Failed to create service: {}", e))?;
 
         info!("Service installed successfully");
 
@@ -58,21 +59,25 @@ pub fn install() -> Result<(), String> {
         let program_data = std::path::Path::new("C:\\ProgramData\\lan-mouse");
         let _ = std::fs::create_dir_all(program_data);
         let dst_config = program_data.join("config.toml");
-        
+
         if !dst_config.exists() {
-             if let Ok(app_data) = std::env::var("LOCALAPPDATA") {
-                 let src_config = std::path::Path::new(&app_data).join("lan-mouse").join("config.toml");
-                 if src_config.exists() {
-                     let _ = std::fs::copy(src_config, dst_config);
-                 }
-             }
+            if let Ok(app_data) = std::env::var("LOCALAPPDATA") {
+                let src_config = std::path::Path::new(&app_data)
+                    .join("lan-mouse")
+                    .join("config.toml");
+                if src_config.exists() {
+                    let _ = std::fs::copy(src_config, dst_config);
+                }
+            }
         }
 
         // Copy certificate (lan-mouse.pem) from user's LOCALAPPDATA if present
         let dst_cert = program_data.join("lan-mouse.pem");
         if !dst_cert.exists() {
             if let Ok(app_data) = std::env::var("LOCALAPPDATA") {
-                let src_cert = std::path::Path::new(&app_data).join("lan-mouse").join("lan-mouse.pem");
+                let src_cert = std::path::Path::new(&app_data)
+                    .join("lan-mouse")
+                    .join("lan-mouse.pem");
                 if src_cert.exists() {
                     match std::fs::copy(&src_cert, &dst_cert) {
                         Ok(_) => info!("Copied user certificate to ProgramData: {:?}", dst_cert),
@@ -107,7 +112,10 @@ pub fn install() -> Result<(), String> {
                     info!("Firewall rule added: {}", rule_name);
                 } else {
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    log::warn!("Failed to add firewall rule (netsh returned non-zero): {}", stderr);
+                    log::warn!(
+                        "Failed to add firewall rule (netsh returned non-zero): {}",
+                        stderr
+                    );
                 }
             }
             Err(e) => {
@@ -116,7 +124,8 @@ pub fn install() -> Result<(), String> {
         }
 
         // Register event source
-        let sub_key = HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
+        let sub_key =
+            HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
         let mut h_key = HKEY::default();
         if RegCreateKeyExW(
             HKEY_LOCAL_MACHINE,
@@ -128,14 +137,23 @@ pub fn install() -> Result<(), String> {
             None,
             &mut h_key,
             None,
-        ).is_ok() {
-            let path_wide: Vec<u16> = exe_path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+        )
+        .is_ok()
+        {
+            let path_wide: Vec<u16> = exe_path
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
             let _ = RegSetValueExW(
                 h_key,
                 &HSTRING::from("EventMessageFile"),
                 Some(0),
                 REG_SZ,
-                Some(std::slice::from_raw_parts(path_wide.as_ptr() as *const u8, path_wide.len() * 2)),
+                Some(std::slice::from_raw_parts(
+                    path_wide.as_ptr() as *const u8,
+                    path_wide.len() * 2,
+                )),
             );
             let types_supported = 7u32;
             let _ = RegSetValueExW(
@@ -143,14 +161,20 @@ pub fn install() -> Result<(), String> {
                 &HSTRING::from("TypesSupported"),
                 Some(0),
                 REG_DWORD,
-                Some(std::slice::from_raw_parts(&types_supported as *const u32 as *const u8, 4)),
+                Some(std::slice::from_raw_parts(
+                    &types_supported as *const u32 as *const u8,
+                    4,
+                )),
             );
             let _ = RegCloseKey(h_key);
         }
 
         // Try to set service description using ChangeServiceConfig2W (preferred)
         let description = "Lan Mouse - share mouse and keyboard across local networks";
-        let mut desc_wide: Vec<u16> = description.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut desc_wide: Vec<u16> = description
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
         let mut svc_desc = SERVICE_DESCRIPTIONW {
             lpDescription: PWSTR(desc_wide.as_mut_ptr()),
         };
@@ -188,7 +212,8 @@ pub fn uninstall() -> Result<(), String> {
             Err(e) => {
                 // Check if the service doesn't exist (error code 1060)
                 let hresult = e.code();
-                if hresult.0 == -2147024908i32 {  // 1060 in HRESULT format (ERROR_SERVICE_DOES_NOT_EXIST)
+                if hresult.0 == -2147024908i32 {
+                    // 1060 in HRESULT format (ERROR_SERVICE_DOES_NOT_EXIST)
                     return Ok(());
                 }
                 return Err(format!("Failed to open service: {}", e));
@@ -201,7 +226,8 @@ pub fn uninstall() -> Result<(), String> {
         DeleteService(service).map_err(|e| format!("Failed to delete service: {}", e))?;
 
         // Cleanup event source registry
-        let sub_key = HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
+        let sub_key =
+            HSTRING::from("SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\lan-mouse");
         let _ = windows::Win32::System::Registry::RegDeleteKeyW(HKEY_LOCAL_MACHINE, &sub_key);
 
         info!("Service uninstalled successfully");

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -28,9 +28,9 @@ pub fn install() -> Result<(), String> {
         let exe_path = std::env::current_exe()
             .map_err(|e| format!("Failed to get current exe path: {}", e))?;
         
-        // Add "winsvc" argument to the service command line
+        // Add "win-svc" argument to the service command line
         let exe_path_str = exe_path.to_str().ok_or("Invalid exe path")?;
-        let cmd_line = format!("\"{}\" winsvc", exe_path_str);
+        let cmd_line = format!("\"{}\" win-svc", exe_path_str);
         let cmd_line_h = HSTRING::from(cmd_line);
 
         let service_name = HSTRING::from("lan-mouse");

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,6 @@
 //! Windows-specific platform support: install/uninstall commands.
 //!
-//! This module handles registering lan-mouse as a Windows service (watchdog architecture)
+//! This module handles registering lan-mouse as a Windows service
 //! and related setup tasks like config/cert migration and firewall rules.
 
 use log::info;
@@ -19,10 +19,7 @@ use windows::core::{HSTRING, PWSTR};
 use lan_mouse_ipc::DEFAULT_PORT;
 use std::os::windows::ffi::OsStrExt;
 
-/// Install lan-mouse as a Windows service (watchdog mode).
-///
-/// This registers the service with SCM, copies config/cert to ProgramData,
-/// adds a firewall rule, and starts the service.
+/// Install lan-mouse as a Windows service.
 pub fn install() -> Result<(), String> {
     unsafe {
         let scm = OpenSCManagerW(None, None, SC_MANAGER_ALL_ACCESS)
@@ -31,9 +28,9 @@ pub fn install() -> Result<(), String> {
         let exe_path = std::env::current_exe()
             .map_err(|e| format!("Failed to get current exe path: {}", e))?;
         
-        // Add "watchdog" argument to the service command line
+        // Add "winsvc" argument to the service command line
         let exe_path_str = exe_path.to_str().ok_or("Invalid exe path")?;
-        let cmd_line = format!("\"{}\" watchdog", exe_path_str);
+        let cmd_line = format!("\"{}\" winsvc", exe_path_str);
         let cmd_line_h = HSTRING::from(cmd_line);
 
         let service_name = HSTRING::from("lan-mouse");

--- a/src/windows_service.rs
+++ b/src/windows_service.rs
@@ -1,0 +1,592 @@
+use std::ffi::OsString;
+use windows_service::{
+    define_windows_service,
+    service::{
+        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceStatus, ServiceType,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult},
+    service_dispatcher,
+};
+use std::time::Duration;
+use windows::Win32::System::Services::{
+    OpenSCManagerW, OpenServiceW, ControlService,
+    SC_MANAGER_ALL_ACCESS, SERVICE_ALL_ACCESS,
+};
+use windows::Win32::System::RemoteDesktop::{WTSGetActiveConsoleSessionId, ProcessIdToSessionId};
+use windows::Win32::System::Threading::{
+    CreateProcessAsUserW, PROCESS_INFORMATION, STARTUPINFOW, CREATE_UNICODE_ENVIRONMENT,
+    CREATE_NO_WINDOW, TerminateProcess, WaitForSingleObject, OpenProcess,
+    OpenProcessToken, PROCESS_ALL_ACCESS,
+};
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+    TH32CS_SNAPPROCESS,
+};
+use windows::Win32::System::Environment::{CreateEnvironmentBlock, DestroyEnvironmentBlock};
+use windows::Win32::Security::{
+    DuplicateTokenEx, TOKEN_ALL_ACCESS,
+    SecurityImpersonation, TokenPrimary, SetTokenInformation,
+    TokenUIAccess, TOKEN_ASSIGN_PRIMARY,
+};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0};
+use windows::core::{HSTRING, PWSTR, w};
+use std::ptr;
+
+define_windows_service!(ffi_service_main, lan_mouse_service_main);
+
+pub fn run_as_service() -> Result<(), windows_service::Error> {
+    // Check if we were invoked with "watchdog" command
+    // The SCM passes the service name as first arg, then our command-line args
+    let args: Vec<String> = std::env::args().collect();
+    let is_watchdog = args.iter().any(|arg| arg == "watchdog");
+    
+    if is_watchdog {
+        service_dispatcher::start("lan-mouse", ffi_service_main)
+    } else {
+        // Not invoked as watchdog service
+        Err(windows_service::Error::Winapi(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Not started by SCM",
+        )))
+    }
+}
+
+fn lan_mouse_service_main(_arguments: Vec<OsString>) {
+    // Initialize file-based logging (services don't have console)
+    let log_dir = std::path::Path::new("C:\\ProgramData\\lan-mouse");
+    let _ = std::fs::create_dir_all(log_dir);
+    let log_path = log_dir.join("watchdog.log");
+    
+    if let Ok(log_file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        use env_logger::Env;
+        let env = Env::default().filter_or("LAN_MOUSE_LOG_LEVEL", "info");
+        let _ = env_logger::Builder::from_env(env)
+            .format_timestamp_secs()
+            .target(env_logger::Target::Pipe(Box::new(log_file)))
+            .try_init();
+    }
+    
+    log::info!("lan-mouse watchdog service starting");
+    
+    if let Err(e) = run_watchdog_service() {
+        log::error!("Watchdog service error: {:?}", e);
+    }
+}
+
+fn run_watchdog_service() -> Result<(), windows_service::Error> {
+    /* ==================================================================================
+     * WATCHDOG SERVICE - Session Manager for lan-mouse
+     * ==================================================================================
+     * 
+     * This service runs in Session 0 as SYSTEM and manages session daemon processes:
+     * 
+     * 1. Monitor active console session via WTSGetActiveConsoleSessionId()
+     * 2. Spawn `lan-mouse daemon` in user session using CreateProcessAsUser()
+     * 3. Acquire appropriate token (WTSQueryUserToken or winlogon token)
+     * 4. Monitor daemon health, respawn on crash or session change
+     * 5. Handle SendSAS for Ctrl+Alt+Del (future: when IPC is implemented)
+     * 
+     * Session daemons perform actual input capture/emulation since they run in the
+     * user's session where SendInput works correctly.
+     * ==================================================================================
+     */
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop | ServiceControl::Shutdown => {
+                log::info!("Received stop/shutdown signal");
+                tx.send(()).unwrap_or_default();
+                ServiceControlHandlerResult::NoError
+            }
+            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    let status_handle = service_control_handler::register("lan-mouse", event_handler)?;
+
+    status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: windows_service::service::ServiceState::StartPending,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::from_secs(5),
+        process_id: None,
+    })?;
+
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("Failed to create tokio runtime: {:?}", e);
+            return Err(windows_service::Error::Winapi(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to create tokio runtime",
+            )));
+        }
+    };
+
+    let local = tokio::task::LocalSet::new();
+    rt.block_on(local.run_until(async {
+        status_handle
+            .set_service_status(ServiceStatus {
+                service_type: ServiceType::OWN_PROCESS,
+                current_state: windows_service::service::ServiceState::Running,
+                controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 0,
+                wait_hint: Duration::default(),
+                process_id: None,
+            })
+            .unwrap();
+
+        log::info!("Watchdog service running - monitoring sessions and managing daemons");
+
+        if let Err(e) = watchdog_main_loop(rx).await {
+            log::error!("Watchdog main loop error: {:?}", e);
+        }
+
+        status_handle
+            .set_service_status(ServiceStatus {
+                service_type: ServiceType::OWN_PROCESS,
+                current_state: windows_service::service::ServiceState::StopPending,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 0,
+                wait_hint: Duration::from_secs(5),
+                process_id: None,
+            })
+            .unwrap();
+    }));
+
+    status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: windows_service::service::ServiceState::Stopped,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    })?;
+
+    log::info!("Watchdog service stopped");
+    Ok(())
+}
+
+async fn watchdog_main_loop(mut shutdown_rx: tokio::sync::mpsc::UnboundedReceiver<()>) -> Result<(), std::io::Error> {
+    log::info!("Watchdog main loop started - monitoring console sessions");
+    
+    let mut current_session_id: Option<u32> = None;
+    let mut session_daemon: Option<SessionDaemonHandle> = None;
+    let mut crash_count = 0u32;
+    let mut last_crash_time = std::time::Instant::now();
+    
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                log::info!("Watchdog received shutdown signal");
+                
+                // Terminate session daemon if running
+                if let Some(daemon) = session_daemon.take() {
+                    log::info!("Terminating session daemon (PID={})", daemon.process_id);
+                    daemon.terminate();
+                }
+                
+                break;
+            }
+            _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                // Check active console session
+                let active_session = get_active_console_session();
+                
+                // 0xFFFFFFFF means no active session (e.g., no user logged in)
+                if active_session == 0xFFFFFFFF {
+                    if current_session_id.is_some() {
+                        log::info!("No active console session (user logged out or switching sessions)");
+                        
+                        // Terminate session daemon
+                        if let Some(daemon) = session_daemon.take() {
+                            log::info!("Terminating session daemon (PID={})", daemon.process_id);
+                            daemon.terminate();
+                        }
+                        
+                        current_session_id = None;
+                    }
+                    continue;
+                }
+                
+                // Check if daemon crashed (if we think we have one but it's not running)
+                if let Some(ref daemon) = session_daemon {
+                    if !daemon.is_running() {
+                        let now = std::time::Instant::now();
+                        let time_since_last_crash = now.duration_since(last_crash_time);
+                        
+                        // Reset crash count if it's been more than 60 seconds since last crash
+                        if time_since_last_crash.as_secs() > 60 {
+                            crash_count = 0;
+                        }
+                        
+                        crash_count += 1;
+                        last_crash_time = now;
+                        
+                        log::error!("Session daemon crashed (PID={}, crash #{}) - will respawn after backoff", 
+                                   daemon.process_id, crash_count);
+                        
+                        // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
+                        let backoff_secs = std::cmp::min(1u64 << (crash_count - 1), 30);
+                        log::info!("Waiting {}s before respawn attempt...", backoff_secs);
+                        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                        
+                        session_daemon = None;
+                        // Will respawn below
+                    } else {
+                        // Daemon is running - reset crash count
+                        if crash_count > 0 {
+                            crash_count = 0;
+                        }
+                    }
+                }
+                
+                // Check if session changed
+                let session_changed = current_session_id != Some(active_session);
+                let need_spawn = session_changed || (session_daemon.is_none() && current_session_id.is_some());
+                
+                if session_changed {
+                    log::info!("Console session changed: {:?} -> {}", current_session_id, active_session);
+                    
+                    // Terminate old session daemon
+                    if let Some(daemon) = session_daemon.take() {
+                        log::info!("Terminating session daemon in old session (PID={})", daemon.process_id);
+                        daemon.terminate();
+                    }
+                    
+                    current_session_id = Some(active_session);
+                }
+                
+                // Spawn daemon in active session if needed
+                if need_spawn && session_daemon.is_none() {
+                    match get_session_token(active_session) {
+                        Ok(token) => {
+                            match spawn_session_daemon(active_session, token) {
+                                Ok(daemon) => {
+                                    log::info!("Successfully spawned session daemon in session {} (PID={})", 
+                                               active_session, daemon.process_id);
+                                    session_daemon = Some(daemon);
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to spawn session daemon: {}", e);
+                                }
+                            }
+                            
+                            // Clean up token
+                            unsafe { let _ = CloseHandle(token); }
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to get session token for session {}: {} (will retry)", active_session, e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    log::info!("Watchdog main loop shutting down");
+    Ok(())
+}
+
+fn get_active_console_session() -> u32 {
+    unsafe { WTSGetActiveConsoleSessionId() }
+}
+
+/// Holds process information for a spawned session daemon
+struct SessionDaemonHandle {
+    process_handle: HANDLE,
+    thread_handle: HANDLE,
+    process_id: u32,
+}
+
+impl SessionDaemonHandle {
+    fn is_running(&self) -> bool {
+        unsafe {
+            // WAIT_TIMEOUT = 0x00000102, means process still running
+            WaitForSingleObject(self.process_handle, 0) != WAIT_OBJECT_0
+        }
+    }
+
+    fn terminate(&self) {
+        unsafe {
+            let _ = TerminateProcess(self.process_handle, 1);
+            // Wait up to 5 seconds for process to exit
+            let _ = WaitForSingleObject(self.process_handle, 5000);
+        }
+    }
+}
+
+impl Drop for SessionDaemonHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.process_handle);
+            let _ = CloseHandle(self.thread_handle);
+        }
+    }
+}
+
+/// Find a process by name in a specific session
+fn find_process_in_session(process_name: &str, session_id: u32) -> Result<u32, std::io::Error> {
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("CreateToolhelp32Snapshot failed: {}", e)
+            ))?;
+
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+
+        if Process32FirstW(snapshot, &mut entry).is_err() {
+            let _ = CloseHandle(snapshot);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Process32FirstW failed"
+            ));
+        }
+
+        let target_name_lower = process_name.to_lowercase();
+
+        loop {
+            // Convert process name from wide string
+            let name_len = entry.szExeFile.iter().position(|&c| c == 0).unwrap_or(entry.szExeFile.len());
+            let process_name_str = String::from_utf16_lossy(&entry.szExeFile[..name_len]);
+
+            if process_name_str.to_lowercase() == target_name_lower {
+                // Check if process is in the target session
+                let mut proc_session_id = 0u32;
+                if ProcessIdToSessionId(entry.th32ProcessID, &mut proc_session_id).is_ok() {
+                    if proc_session_id == session_id {
+                        let pid = entry.th32ProcessID;
+                        let _ = CloseHandle(snapshot);
+                        return Ok(pid);
+                    }
+                }
+            }
+
+            if Process32NextW(snapshot, &mut entry).is_err() {
+                break;
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Process '{}' not found in session {}", process_name, session_id)
+        ))
+    }
+}
+
+/// Check if a process exists in a session
+fn process_exists_in_session(process_name: &str, session_id: u32) -> bool {
+    find_process_in_session(process_name, session_id).is_ok()
+}
+
+/// Get winlogon token for login screen access (elevated token with UIAccess)
+fn get_winlogon_token(session_id: u32) -> Result<HANDLE, std::io::Error> {
+    unsafe {
+        // Find winlogon.exe in the target session
+        let winlogon_pid = find_process_in_session("winlogon.exe", session_id)?;
+
+        // Open the winlogon process
+        let process_handle = OpenProcess(PROCESS_ALL_ACCESS, false, winlogon_pid)
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("OpenProcess failed for winlogon PID {}: {}", winlogon_pid, e)
+            ))?;
+
+        // Get the winlogon process token
+        let mut source_token = HANDLE::default();
+        let result = OpenProcessToken(
+            process_handle,
+            TOKEN_ASSIGN_PRIMARY | TOKEN_ALL_ACCESS,
+            &mut source_token
+        );
+        let _ = CloseHandle(process_handle);
+        
+        result.map_err(|e| std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("OpenProcessToken failed for winlogon: {}", e)
+        ))?;
+
+        // Duplicate the token as a primary token
+        let mut new_token = HANDLE::default();
+        DuplicateTokenEx(
+            source_token,
+            TOKEN_ASSIGN_PRIMARY | TOKEN_ALL_ACCESS,
+            None,
+            SecurityImpersonation,
+            TokenPrimary,
+            &mut new_token,
+        ).map_err(|e| {
+            let _ = CloseHandle(source_token);
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("DuplicateTokenEx failed: {}", e)
+            )
+        })?;
+
+        let _ = CloseHandle(source_token);
+
+        // Enable UIAccess on the token for secure desktop access
+        let ui_access: u32 = 1;
+        SetTokenInformation(
+            new_token,
+            TokenUIAccess,
+            &ui_access as *const u32 as *const _,
+            std::mem::size_of::<u32>() as u32,
+        ).map_err(|e| {
+            log::warn!("SetTokenInformation(TokenUIAccess) failed: {} (may need code signing)", e);
+            // Don't fail here - token is still usable, just without UIAccess
+        }).ok();
+
+        log::info!("Acquired winlogon token for session {} (PID={})", session_id, winlogon_pid);
+        Ok(new_token)
+    }
+}
+
+/// Determine which token to use based on session context
+/// 
+/// For UAC/secure desktop access, we ALWAYS use the winlogon token.
+/// The winlogon process runs with SYSTEM privileges and has access to the
+/// Secure Desktop (UAC prompts). When we spawn the daemon with a winlogon-derived
+/// token, it inherits those access rights, allowing OpenInputDesktop to succeed.
+/// 
+/// Using WTSQueryUserToken only gets a limited user token which cannot access
+/// the Secure Desktop even with TokenUIAccess set.
+fn get_session_token(session_id: u32) -> Result<HANDLE, std::io::Error> {
+    // Check if we're at the login screen (logonui.exe present, no explorer.exe)
+    let is_login_screen = process_exists_in_session("logonui.exe", session_id)
+        && !process_exists_in_session("explorer.exe", session_id);
+
+    if is_login_screen {
+        log::info!("Detected login screen in session {} - using winlogon token", session_id);
+    } else {
+        log::info!("Detected normal user session {} - using winlogon token for secure desktop access", session_id);
+    }
+    
+    // Always use winlogon token - it has the privileges needed to access
+    // the Secure Desktop (UAC prompts) via OpenInputDesktop
+    get_winlogon_token(session_id)
+}
+
+/// Spawn session daemon in the specified session with the given token
+fn spawn_session_daemon(session_id: u32, token: HANDLE) -> Result<SessionDaemonHandle, std::io::Error> {
+    unsafe {
+        let exe_path = std::env::current_exe()?;
+        
+        // Build command line with explicit config path pointing to ProgramData
+        // This ensures the session daemon uses the machine-wide config regardless of
+        // which user token (or winlogon token) is used to spawn it
+        let config_path = r"C:\ProgramData\lan-mouse\config.toml";
+        let command = format!(r#""{}" --config "{}" daemon"#, exe_path.display(), config_path);
+        
+        log::info!("Spawning session daemon in session {} with command: {}", session_id, command);
+        
+        let mut command_wide: Vec<u16> = command.encode_utf16().chain(std::iter::once(0)).collect();
+        
+        let startup_info = STARTUPINFOW {
+            cb: std::mem::size_of::<STARTUPINFOW>() as u32,
+            lpDesktop: PWSTR(w!("winsta0\\Default").as_ptr() as *mut u16),
+            ..Default::default()
+        };
+        
+        // Create environment block for the user session
+        let mut env_block = ptr::null_mut();
+        CreateEnvironmentBlock(&mut env_block, Some(token), false)
+            .map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("CreateEnvironmentBlock failed: {}", e)
+            ))?;
+        
+        let mut proc_info = PROCESS_INFORMATION::default();
+        
+        let result = CreateProcessAsUserW(
+            Some(token),
+            None,
+            Some(PWSTR(command_wide.as_mut_ptr())),
+            None, // Process security
+            None, // Thread security
+            true, // Inherit handles
+            CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+            Some(env_block as *const _),
+            None, // Current directory
+            &startup_info,
+            &mut proc_info,
+        );
+        
+        DestroyEnvironmentBlock(env_block)
+            .map_err(|e| log::warn!("DestroyEnvironmentBlock failed: {}", e))
+            .ok();
+        
+        result.map_err(|e| std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("CreateProcessAsUserW failed: {}", e)
+        ))?;
+        
+        log::info!("Session daemon spawned successfully: PID={}", proc_info.dwProcessId);
+        
+        Ok(SessionDaemonHandle {
+            process_handle: proc_info.hProcess,
+            thread_handle: proc_info.hThread,
+            process_id: proc_info.dwProcessId,
+        })
+    }
+}
+
+pub fn service_status() -> Result<(), String> {
+    unsafe {
+        let scm = OpenSCManagerW(None, None, SC_MANAGER_ALL_ACCESS)
+            .map_err(|e| format!("Failed to open SCM: {}", e))?;
+
+        let service_name = HSTRING::from("lan-mouse");
+        let service = match OpenServiceW(scm, &service_name, SERVICE_ALL_ACCESS) {
+            Ok(s) => s,
+            Err(e) => {
+                // Check if the service doesn't exist (error code 1060)
+                let hresult = e.code();
+                if hresult.0 == -2147024908i32 {  // 1060 in HRESULT format (ERROR_SERVICE_DOES_NOT_EXIST)
+                    println!("Service not installed");
+                    return Ok(());
+                }
+                return Err(format!("Failed to open service: {}", e));
+            }
+        };
+
+        // Query service status
+        let mut status = windows::Win32::System::Services::SERVICE_STATUS::default();
+        ControlService(service, windows::Win32::System::Services::SERVICE_CONTROL_INTERROGATE, &mut status)
+            .ok();
+
+        let status_str = match status.dwCurrentState.0 {
+            1 => "Stopped",
+            2 => "Start Pending",
+            3 => "Stop Pending",
+            4 => "Running",
+            5 => "Continue Pending",
+            6 => "Pause Pending",
+            7 => "Paused",
+            _ => "Unknown",
+        };
+
+        println!("Service Status: {}", status_str);
+        Ok(())
+    }
+}

--- a/src/windows_service.rs
+++ b/src/windows_service.rs
@@ -318,9 +318,7 @@ impl Drop for SessionDaemonHandle {
 fn find_process_in_session(process_name: &str, session_id: u32) -> Result<u32, std::io::Error> {
     unsafe {
         let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0).map_err(|e| {
-            std::io::Error::other(
-                format!("CreateToolhelp32Snapshot failed: {}", e),
-            )
+            std::io::Error::other(format!("CreateToolhelp32Snapshot failed: {}", e))
         })?;
 
         let mut entry = PROCESSENTRY32W {
@@ -330,9 +328,7 @@ fn find_process_in_session(process_name: &str, session_id: u32) -> Result<u32, s
 
         if Process32FirstW(snapshot, &mut entry).is_err() {
             let _ = CloseHandle(snapshot);
-            return Err(std::io::Error::other(
-                "Process32FirstW failed",
-            ));
+            return Err(std::io::Error::other("Process32FirstW failed"));
         }
 
         let target_name_lower = process_name.to_lowercase();
@@ -389,12 +385,10 @@ fn get_session_token(session_id: u32) -> Result<HANDLE, std::io::Error> {
 
         // Open the winlogon process
         let process_handle = OpenProcess(PROCESS_ALL_ACCESS, false, winlogon_pid).map_err(|e| {
-            std::io::Error::other(
-                format!(
-                    "OpenProcess failed for winlogon PID {}: {}",
-                    winlogon_pid, e
-                ),
-            )
+            std::io::Error::other(format!(
+                "OpenProcess failed for winlogon PID {}: {}",
+                winlogon_pid, e
+            ))
         })?;
 
         // Get the winlogon process token
@@ -407,9 +401,7 @@ fn get_session_token(session_id: u32) -> Result<HANDLE, std::io::Error> {
         let _ = CloseHandle(process_handle);
 
         result.map_err(|e| {
-            std::io::Error::other(
-                format!("OpenProcessToken failed for winlogon: {}", e),
-            )
+            std::io::Error::other(format!("OpenProcessToken failed for winlogon: {}", e))
         })?;
 
         // Duplicate the token as a primary token
@@ -424,9 +416,7 @@ fn get_session_token(session_id: u32) -> Result<HANDLE, std::io::Error> {
         )
         .map_err(|e| {
             let _ = CloseHandle(source_token);
-            std::io::Error::other(
-                format!("DuplicateTokenEx failed: {}", e),
-            )
+            std::io::Error::other(format!("DuplicateTokenEx failed: {}", e))
         })?;
 
         let _ = CloseHandle(source_token);
@@ -495,11 +485,8 @@ fn spawn_session_daemon(
 
         // Create environment block for the user session
         let mut env_block = ptr::null_mut();
-        CreateEnvironmentBlock(&mut env_block, Some(token), false).map_err(|e| {
-            std::io::Error::other(
-                format!("CreateEnvironmentBlock failed: {}", e),
-            )
-        })?;
+        CreateEnvironmentBlock(&mut env_block, Some(token), false)
+            .map_err(|e| std::io::Error::other(format!("CreateEnvironmentBlock failed: {}", e)))?;
 
         let mut proc_info = PROCESS_INFORMATION::default();
 
@@ -521,11 +508,7 @@ fn spawn_session_daemon(
             .map_err(|e| log::warn!("DestroyEnvironmentBlock failed: {}", e))
             .ok();
 
-        result.map_err(|e| {
-            std::io::Error::other(
-                format!("CreateProcessAsUserW failed: {}", e),
-            )
-        })?;
+        result.map_err(|e| std::io::Error::other(format!("CreateProcessAsUserW failed: {}", e)))?;
 
         log::info!(
             "Session daemon spawned successfully: PID={}",

--- a/src/windows_service.rs
+++ b/src/windows_service.rs
@@ -41,8 +41,6 @@ pub fn run_dispatch() -> Result<(), windows_service::Error> {
 }
 
 fn lan_mouse_service_main(_arguments: Vec<OsString>) {
-    crate::set_is_service(true);
-    
     log::info!("lan-mouse Windows service starting");
     
     if let Err(e) = run_win_service() {


### PR DESCRIPTION
Support for installing and running lan-mouse as a windows service.  This allows lan-mouse input on UAC elevation prompts and the login/unlock screens.

I'm flipping this PR out of draft mode but I imagine it will need some feedback and comments/direction for things to clean up before it's 100% ready to merge.

## General architecture
- lan-mouse can still be run directly on windows without installing/running the service.  This will have the current limitation around not being able to control UAC elevation prompts or login/unlock screens, but still works exactly as it does today
- lan-mouse can optionally run as service - The service is a sort of watchdog/orchestrator that will spawn individual lan-mouse daemon processes inside/attached-to user sessions with elevated permissions

## Running/Testing
1a. build lan-mouse from the [jonstelly:pr/windows-service](https://github.com/jonstelly/lan-mouse/tree/pr/windows-service) branch
OR
1b. Download build from [my fork](https://github.com/jonstelly/lan-mouse/releases/tag/main)
2. Copy `./target/debug` files or extract the release zip file to a directory - `c:\ProgramData\lan-mouse` is a good option, this is where the config file and certificate will live
3. Launch an elevated terminal from the directory
4. Run `lan-mouse install` to install and start the windows service - If you already had a lan-mouse config file in your user's local-app-data lan-mouse directory, then the config and certificate will be copied into `c:\ProgramData\lan-mouse` with the install command, if not then the service will fail to start, you'll need to create the config.toml file in this directory now and then start the service

At this point, lan-mouse should be working in your normal windows desktop session, login screen, unlock screen, or UAC elevation prompts.

## Looking for feedback
- I added an "install" and "uninstall" CLI command to install the service in windows.  In my head it feels like it would be nice to have 1 "install" command for each OS.  For linux the install command could write the systemd user service file then enable it... For macos I understand there's launchd but I've never even looked into it.  But the general thinking was that this could be the same command for install to make documenting process easy, even though on each OS, install means something different
- For lan-mouse running as a service, it shouldn't attempt to load the config from a user's directory, so I adopted the recommended `c:\ProgramData\lan-mouse` directory for storing config and certificate.  The install command above will look for a config.toml and lan-mouse.pem file in the user's lan-mouse config directory, if present in user path and not yet in ProgramData, then the install command will copy those files.  It's not my favorite pattern, but it seems mostly intuitive, but open for any discussion here
- Meta+l to lock a remote windows machine doesn't work.  That's a secure action sequence, so I added special handling for windows emulation to catch Meta+l and lock the desktop.  I tested this code both running lan-mouse as the windows service, and running it from non-elevated terminal, it seems to work in both cases
- Added a handful of comments for different parts of code, specifically curious for input on the file logging, anything else
- This is probably the most rust code I've put together in 1 PR so welcome any feedback, I know there's already some cleanup I want to do, but happy to hear about anything else