### PR TITLE
Linux -> macOS fixes

### DIFF
--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -418,10 +418,7 @@ impl Emulation for MacOSEmulation {
                     };
                     let is_modifier = update_modifiers(&self.modifier_state, key, state);
                     if is_modifier {
-                        modifier_event(
-                            self.event_source.clone(),
-                            self.modifier_state.get(),
-                        );
+                        modifier_event(self.event_source.clone(), self.modifier_state.get());
                     }
                     match state {
                         // pressed


### PR DESCRIPTION
* address #357 - When handling a KeyboardEvent::Key for a modifier key, emit a CGEventType::FlagsChanged event so macOS updates its system modifier state, rather than relying solely on a KeyboardEvent::Modifiers event that Linux/libei never sends.