### PR TITLE
fix: negate macOS scroll delta to match wl_pointer/libei sign

### DIFF
--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -357,6 +357,10 @@ fn get_events(
             })))
         }
         CGEventType::ScrollWheel => {
+            // macOS CGEvent scroll deltas use the opposite sign convention
+            // from wl_pointer/libei (positive = scroll-down direction).
+            // Negate so the forwarded values match the wire protocol
+            // convention used by the libei/Linux capture backend.
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
                 let v =
                     ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
@@ -366,14 +370,14 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
                         axis: 0, // Vertical
-                        value: v as f64,
+                        value: -v as f64,
                     })));
                 }
                 if h != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
                         axis: 1, // Horizontal
-                        value: h as f64,
+                        value: -h as f64,
                     })));
                 }
             } else {
@@ -386,7 +390,7 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {
                             axis: 0, // Vertical
-                            value: V120_STEPS_PER_LINE * v as i32,
+                            value: -V120_STEPS_PER_LINE * v as i32,
                         },
                     )));
                 }
@@ -394,7 +398,7 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {
                             axis: 1, // Horizontal
-                            value: V120_STEPS_PER_LINE * h as i32,
+                            value: -V120_STEPS_PER_LINE * h as i32,
                         },
                     )));
                 }


### PR DESCRIPTION
## Summary

macOS CGEvent scroll deltas use the opposite sign convention from `wl_pointer.axis` (and the libei capture backend used on Linux hosts). On macOS, a positive delta means "content moves up" (finger-up gesture under natural scrolling), while on Wayland a positive axis value means "scroll-down direction". The wire protocol value was therefore landing on the sink with the sign flipped relative to what other capture backends produce, so scrolling felt backwards whenever the source machine was macOS.

This normalizes the sign at capture time in ``input-capture/src/macos.rs`` so the wire protocol stays source-agnostic — both continuous (trackpad/Magic Mouse point-delta) and line-based (mouse-wheel) scroll values are negated to match wl_pointer/libei semantics.

### Before / after
- **Before**: scrolling from a macOS source with another lan-mouse client on Linux (wlroots emulation backend) scrolled the opposite direction from what the user gestured on the Mac.
- **After**: gesture direction on macOS matches content direction on the Linux sink, identical to behavior with a libei/Linux source.

## Test plan
- [x] Tested locally with a Mac (Dygma Defy + Magic Trackpad) as the source and an Arch + Hyprland host (wlroots sink) as the target. Scroll direction now matches gesture direction on both machines.
- [ ] Would appreciate confirmation from another macOS user that direction feels correct with both natural-scroll on and off in System Settings.
- [ ] Line-based (non-continuous) scroll path is negated symmetrically; no test environment with a PS/2-style wheel mouse on Mac to verify, but the change is trivially the same sign flip applied to the ``V120_STEPS_PER_LINE * v`` calculation.

## Notes
The fix deliberately lives in the macOS capture path rather than on the emission side, so the wire format stays consistent with what the libei capture backend already produces. No sink-side change is needed and Linux→Linux scrolling is unaffected.