### PR TITLE
Use absolute pointer coordinates to move back to the host screen

### DIFF
--- a/input-emulation/src/error.rs
+++ b/input-emulation/src/error.rs
@@ -26,6 +26,8 @@ use wayland_client::{
 pub enum EmulationError {
     #[error("event stream closed")]
     EndOfStream,
+    #[error("pointer moved out of bounds - client should leave")]
+    OutOfBounds,
     #[cfg(all(unix, feature = "libei", not(target_os = "macos")))]
     #[error("libei error: `{0}`")]
     Libei(#[from] reis::Error),


### PR DESCRIPTION
I'm filing this as Draft because I need some feedback whether this is the right thing to do or whether I'm missing something here.

Testing lan-mouse on two Fedora 43 hosts here, main machine in front of me and a laptop to the right. Moving the mouse to the laptop works fine but it got stuck moving back. As far as I can tell (and Claude seemed to confirm this) lan-mouse is trying to use inputcapture on the remote to detect a barrier entry. This cannot work, those two sessions are fundamentally incompatible (remote desktop input does not count as input for inputcapture purposes[^1]).

Which means we can't rely on barriers on the remote - but since we know the remote's dimensions and we control the events we convert the relative coords from the mouse to absolute coordinates on the remote screen. And whenever we detect a movement off that area, we `release()` the inputcapture session and are back to the local screen.

Now, this works with my local setup but maybe I'm missing something?

AI disclaimer: written by claude code and stared long and hard at by me :)

[^1]: this may not be spelled out anywhere and ultimately depends on the compositor anyway but I never even considered this case when spec-ing the portal :)