### PR TITLE
feat(gui): cross-platform GUI singleton via dedicated socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.claude/
 .gdbinit
 .idea/
 .vs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +526,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -523,7 +557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -536,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -841,6 +875,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1354,6 +1394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1568,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+dependencies = [
+ "async-io",
+ "core-foundation 0.9.4",
+ "fnv",
+ "futures",
+ "if-addrs 0.15.0",
+ "ipnet",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,7 +1659,7 @@ dependencies = [
  "ashpd",
  "async-trait",
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "core-graphics",
  "futures",
@@ -1589,7 +1678,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
- "windows",
+ "windows 0.61.3",
  "x11",
 ]
 
@@ -1600,7 +1689,7 @@ dependencies = [
  "ashpd",
  "async-trait",
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "core-graphics",
  "futures",
@@ -1615,7 +1704,7 @@ dependencies = [
  "wayland-protocols",
  "wayland-protocols-misc",
  "wayland-protocols-wlr",
- "windows",
+ "windows 0.61.3",
  "x11",
 ]
 
@@ -1750,6 +1839,8 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "if-addrs 0.13.4",
+ "if-watch",
  "input-capture",
  "input-emulation",
  "input-event",
@@ -2001,6 +2092,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2150,18 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2289,6 +2440,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2685,24 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -2850,6 +3033,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3514,7 +3718,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.26.4",
  "portable-atomic",
  "rand",
  "thiserror 1.0.69",
@@ -3559,11 +3763,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -3573,6 +3789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3609,7 +3834,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -3654,6 +3890,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3768,6 +4014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,30 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -598,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -735,7 +711,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -746,18 +722,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "enumflags2"
@@ -852,7 +816,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1281,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1394,52 +1358,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.2",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "hkdf"
@@ -1714,19 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,7 +1750,6 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
- "hickory-resolver",
  "input-capture",
  "input-emulation",
  "input-event",
@@ -2097,23 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,10 +2129,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2530,18 +2413,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2551,17 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2571,15 +2434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2643,12 +2497,6 @@ dependencies = [
  "rustix 0.38.44",
  "tokio",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -2929,7 +2777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3016,12 +2864,6 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
@@ -3124,21 +2966,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3417,7 +3244,6 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3658,8 +3484,8 @@ dependencies = [
  "p384",
  "pem",
  "portable-atomic",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rcgen",
  "ring",
  "rustls",
@@ -3690,17 +3516,11 @@ dependencies = [
  "log",
  "nix",
  "portable-atomic",
- "rand 0.8.5",
+ "rand",
  "thiserror 1.0.69",
  "tokio",
  "winapi",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -3834,17 +3654,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -4186,7 +3995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +709,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +729,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -875,6 +907,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -1601,7 +1644,7 @@ dependencies = [
  "ipnet",
  "log",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.28.0",
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
@@ -1839,6 +1882,7 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "hostname",
  "if-addrs 0.13.4",
  "if-watch",
  "input-capture",
@@ -1851,6 +1895,8 @@ dependencies = [
  "libc",
  "local-channel",
  "log",
+ "mdns-sd",
+ "netdev",
  "notify",
  "rcgen",
  "rustls",
@@ -2040,6 +2086,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
+
+[[package]]
+name = "mdns-sd"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2bb8ce26633738d98ffcef71ec58bff967c6675be50229823c2835f6316e67e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs 0.15.0",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2159,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core",
+ "netlink-packet-route 0.29.0",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2196,18 @@ name = "netlink-packet-route"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2264,6 +2367,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -2438,6 +2631,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "polling"
@@ -2697,7 +2903,7 @@ dependencies = [
  "futures-util",
  "log",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.28.0",
  "netlink-proto",
  "netlink-sys",
  "nix 0.30.1",
@@ -2976,6 +3182,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3200,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ sha2 = "0.10.8"
 notify = "8.2.0"
 if-addrs = "0.13"
 if-watch = { version = "3.2", features = ["tokio"] }
+mdns-sd = "0.19"
+netdev = "0.43"
+hostname = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.148"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ rustls = { version = "0.23.12", default-features = false, features = [
 rcgen = "0.13.1"
 sha2 = "0.10.8"
 notify = "8.2.0"
+if-addrs = "0.13"
+if-watch = { version = "3.2", features = ["tokio"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.148"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ lan-mouse-ipc = { path = "lan-mouse-ipc", version = "0.2.0" }
 lan-mouse-proto = { path = "lan-mouse-proto", version = "0.2.0" }
 shadow-rs = { version = "1.2.0", features = ["metadata"] }
 
-hickory-resolver = "0.25.2"
 toml = "0.8"
 toml_edit = { version = "0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/input-capture/Cargo.toml
+++ b/input-capture/Cargo.toml
@@ -58,6 +58,7 @@ bitflags = "2.6.0"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.2", features = [
     "Win32_System_LibraryLoader",
+    "Win32_System_RemoteDesktop",
     "Win32_System_Threading",
     "Win32_Foundation",
     "Win32_Graphics",

--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -42,7 +42,7 @@ impl Capture for DummyInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         Ok(())
     }
 

--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -62,7 +62,7 @@ impl Stream for DummyInputCapture {
         let event = match self.start {
             None => {
                 self.start.replace(current);
-                CaptureEvent::Begin
+                CaptureEvent::Begin { cursor: None }
             }
             Some(start) => {
                 let elapsed = start.elapsed();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -654,7 +654,7 @@ impl Capture for LayerShellInputCapture {
         Ok(inner.flush_events()?)
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         log::debug!("releasing pointer");
         let inner = self.0.get_mut();
         inner.state.ungrab();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -753,7 +753,8 @@ impl Dispatch<WlPointer, ()> for State {
                     .find(|w| w.surface == surface)
                     .map(|w| w.pos)
                     .unwrap();
-                app.pending_events.push_back((pos, CaptureEvent::Begin));
+                app.pending_events
+                    .push_back((pos, CaptureEvent::Begin { cursor: None }));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -149,6 +149,13 @@ struct Window {
     surface: WlSurface,
     layer_surface: ZwlrLayerSurfaceV1,
     pos: Position,
+    /// Output's top-left corner in compositor coordinate space —
+    /// used together with `wl_pointer::Enter`'s surface-local coords
+    /// to recover the host screen-space cursor position at the moment
+    /// of crossing, so we can populate `CaptureEvent::Begin { cursor }`
+    /// for cross-axis preservation.
+    output_pos: (i32, i32),
+    output_size: (i32, i32),
 }
 
 impl Window {
@@ -157,6 +164,7 @@ impl Window {
         qh: &QueueHandle<State>,
         output: &WlOutput,
         pos: Position,
+        output_pos: (i32, i32),
         size: (i32, i32),
     ) -> Window {
         log::debug!("creating window output: {output:?}, size: {size:?}");
@@ -208,6 +216,8 @@ impl Window {
             buffer,
             surface,
             layer_surface,
+            output_pos,
+            output_size: size,
         }
     }
 }
@@ -218,6 +228,22 @@ impl Drop for Window {
         self.layer_surface.destroy();
         self.surface.destroy();
         self.buffer.destroy();
+    }
+}
+
+/// Translate `wl_pointer.enter` surface-local coords into the host's
+/// compositor coordinate space, using the layer-surface's anchor edge
+/// and the output it's attached to. Layer surfaces here are 1 px on
+/// the on-axis dimension and span the cross-axis, so the surface-local
+/// cross-axis coord is the screen offset directly.
+fn surface_to_screen(window: &Window, surface_x: f64, surface_y: f64) -> (i32, i32) {
+    let (ox, oy) = window.output_pos;
+    let (ow, oh) = window.output_size;
+    match window.pos {
+        Position::Left => (ox, oy + surface_y as i32),
+        Position::Right => (ox + ow.saturating_sub(1), oy + surface_y as i32),
+        Position::Top => (ox + surface_x as i32, oy),
+        Position::Bottom => (ox + surface_x as i32, oy + oh.saturating_sub(1)),
     }
 }
 
@@ -525,7 +551,7 @@ impl State {
         );
         outputs.iter().for_each(|o| {
             if let Some(info) = o.info.as_ref() {
-                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.size);
+                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
                 let window = Arc::new(window);
                 self.active_windows.push(window);
             }
@@ -638,6 +664,28 @@ impl Capture for LayerShellInputCapture {
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Union of every active output's rectangle in compositor
+        // coords. Mirrors the macOS impl so MotionAbsolute scaling
+        // stays consistent: cursor coords reported in this same
+        // space normalize cleanly against the returned dimensions.
+        let outputs = &self.0.get_ref().state.outputs;
+        let mut xmin = i32::MAX;
+        let mut ymin = i32::MAX;
+        let mut xmax = i32::MIN;
+        let mut ymax = i32::MIN;
+        for info in outputs.iter().filter_map(|o| o.info.as_ref()) {
+            xmin = xmin.min(info.position.0);
+            ymin = ymin.min(info.position.1);
+            xmax = xmax.max(info.position.0 + info.size.0);
+            ymax = ymax.max(info.position.1 + info.size.1);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
+    }
 }
 
 impl Stream for LayerShellInputCapture {
@@ -735,26 +783,26 @@ impl Dispatch<WlPointer, ()> for State {
             wl_pointer::Event::Enter {
                 serial,
                 surface,
-                surface_x: _,
-                surface_y: _,
+                surface_x,
+                surface_y,
             } => {
-                // get client corresponding to the focused surface
-                {
-                    if let Some(window) = app.active_windows.iter().find(|w| w.surface == surface) {
-                        app.focused = Some(window.clone());
-                        app.grab(&surface, pointer, serial, qh);
-                    } else {
-                        return;
-                    }
-                }
-                let pos = app
+                let Some(window) = app
                     .active_windows
                     .iter()
                     .find(|w| w.surface == surface)
-                    .map(|w| w.pos)
-                    .unwrap();
-                app.pending_events
-                    .push_back((pos, CaptureEvent::Begin { cursor: None }));
+                    .cloned()
+                else {
+                    return;
+                };
+                app.focused = Some(window.clone());
+                app.grab(&surface, pointer, serial, qh);
+                let cursor = surface_to_screen(&window, surface_x, surface_y);
+                app.pending_events.push_back((
+                    window.pos,
+                    CaptureEvent::Begin {
+                        cursor: Some(cursor),
+                    },
+                ));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -551,7 +551,8 @@ impl State {
         );
         outputs.iter().for_each(|o| {
             if let Some(info) = o.info.as_ref() {
-                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
+                let window =
+                    Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
                 let window = Arc::new(window);
                 self.active_windows.push(window);
             }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures_core::Stream;
 
-use input_event::{Event, KeyboardEvent, scancode};
+use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
 
 pub use error::{CaptureCreationError, CaptureError, InputCaptureError};
 
@@ -41,6 +41,11 @@ pub enum CaptureEvent {
     Begin,
     /// input event coming from capture handle
     Input(Event),
+    /// the capture wrapper detected sustained back-toward-host motion
+    /// past the configured threshold (the user has pinned the cursor
+    /// at the host-adjacent edge of the guest and kept pushing). The
+    /// capture loop should treat this like a release-bind chord.
+    AutoRelease,
 }
 
 impl Display for CaptureEvent {
@@ -48,6 +53,7 @@ impl Display for CaptureEvent {
         match self {
             CaptureEvent::Begin => write!(f, "begin capture"),
             CaptureEvent::Input(e) => write!(f, "{e}"),
+            CaptureEvent::AutoRelease => write!(f, "auto-release"),
         }
     }
 }
@@ -127,6 +133,37 @@ pub struct InputCapture {
     id_map: HashMap<CaptureHandle, Position>,
     /// pending events
     pending: VecDeque<(CaptureHandle, CaptureEvent)>,
+    /// pixel threshold for the cross-platform auto-release-on-wall-
+    /// press fallback. 0 disables. See `track_wall_press`.
+    release_threshold_px: u32,
+    /// position the cursor is currently captured into, if any. Tracks
+    /// `Begin`/release transitions so the wall-press accumulator
+    /// resets correctly across capture sessions.
+    capture_pos: Option<Position>,
+    /// Modeled cursor position on the guest along the entry axis,
+    /// relative to the host-adjacent edge. 0 = at the entry edge,
+    /// growing values = further into the guest. Clamped at 0 from
+    /// below; *not* clamped from above (the wrapper can't know the
+    /// guest's far-edge extent without a protocol-level Bounds event,
+    /// and any proxy is wrong for some user's setup).
+    virtual_pos: f64,
+    /// Pixels of back-toward-host motion that the modeled cursor
+    /// could not absorb (proposed virtual_pos < 0). Resets whenever
+    /// the cursor is back in the interior or moving deeper.
+    wall_pressure: f64,
+}
+
+/// Project a motion delta onto the entry axis. Positive return =
+/// "into guest", so virtual_pos increases as the user pushes deeper.
+fn entry_axis_delta(position: Position, dx: f64, dy: f64) -> f64 {
+    match position {
+        // Position::Left = guest is to the LEFT of host. User entered
+        // by moving left (-dx). Convention: positive = into guest.
+        Position::Left => -dx,
+        Position::Right => dx,
+        Position::Top => -dy,
+        Position::Bottom => dy,
+    }
 }
 
 impl InputCapture {
@@ -168,7 +205,80 @@ impl InputCapture {
     /// release mouse
     pub async fn release(&mut self) -> Result<(), CaptureError> {
         self.pressed_keys.clear();
+        self.reset_wall_press_state();
         self.capture.release().await
+    }
+
+    /// Configure the wall-press auto-release pixel threshold.
+    /// 0 disables. Effective immediately for the next motion event;
+    /// no need to recreate the backend.
+    pub fn set_release_threshold(&mut self, threshold: u32) {
+        self.release_threshold_px = threshold;
+    }
+
+    fn reset_wall_press_state(&mut self) {
+        self.capture_pos = None;
+        self.virtual_pos = 0.0;
+        self.wall_pressure = 0.0;
+    }
+
+    /// Update the wall-press accumulator from one event coming up
+    /// from the backend. Returns true if the threshold was reached
+    /// and an `AutoRelease` should be synthesized for the active
+    /// capture position.
+    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
+        match event {
+            CaptureEvent::Begin => {
+                self.capture_pos = Some(pos);
+                self.virtual_pos = 0.0;
+                self.wall_pressure = 0.0;
+                false
+            }
+            CaptureEvent::AutoRelease => {
+                self.reset_wall_press_state();
+                false
+            }
+            CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
+                if self.release_threshold_px == 0 {
+                    return false;
+                }
+                let Some(active_pos) = self.capture_pos else {
+                    return false;
+                };
+                if active_pos != pos {
+                    return false;
+                }
+
+                let delta = entry_axis_delta(active_pos, *dx, *dy);
+                let proposed = self.virtual_pos + delta;
+                self.virtual_pos = proposed.max(0.0);
+
+                if proposed < 0.0 {
+                    // Motion overshot the host-adjacent edge —
+                    // accumulate the unabsorbed amount as wall
+                    // pressure.
+                    self.wall_pressure += -proposed;
+                } else {
+                    // Cursor moved into the interior or further in;
+                    // reset so a brief bump against the wall followed
+                    // by motion deeper into the guest doesn't combine
+                    // with a later wall-press to fire spuriously.
+                    self.wall_pressure = 0.0;
+                }
+
+                if self.wall_pressure >= f64::from(self.release_threshold_px) {
+                    log::info!(
+                        "auto-release: {:.0}px wall-press past entry edge ({}px threshold)",
+                        self.wall_pressure,
+                        self.release_threshold_px
+                    );
+                    self.reset_wall_press_state();
+                    return true;
+                }
+                false
+            }
+            _ => false,
+        }
     }
 
     /// Drain and return every key the capture has forwarded as
@@ -198,6 +308,10 @@ impl InputCapture {
             pending: Default::default(),
             position_map: Default::default(),
             pressed_keys: HashSet::new(),
+            release_threshold_px: 0,
+            capture_pos: None,
+            virtual_pos: 0.0,
+            wall_pressure: 0.0,
         })
     }
 
@@ -248,6 +362,11 @@ impl Stream for InputCapture {
             self.update_pressed_keys(key, state);
         }
 
+        // wall-press auto-release tracking. Runs against every event
+        // before routing so a single global accumulator stays consistent
+        // regardless of how many handles exist at this position.
+        let auto_release = self.track_wall_press(pos, &event);
+
         let len = self
             .position_map
             .get(&pos)
@@ -256,16 +375,25 @@ impl Stream for InputCapture {
 
         match len {
             0 => Poll::Pending,
-            1 => Poll::Ready(Some(Ok((
-                self.position_map.get(&pos).expect("no id")[0],
-                event,
-            )))),
+            1 => {
+                let id = self.position_map.get(&pos).expect("no id")[0];
+                if auto_release {
+                    // Deliver the original motion first; queue the
+                    // synthesized AutoRelease so the next poll picks
+                    // it up.
+                    self.pending.push_back((id, CaptureEvent::AutoRelease));
+                }
+                Poll::Ready(Some(Ok((id, event))))
+            }
             _ => {
                 let mut position_map = HashMap::new();
                 swap(&mut self.position_map, &mut position_map);
                 {
                     for &id in position_map.get(&pos).expect("position") {
                         self.pending.push_back((id, event));
+                        if auto_release {
+                            self.pending.push_back((id, CaptureEvent::AutoRelease));
+                        }
                     }
                 }
                 swap(&mut self.position_map, &mut position_map);

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -37,8 +37,15 @@ pub type CaptureHandle = u64;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CaptureEvent {
-    /// capture on this capture handle is now active
-    Begin,
+    /// Capture on this handle is now active. `cursor`, when present,
+    /// is the host's screen-space cursor position (in pixels) at the
+    /// instant of the edge crossing — the capture loop forwards it to
+    /// the peer as a [`ProtoEvent::MotionAbsolute`] so the guest's
+    /// cursor lands at the visually-corresponding point on its own
+    /// screen rather than snapping to the entry-edge midpoint.
+    /// Backends that can't report cursor position emit `None` and
+    /// the peer falls back to the entry-edge-midpoint warp.
+    Begin { cursor: Option<(i32, i32)> },
     /// input event coming from capture handle
     Input(Event),
     /// the capture wrapper detected sustained back-toward-host motion
@@ -51,7 +58,10 @@ pub enum CaptureEvent {
 impl Display for CaptureEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CaptureEvent::Begin => write!(f, "begin capture"),
+            CaptureEvent::Begin { cursor: None } => write!(f, "begin capture"),
+            CaptureEvent::Begin {
+                cursor: Some((x, y)),
+            } => write!(f, "begin capture @ ({x}, {y})"),
             CaptureEvent::Input(e) => write!(f, "{e}"),
             CaptureEvent::AutoRelease => write!(f, "auto-release"),
         }
@@ -237,6 +247,49 @@ impl InputCapture {
         self.peer_bounds.remove(&pos);
     }
 
+    /// Host's own display geometry — width and height in pixels of
+    /// the union of all displays. Returns `None` when the active
+    /// backend can't query its own bounds (e.g. xdg-desktop-portal,
+    /// dummy). Used together with `peer_bounds` to compute a
+    /// [`ProtoEvent::MotionAbsolute`] target so the guest cursor
+    /// lands at the visually-corresponding point on Enter.
+    pub fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.capture.display_bounds()
+    }
+
+    /// Cursor warp target on the peer for a transition at `pos`,
+    /// given the host's screen-space cursor position at the moment
+    /// of crossing. Returns `None` when either the host's own
+    /// `display_bounds` or the cached peer geometry is unavailable —
+    /// in that case the capture loop just doesn't send MotionAbsolute
+    /// and the guest falls back to its entry-edge-midpoint warp.
+    ///
+    /// Coordinates returned are pixels in the peer's screen space:
+    /// the cross-axis is preserved as a normalized fraction of the
+    /// host screen (so a host_y near the top maps to a peer_y near
+    /// the top regardless of resolution mismatch), the on-axis is
+    /// pinned to the peer's far edge for the entering side.
+    pub fn peer_warp_target(&self, pos: Position, cursor: (i32, i32)) -> Option<(i32, i32)> {
+        let (host_w, host_h) = self.display_bounds()?;
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (cx, cy) = cursor;
+        let nx = (cx as f64 / host_w as f64).clamp(0.0, 1.0);
+        let ny = (cy as f64 / host_h as f64).clamp(0.0, 1.0);
+        let peer_w_i = peer_w as i32;
+        let peer_h_i = peer_h as i32;
+        let target = match pos {
+            // Peer to our Left → cursor exits on left, enters peer on right
+            Position::Left => (peer_w_i.saturating_sub(1), (ny * peer_h as f64) as i32),
+            // Peer to our Right → cursor enters peer on left
+            Position::Right => (0, (ny * peer_h as f64) as i32),
+            // Peer above → cursor enters peer on bottom
+            Position::Top => ((nx * peer_w as f64) as i32, peer_h_i.saturating_sub(1)),
+            // Peer below → cursor enters peer on top
+            Position::Bottom => ((nx * peer_w as f64) as i32, 0),
+        };
+        Some(target)
+    }
+
     /// Returns the upper-clamp value (along the entry axis) for the
     /// given position, or `f64::INFINITY` if the peer hasn't reported
     /// bounds yet.
@@ -262,7 +315,7 @@ impl InputCapture {
     /// capture position.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
         match event {
-            CaptureEvent::Begin => {
+            CaptureEvent::Begin { .. } => {
                 self.capture_pos = Some(pos);
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
@@ -462,6 +515,13 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;
+
+    /// Host's own display geometry. Default implementation returns
+    /// `None`; backends that can query their own dimensions override
+    /// (currently macOS via CGDisplay; others may add this later).
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        None
+    }
 }
 
 async fn create_backend(

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -143,14 +143,19 @@ pub struct InputCapture {
     /// Modeled cursor position on the guest along the entry axis,
     /// relative to the host-adjacent edge. 0 = at the entry edge,
     /// growing values = further into the guest. Clamped at 0 from
-    /// below; *not* clamped from above (the wrapper can't know the
-    /// guest's far-edge extent without a protocol-level Bounds event,
-    /// and any proxy is wrong for some user's setup).
+    /// below; clamped at the cached peer extent from above when
+    /// available, otherwise unbounded (degraded fallback).
     virtual_pos: f64,
     /// Pixels of back-toward-host motion that the modeled cursor
     /// could not absorb (proposed virtual_pos < 0). Resets whenever
     /// the cursor is back in the interior or moving deeper.
     wall_pressure: f64,
+    /// Per-position cache of peer display geometry. Populated when
+    /// the peer responds with a `ProtoEvent::Bounds` event after
+    /// Ack. Used as the upper clamp for `virtual_pos` so that
+    /// pushing past the guest's actual far edge doesn't make the
+    /// model run away. Only the entry-axis dimension is consulted.
+    peer_bounds: HashMap<Position, (u32, u32)>,
 }
 
 /// Project a motion delta onto the entry axis. Positive return =
@@ -216,6 +221,35 @@ impl InputCapture {
         self.release_threshold_px = threshold;
     }
 
+    /// Cache the peer's display geometry for a position. Used by
+    /// the wall-press tracker as the upper bound for `virtual_pos`
+    /// so the model can't run away when the user pushes past the
+    /// peer's actual far edge.
+    pub fn set_peer_bounds(&mut self, pos: Position, width: u32, height: u32) {
+        log::debug!("peer at {pos} reports bounds {width}x{height}");
+        self.peer_bounds.insert(pos, (width, height));
+    }
+
+    /// Forget the cached peer geometry for a position. Called when
+    /// the corresponding capture is destroyed so re-adding the same
+    /// peer later (potentially with new geometry) starts fresh.
+    pub fn clear_peer_bounds(&mut self, pos: Position) {
+        self.peer_bounds.remove(&pos);
+    }
+
+    /// Returns the upper-clamp value (along the entry axis) for the
+    /// given position, or `f64::INFINITY` if the peer hasn't reported
+    /// bounds yet.
+    fn peer_extent(&self, pos: Position) -> f64 {
+        let Some(&(w, h)) = self.peer_bounds.get(&pos) else {
+            return f64::INFINITY;
+        };
+        match pos {
+            Position::Left | Position::Right => f64::from(w),
+            Position::Top | Position::Bottom => f64::from(h),
+        }
+    }
+
     fn reset_wall_press_state(&mut self) {
         self.capture_pos = None;
         self.virtual_pos = 0.0;
@@ -251,7 +285,17 @@ impl InputCapture {
 
                 let delta = entry_axis_delta(active_pos, *dx, *dy);
                 let proposed = self.virtual_pos + delta;
-                self.virtual_pos = proposed.max(0.0);
+                let upper = self.peer_extent(active_pos);
+                // Clamp at 0 from below (host-adjacent edge — wall
+                // pressure accumulates here) and at the peer's
+                // entry-axis extent from above when known. The upper
+                // clamp prevents the model from running away if the
+                // user obliviously pushes their physical mouse past
+                // the guest's actual far edge. When the peer hasn't
+                // reported bounds yet (older peer, or pre-Ack
+                // window), `upper` is INFINITY and we fall back to
+                // the heuristic behavior.
+                self.virtual_pos = proposed.clamp(0.0, upper);
 
                 if proposed < 0.0 {
                     // Motion overshot the host-adjacent edge —
@@ -312,6 +356,7 @@ impl InputCapture {
             capture_pos: None,
             virtual_pos: 0.0,
             wall_pressure: 0.0,
+            peer_bounds: HashMap::new(),
         })
     }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -281,6 +281,27 @@ impl InputCapture {
         self.capture.display_bounds()
     }
 
+    /// Host's screen-space cursor position normalized to the host's
+    /// own display bounds (each axis in 0..1, clamped). Returns
+    /// `None` when the active backend can't report its own bounds.
+    /// Used for the self-sufficient `ProtoEvent::CursorPos` event
+    /// (the receiver scales the normalized fraction against its
+    /// own bounds and pins the entry axis to the matching edge), so
+    /// the first crossing isn't blocked by the bootstrap problem
+    /// `peer_warp_target` has — that variant requires a prior
+    /// `Bounds` round-trip from the peer, which can't have happened
+    /// yet on the very first Enter.
+    pub fn host_normalized_cursor(&self, cursor: (i32, i32)) -> Option<(f32, f32)> {
+        let (host_w, host_h) = self.display_bounds()?;
+        if host_w == 0 || host_h == 0 {
+            return None;
+        }
+        let (cx, cy) = cursor;
+        let nx = (cx as f32 / host_w as f32).clamp(0.0, 1.0);
+        let ny = (cy as f32 / host_h as f32).clamp(0.0, 1.0);
+        Some((nx, ny))
+    }
+
     /// Cursor warp target on the peer for a transition at `pos`,
     /// given the host's screen-space cursor position at the moment
     /// of crossing. Returns `None` when either the host's own

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -171,6 +171,21 @@ pub struct InputCapture {
     /// the matching point on the host's screen instead of jumping
     /// back to where capture started.
     virtual_cursor: Option<(f64, f64)>,
+    /// Host-coord cursor at the moment of `Begin`, retained until
+    /// `peer_bounds` arrives so we can retroactively seed
+    /// `virtual_cursor` once the round-trip completes. Without this,
+    /// a `Begin` that fires before the peer's `Bounds` reply leaves
+    /// `virtual_cursor` stuck at `None` for the rest of the session
+    /// — the wall-press accumulator skips updates and the
+    /// release-time warp falls back to the original crossing
+    /// y-value instead of where the cursor visually was on the peer.
+    pending_begin_cursor: Option<(i32, i32)>,
+    /// Motion deltas that arrived while `virtual_cursor` was still
+    /// `None` (between `Begin` and the late-arriving
+    /// `set_peer_bounds`). Drained into the freshly-seeded
+    /// `virtual_cursor` when the bootstrap completes so deltas
+    /// during the round-trip aren't lost.
+    pending_motion: (f64, f64),
     /// Per-position cache of peer display geometry. Populated when
     /// the peer responds with a `ProtoEvent::Bounds` event after
     /// Ack. Used as the upper clamp for `virtual_pos` so that
@@ -261,9 +276,39 @@ impl InputCapture {
     /// the wall-press tracker as the upper bound for `virtual_pos`
     /// so the model can't run away when the user pushes past the
     /// peer's actual far edge.
+    ///
+    /// If `Begin` fired before this arrived (the round-trip
+    /// bootstrap case — `Bounds` is sent in response to `Enter`,
+    /// which is sent by the host AFTER `Begin` fires), seed
+    /// `virtual_cursor` retroactively so the wall-press / release
+    /// machinery has a baseline to track from. Drains any motion
+    /// that piled up in `pending_motion` so deltas during the
+    /// round-trip aren't lost.
     pub fn set_peer_bounds(&mut self, pos: Position, width: u32, height: u32) {
         log::debug!("peer at {pos} reports bounds {width}x{height}");
         self.peer_bounds.insert(pos, (width, height));
+
+        if self.virtual_cursor.is_none()
+            && self.capture_pos == Some(pos)
+            && self.pending_begin_cursor.is_some()
+        {
+            let begin_cursor = self.pending_begin_cursor;
+            let seeded = self.initial_virtual_cursor(pos, begin_cursor);
+            if let Some((sx, sy)) = seeded {
+                let (mx, my) = self.pending_motion;
+                let peer_w = width as f64;
+                let peer_h = height as f64;
+                self.virtual_cursor = Some((
+                    (sx + mx).clamp(0.0, peer_w),
+                    (sy + my).clamp(0.0, peer_h),
+                ));
+                self.pending_motion = (0.0, 0.0);
+                log::info!(
+                    "[bootstrap] seeded virtual_cursor={:?} after late peer_bounds at {pos} (drained pending_motion=({mx:.1}, {my:.1}))",
+                    self.virtual_cursor
+                );
+            }
+        }
     }
 
     /// Forget the cached peer geometry for a position. Called when
@@ -372,6 +417,8 @@ impl InputCapture {
         self.virtual_pos = 0.0;
         self.wall_pressure = 0.0;
         self.virtual_cursor = None;
+        self.pending_begin_cursor = None;
+        self.pending_motion = (0.0, 0.0);
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -442,6 +489,16 @@ impl InputCapture {
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
                 self.virtual_cursor = self.initial_virtual_cursor(pos, *cursor);
+                // Stash the host-coord cursor so set_peer_bounds can
+                // retroactively seed virtual_cursor if peer_bounds
+                // arrives after Begin.
+                self.pending_begin_cursor = *cursor;
+                self.pending_motion = (0.0, 0.0);
+                log::info!(
+                    "[wp-begin] pos={pos} cursor={cursor:?} peer_bounds={:?} virtual_cursor={:?}",
+                    self.peer_bounds.get(&pos).copied(),
+                    self.virtual_cursor,
+                );
                 false
             }
             CaptureEvent::AutoRelease => {
@@ -462,12 +519,31 @@ impl InputCapture {
                 // back to the host. Clamped to the peer's bounds so
                 // the model doesn't drift past the guest's screen
                 // when the user pushes obliviously.
-                if let (Some(vc), Some(&(peer_w, peer_h))) = (
+                match (
                     self.virtual_cursor.as_mut(),
                     self.peer_bounds.get(&active_pos),
                 ) {
-                    vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
-                    vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                    (Some(vc), Some(&(peer_w, peer_h))) => {
+                        vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
+                        vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                    }
+                    // virtual_cursor not yet seeded (peer_bounds was
+                    // None at Begin time and the round-trip hasn't
+                    // completed yet). Buffer the deltas so they can
+                    // be applied retroactively in set_peer_bounds
+                    // once the bootstrap finishes — otherwise the
+                    // motion that happened during the round-trip is
+                    // silently lost and the release-time warp picks
+                    // the wrong y.
+                    (None, _) => {
+                        self.pending_motion.0 += *dx;
+                        self.pending_motion.1 += *dy;
+                        log::debug!(
+                            "[wp-motion] deferred dx={dx:.1} dy={dy:.1} (peer_bounds for {active_pos}: {:?})",
+                            self.peer_bounds.get(&active_pos).copied(),
+                        );
+                    }
+                    _ => {}
                 }
 
                 if self.release_threshold_px == 0 {
@@ -548,6 +624,8 @@ impl InputCapture {
             virtual_pos: 0.0,
             wall_pressure: 0.0,
             virtual_cursor: None,
+            pending_begin_cursor: None,
+            pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
         })
     }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -160,6 +160,15 @@ pub struct InputCapture {
     /// could not absorb (proposed virtual_pos < 0). Resets whenever
     /// the cursor is back in the interior or moving deeper.
     wall_pressure: f64,
+    /// Modeled guest cursor position in the guest's screen space,
+    /// updated by accumulating Motion deltas while captured. Seeded
+    /// on `Begin` from the cross-axis warp target (if peer bounds
+    /// are known) or the entry-edge midpoint otherwise — i.e. wherever
+    /// the guest's cursor visually lands at Enter. Read on release
+    /// to compute a host-side warp so the local cursor reappears at
+    /// the matching point on the host's screen instead of jumping
+    /// back to where capture started.
+    virtual_cursor: Option<(f64, f64)>,
     /// Per-position cache of peer display geometry. Populated when
     /// the peer responds with a `ProtoEvent::Bounds` event after
     /// Ack. Used as the upper clamp for `virtual_pos` so that
@@ -219,9 +228,24 @@ impl InputCapture {
 
     /// release mouse
     pub async fn release(&mut self) -> Result<(), CaptureError> {
+        // Compute the host-side warp target before resetting the
+        // wall-press / virtual_cursor state — once those are cleared
+        // we lose the data needed to figure out where the guest's
+        // cursor visually was.
+        let warp_target = self
+            .capture_pos
+            .and_then(|pos| self.host_warp_target_on_release(pos));
+        log::info!(
+            "[release-warp] capture_pos={:?} virtual_cursor={:?} peer_bounds={:?} display_bounds={:?} → warp_target={warp_target:?}",
+            self.capture_pos,
+            self.virtual_cursor,
+            self.capture_pos
+                .and_then(|p| self.peer_bounds.get(&p).copied()),
+            self.capture.display_bounds(),
+        );
         self.pressed_keys.clear();
         self.reset_wall_press_state();
-        self.capture.release().await
+        self.capture.release(warp_target).await
     }
 
     /// Configure the wall-press auto-release pixel threshold.
@@ -307,6 +331,64 @@ impl InputCapture {
         self.capture_pos = None;
         self.virtual_pos = 0.0;
         self.wall_pressure = 0.0;
+        self.virtual_cursor = None;
+    }
+
+    /// Initial guest-space cursor position for a freshly-started
+    /// capture. Mirrors what the guest's emulation will visibly do on
+    /// the corresponding `Enter`: a `MotionAbsolute` warp target if
+    /// the host can compute one (peer bounds known + capture backend
+    /// reports cursor), otherwise the entry-edge midpoint that
+    /// `entry_edge_for` produces on the guest side.
+    fn initial_virtual_cursor(
+        &self,
+        pos: Position,
+        host_cursor: Option<(i32, i32)>,
+    ) -> Option<(f64, f64)> {
+        if let Some(host_cursor) = host_cursor {
+            if let Some((x, y)) = self.peer_warp_target(pos, host_cursor) {
+                return Some((x as f64, y as f64));
+            }
+        }
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let pw = peer_w as f64;
+        let ph = peer_h as f64;
+        Some(match pos {
+            Position::Left => (0.0, ph / 2.0),
+            Position::Right => ((pw - 1.0).max(0.0), ph / 2.0),
+            Position::Top => (pw / 2.0, 0.0),
+            Position::Bottom => (pw / 2.0, (ph - 1.0).max(0.0)),
+        })
+    }
+
+    /// Where on the host's own screen the cursor should land when
+    /// capture is released, given the modeled guest cursor position
+    /// at the moment of release. Symmetric inverse of
+    /// `peer_warp_target`: cross-axis is preserved as a normalized
+    /// fraction of the peer's screen, on-axis is pinned to the
+    /// host's far edge for the side the guest is on so the cursor
+    /// reappears at the boundary it just crossed back through.
+    fn host_warp_target_on_release(&self, pos: Position) -> Option<(i32, i32)> {
+        let (gx, gy) = self.virtual_cursor?;
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (host_w, host_h) = self.capture.display_bounds()?;
+        if peer_w == 0 || peer_h == 0 || host_w == 0 || host_h == 0 {
+            return None;
+        }
+        let nx = (gx / peer_w as f64).clamp(0.0, 1.0);
+        let ny = (gy / peer_h as f64).clamp(0.0, 1.0);
+        let host_w_i = host_w as i32;
+        let host_h_i = host_h as i32;
+        Some(match pos {
+            // Peer to our Left → cursor returns through host's left edge
+            Position::Left => (0, (ny * host_h as f64) as i32),
+            // Peer to our Right → cursor returns through host's right edge
+            Position::Right => (host_w_i.saturating_sub(1), (ny * host_h as f64) as i32),
+            // Peer above → cursor returns through host's top edge
+            Position::Top => ((nx * host_w as f64) as i32, 0),
+            // Peer below → cursor returns through host's bottom edge
+            Position::Bottom => ((nx * host_w as f64) as i32, host_h_i.saturating_sub(1)),
+        })
     }
 
     /// Update the wall-press accumulator from one event coming up
@@ -315,24 +397,39 @@ impl InputCapture {
     /// capture position.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
         match event {
-            CaptureEvent::Begin { .. } => {
+            CaptureEvent::Begin { cursor } => {
                 self.capture_pos = Some(pos);
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
+                self.virtual_cursor = self.initial_virtual_cursor(pos, *cursor);
                 false
             }
             CaptureEvent::AutoRelease => {
-                self.reset_wall_press_state();
+                // Don't reset virtual_cursor here — release() needs it
+                // to compute the host-side warp target. The wrapper's
+                // release() resets state after consuming it.
                 false
             }
             CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
-                if self.release_threshold_px == 0 {
-                    return false;
-                }
                 let Some(active_pos) = self.capture_pos else {
                     return false;
                 };
                 if active_pos != pos {
+                    return false;
+                }
+
+                // Track guest-space cursor for the on-release warp
+                // back to the host. Clamped to the peer's bounds so
+                // the model doesn't drift past the guest's screen
+                // when the user pushes obliviously.
+                if let (Some(vc), Some(&(peer_w, peer_h))) =
+                    (self.virtual_cursor.as_mut(), self.peer_bounds.get(&active_pos))
+                {
+                    vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
+                    vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                }
+
+                if self.release_threshold_px == 0 {
                     return false;
                 }
 
@@ -409,6 +506,7 @@ impl InputCapture {
             capture_pos: None,
             virtual_pos: 0.0,
             wall_pressure: 0.0,
+            virtual_cursor: None,
             peer_bounds: HashMap::new(),
         })
     }
@@ -510,8 +608,14 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
     /// destroy the client with the given id, if it exists
     async fn destroy(&mut self, pos: Position) -> Result<(), CaptureError>;
 
-    /// release mouse
-    async fn release(&mut self) -> Result<(), CaptureError>;
+    /// release mouse. `warp_target`, when present, is a screen-space
+    /// pixel point on the host's own display where the local cursor
+    /// should be placed before becoming visible again — used to
+    /// preserve cross-axis continuity when capture ends so the cursor
+    /// reappears next to where it visually was on the guest, not at
+    /// the spot where capture started. Backends that don't hide the
+    /// system cursor or can't warp it can ignore the parameter.
+    async fn release(&mut self, warp_target: Option<(i32, i32)>) -> Result<(), CaptureError>;
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -281,6 +281,13 @@ impl InputCapture {
         self.capture.display_bounds()
     }
 
+    /// Top-left corner of the host's display union in pointer-event
+    /// coordinate space. See `Capture::display_origin` for why this
+    /// matters on multi-monitor macOS hosts.
+    fn display_origin(&self) -> (i32, i32) {
+        self.capture.display_origin()
+    }
+
     /// Host's screen-space cursor position normalized to the host's
     /// own display bounds (each axis in 0..1, clamped). Returns
     /// `None` when the active backend can't report its own bounds.
@@ -296,9 +303,15 @@ impl InputCapture {
         if host_w == 0 || host_h == 0 {
             return None;
         }
+        let (origin_x, origin_y) = self.display_origin();
         let (cx, cy) = cursor;
-        let nx = (cx as f32 / host_w as f32).clamp(0.0, 1.0);
-        let ny = (cy as f32 / host_h as f32).clamp(0.0, 1.0);
+        // Subtract the union origin before normalizing so that
+        // points on a non-origin display (e.g. a macOS external
+        // monitor positioned to the left of the primary, where
+        // cursor x is negative) map correctly. Without this, the
+        // clamp masks every off-primary point as the screen edge.
+        let nx = ((cx - origin_x) as f32 / host_w as f32).clamp(0.0, 1.0);
+        let ny = ((cy - origin_y) as f32 / host_h as f32).clamp(0.0, 1.0);
         Some((nx, ny))
     }
 
@@ -317,9 +330,12 @@ impl InputCapture {
     pub fn peer_warp_target(&self, pos: Position, cursor: (i32, i32)) -> Option<(i32, i32)> {
         let (host_w, host_h) = self.display_bounds()?;
         let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (origin_x, origin_y) = self.display_origin();
         let (cx, cy) = cursor;
-        let nx = (cx as f64 / host_w as f64).clamp(0.0, 1.0);
-        let ny = (cy as f64 / host_h as f64).clamp(0.0, 1.0);
+        // Subtract the union origin before normalizing — same
+        // rationale as in host_normalized_cursor.
+        let nx = ((cx - origin_x) as f64 / host_w as f64).clamp(0.0, 1.0);
+        let ny = ((cy - origin_y) as f64 / host_h as f64).clamp(0.0, 1.0);
         let peer_w_i = peer_w as i32;
         let peer_h_i = peer_h as i32;
         let target = match pos {
@@ -647,6 +663,21 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
     /// (currently macOS via CGDisplay; others may add this later).
     fn display_bounds(&self) -> Option<(u32, u32)> {
         None
+    }
+
+    /// Top-left corner of the union of all displays in the host's
+    /// global pointer-coordinate system. Defaults to (0, 0) — fine
+    /// for any backend whose primary display is the origin (Windows,
+    /// most X11/Wayland setups). Returns the actual `(xmin, ymin)`
+    /// on macOS, where the global coordinate system is anchored at
+    /// the primary's top-left and a left-attached external display
+    /// occupies negative x. Used by `host_normalized_cursor` and
+    /// `peer_warp_target` to correctly normalize cursor positions
+    /// outside the primary display — without this, the
+    /// `clamp(0.0, 1.0)` in those helpers silently maps every point
+    /// on a non-origin display to the screen edge.
+    fn display_origin(&self) -> (i32, i32) {
+        (0, 0)
     }
 }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -298,10 +298,8 @@ impl InputCapture {
                 let (mx, my) = self.pending_motion;
                 let peer_w = width as f64;
                 let peer_h = height as f64;
-                self.virtual_cursor = Some((
-                    (sx + mx).clamp(0.0, peer_w),
-                    (sy + my).clamp(0.0, peer_h),
-                ));
+                self.virtual_cursor =
+                    Some(((sx + mx).clamp(0.0, peer_w), (sy + my).clamp(0.0, peer_h)));
                 self.pending_motion = (0.0, 0.0);
                 log::info!(
                     "[bootstrap] seeded virtual_cursor={:?} after late peer_bounds at {pos} (drained pending_motion=({mx:.1}, {my:.1}))",

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     mem::swap,
     pin::Pin,
     task::{Poll, ready},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -196,16 +196,17 @@ pub struct InputCapture {
     /// pushing past the guest's actual far edge doesn't make the
     /// model run away. Only the entry-axis dimension is consulted.
     peer_bounds: HashMap<Position, (u32, u32)>,
-    /// Set when wall_pressure first crosses `release_threshold_px`,
-    /// cleared when the peer's handover Leave arrives (which routes
-    /// through `release_no_host_warp` → `reset_wall_press_state`) or
-    /// when the cursor moves back into the interior. The wall-press
-    /// auto-release fires only after `wall_press_deadline` elapses
-    /// without being cleared — turning the historically race-y
-    /// "wall-press vs peer-Leave" into an explicit fallback that
-    /// only kicks in when the peer can't deliver a Leave (lock
-    /// screen, restricted DE, dead peer).
-    wall_press_pending_at: Option<Instant>,
+    /// True when wall_pressure has crossed `release_threshold_px` and
+    /// `wall_press_timer` has been armed but not yet either elapsed
+    /// or been cancelled. Cleared when the peer's handover Leave
+    /// arrives (which routes through `release_no_host_warp` →
+    /// `reset_wall_press_state`) or when the cursor moves back into
+    /// the interior. The wall-press auto-release fires only after
+    /// `wall_press_deadline` elapses without this being cleared —
+    /// turning the historically race-y "wall-press vs peer-Leave"
+    /// into an explicit fallback that only kicks in when the peer
+    /// can't deliver a Leave (lock screen, restricted DE, dead peer).
+    wall_press_pending: bool,
     /// Window after the threshold is crossed during which a peer
     /// Leave can cancel the deferred AutoRelease. Sized so a
     /// healthy LAN round-trip beats it comfortably.
@@ -460,7 +461,7 @@ impl InputCapture {
         self.pending_motion = (0.0, 0.0);
         // Cancel any deferred AutoRelease — release() / handover have
         // taken responsibility for the transition.
-        self.wall_press_pending_at = None;
+        self.wall_press_pending = false;
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -534,11 +535,10 @@ impl InputCapture {
     }
 
     /// Update the wall-press accumulator from one event coming up
-    /// from the backend. Sets `wall_press_pending_at` (and arms the
+    /// from the backend. Sets `wall_press_pending` (and arms the
     /// timer) when the threshold is first crossed; the actual
     /// `AutoRelease` synthesis happens in `poll_next` once the
-    /// deadline elapses without a peer Leave clearing the pending
-    /// flag.
+    /// deadline elapses without a peer Leave clearing the flag.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) {
         match event {
             CaptureEvent::Begin { cursor } => {
@@ -630,7 +630,7 @@ impl InputCapture {
                     // by motion deeper into the guest doesn't combine
                     // with a later wall-press to fire spuriously.
                     self.wall_pressure = 0.0;
-                    if self.wall_press_pending_at.take().is_some() {
+                    if std::mem::take(&mut self.wall_press_pending) {
                         log::info!(
                             "wall-press deferred AutoRelease cancelled (cursor moved away from entry edge)"
                         );
@@ -638,15 +638,12 @@ impl InputCapture {
                 }
 
                 if self.wall_pressure >= f64::from(self.release_threshold_px)
-                    && self.wall_press_pending_at.is_none()
+                    && !self.wall_press_pending
                 {
-                    let now = Instant::now();
-                    self.wall_press_pending_at = Some(now);
+                    self.wall_press_pending = true;
                     self.wall_press_timer
                         .as_mut()
-                        .reset(tokio::time::Instant::from_std(
-                            now + self.wall_press_deadline,
-                        ));
+                        .reset(tokio::time::Instant::now() + self.wall_press_deadline);
                     log::info!(
                         "wall-press threshold reached ({:.0}px past entry edge, {}px threshold) — \
                          deferring AutoRelease for {}ms pending peer Leave",
@@ -699,7 +696,7 @@ impl InputCapture {
             pending_begin_cursor: None,
             pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
-            wall_press_pending_at: None,
+            wall_press_pending: false,
             wall_press_deadline: Duration::from_millis(150),
             wall_press_timer: Box::pin(tokio::time::sleep(Duration::from_secs(0))),
         })
@@ -734,16 +731,14 @@ impl Stream for InputCapture {
 
         // Deferred wall-press fallback. If the threshold was crossed
         // and the deadline elapsed without a peer Leave clearing
-        // `wall_press_pending_at` (release_no_host_warp →
+        // `wall_press_pending` (release_no_host_warp →
         // reset_wall_press_state), synthesize AutoRelease for every
         // capture handle at the active position. Polled before the
         // backend so a fire still happens when the user pinned the
         // cursor against the wall and stopped moving (no further
         // backend events, but the deadline still has to elapse).
-        if self.wall_press_pending_at.is_some()
-            && self.wall_press_timer.as_mut().poll(cx).is_ready()
-        {
-            self.wall_press_pending_at = None;
+        if self.wall_press_pending && self.wall_press_timer.as_mut().poll(cx).is_ready() {
+            self.wall_press_pending = false;
             log::info!(
                 "wall-press deadline elapsed ({}ms) — firing AutoRelease (no peer Leave; \
                  assuming peer-side capture is unavailable, e.g. lock screen)",

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -462,19 +462,32 @@ impl InputCapture {
         if peer_w == 0 || peer_h == 0 || host_w == 0 || host_h == 0 {
             return None;
         }
+        let (origin_x, origin_y) = self.display_origin();
         let nx = (gx / peer_w as f64).clamp(0.0, 1.0);
         let ny = (gy / peer_h as f64).clamp(0.0, 1.0);
         let host_w_i = host_w as i32;
         let host_h_i = host_h as i32;
+        // Add the union origin back so the result is in pointer-event
+        // coordinate space (which is what `CGDisplay::warp_mouse_cursor_position`
+        // and friends consume), not "0..host_w" of the union rectangle.
+        // Matters on macOS hosts whose primary isn't anchored at (0, 0)
+        // — `display_bounds` returns just the size of the union, so the
+        // origin needs to be reapplied to recover absolute coords.
         Some(match pos {
             // Peer to our Left → cursor returns through host's left edge
-            Position::Left => (0, (ny * host_h as f64) as i32),
+            Position::Left => (origin_x, origin_y + (ny * host_h as f64) as i32),
             // Peer to our Right → cursor returns through host's right edge
-            Position::Right => (host_w_i.saturating_sub(1), (ny * host_h as f64) as i32),
+            Position::Right => (
+                origin_x + host_w_i.saturating_sub(1),
+                origin_y + (ny * host_h as f64) as i32,
+            ),
             // Peer above → cursor returns through host's top edge
-            Position::Top => ((nx * host_w as f64) as i32, 0),
+            Position::Top => (origin_x + (nx * host_w as f64) as i32, origin_y),
             // Peer below → cursor returns through host's bottom edge
-            Position::Bottom => ((nx * host_w as f64) as i32, host_h_i.saturating_sub(1)),
+            Position::Bottom => (
+                origin_x + (nx * host_w as f64) as i32,
+                origin_y + host_h_i.saturating_sub(1),
+            ),
         })
     }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -39,12 +39,14 @@ pub type CaptureHandle = u64;
 pub enum CaptureEvent {
     /// Capture on this handle is now active. `cursor`, when present,
     /// is the host's screen-space cursor position (in pixels) at the
-    /// instant of the edge crossing — the capture loop forwards it to
-    /// the peer as a [`ProtoEvent::MotionAbsolute`] so the guest's
-    /// cursor lands at the visually-corresponding point on its own
-    /// screen rather than snapping to the entry-edge midpoint.
-    /// Backends that can't report cursor position emit `None` and
-    /// the peer falls back to the entry-edge-midpoint warp.
+    /// instant of the edge crossing — the capture loop normalizes it
+    /// against the host's display bounds and forwards it to the peer
+    /// as a [`ProtoEvent::CursorPos`] so the guest's cursor lands at
+    /// the visually-corresponding point on its own screen. Backends
+    /// that can't report cursor position emit `None`; the peer's
+    /// cursor stays where it was on remote-takeover (no forced
+    /// midpoint warp — that masquerades as a mid-screen crossing on
+    /// fast re-crosses).
     Begin { cursor: Option<(i32, i32)> },
     /// input event coming from capture handle
     Input(Event),
@@ -274,9 +276,9 @@ impl InputCapture {
     /// Host's own display geometry — width and height in pixels of
     /// the union of all displays. Returns `None` when the active
     /// backend can't query its own bounds (e.g. xdg-desktop-portal,
-    /// dummy). Used together with `peer_bounds` to compute a
-    /// [`ProtoEvent::MotionAbsolute`] target so the guest cursor
-    /// lands at the visually-corresponding point on Enter.
+    /// dummy). Used by `host_normalized_cursor` to compute the
+    /// [`ProtoEvent::CursorPos`] fraction the guest scales against
+    /// its own bounds on Enter.
     pub fn display_bounds(&self) -> Option<(u32, u32)> {
         self.capture.display_bounds()
     }
@@ -319,8 +321,9 @@ impl InputCapture {
     /// given the host's screen-space cursor position at the moment
     /// of crossing. Returns `None` when either the host's own
     /// `display_bounds` or the cached peer geometry is unavailable —
-    /// in that case the capture loop just doesn't send MotionAbsolute
-    /// and the guest falls back to its entry-edge-midpoint warp.
+    /// in that case there's no warp target to compute and the peer's
+    /// cursor stays wherever the most recent `CursorPos` (or, if none
+    /// arrived this session, where it was) put it.
     ///
     /// Coordinates returned are pixels in the peer's screen space:
     /// the cross-axis is preserved as a normalized fraction of the
@@ -373,10 +376,10 @@ impl InputCapture {
 
     /// Initial guest-space cursor position for a freshly-started
     /// capture. Mirrors what the guest's emulation will visibly do on
-    /// the corresponding `Enter`: a `MotionAbsolute` warp target if
-    /// the host can compute one (peer bounds known + capture backend
-    /// reports cursor), otherwise the entry-edge midpoint that
-    /// `entry_edge_for` produces on the guest side.
+    /// the corresponding `Enter`: the `CursorPos` proportional warp
+    /// target if the host can compute one (capture backend reports
+    /// cursor), otherwise the entry-edge midpoint as a fallback for
+    /// the wall-press model's starting position.
     fn initial_virtual_cursor(
         &self,
         pos: Position,

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -265,6 +265,24 @@ impl InputCapture {
         self.capture.release(warp_target).await
     }
 
+    /// Release without applying a host-side cursor warp. Used when
+    /// the remote peer is taking over (it just sent us Enter +
+    /// CursorPos): the proportional warp from CursorPos is the
+    /// authoritative final position for our shared cursor, and the
+    /// stale `virtual_cursor`-derived warp would race against it
+    /// and frequently win — clobbering the proportional landing
+    /// with whatever position Linux *thought* the peer's cursor was
+    /// at before the user moved it.
+    pub async fn release_no_host_warp(&mut self) -> Result<(), CaptureError> {
+        log::info!(
+            "[release-warp] handover release: capture_pos={:?} — skipping host warp, peer's CursorPos is authoritative",
+            self.capture_pos,
+        );
+        self.pressed_keys.clear();
+        self.reset_wall_press_state();
+        self.capture.release(None).await
+    }
+
     /// Configure the wall-press auto-release pixel threshold.
     /// 0 disables. Effective immediately for the next motion event;
     /// no need to recreate the backend.

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -422,9 +422,10 @@ impl InputCapture {
                 // back to the host. Clamped to the peer's bounds so
                 // the model doesn't drift past the guest's screen
                 // when the user pushes obliviously.
-                if let (Some(vc), Some(&(peer_w, peer_h))) =
-                    (self.virtual_cursor.as_mut(), self.peer_bounds.get(&active_pos))
-                {
+                if let (Some(vc), Some(&(peer_w, peer_h))) = (
+                    self.virtual_cursor.as_mut(),
+                    self.peer_bounds.get(&active_pos),
+                ) {
                     vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
                     vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
                 }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -1,13 +1,17 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Display,
+    future::Future,
     mem::swap,
+    pin::Pin,
     task::{Poll, ready},
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_core::Stream;
+use tokio::time::Sleep;
 
 use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
 
@@ -192,6 +196,25 @@ pub struct InputCapture {
     /// pushing past the guest's actual far edge doesn't make the
     /// model run away. Only the entry-axis dimension is consulted.
     peer_bounds: HashMap<Position, (u32, u32)>,
+    /// Set when wall_pressure first crosses `release_threshold_px`,
+    /// cleared when the peer's handover Leave arrives (which routes
+    /// through `release_no_host_warp` → `reset_wall_press_state`) or
+    /// when the cursor moves back into the interior. The wall-press
+    /// auto-release fires only after `wall_press_deadline` elapses
+    /// without being cleared — turning the historically race-y
+    /// "wall-press vs peer-Leave" into an explicit fallback that
+    /// only kicks in when the peer can't deliver a Leave (lock
+    /// screen, restricted DE, dead peer).
+    wall_press_pending_at: Option<Instant>,
+    /// Window after the threshold is crossed during which a peer
+    /// Leave can cancel the deferred AutoRelease. Sized so a
+    /// healthy LAN round-trip beats it comfortably.
+    wall_press_deadline: Duration,
+    /// Timer driving the deferred fire. Reset to deadline-from-now
+    /// on first threshold crossing; polled in `poll_next` so the
+    /// fire happens even when no further backend events arrive
+    /// (the user pinned the cursor against the wall and stopped).
+    wall_press_timer: Pin<Box<Sleep>>,
 }
 
 /// Project a motion delta onto the entry axis. Positive return =
@@ -435,6 +458,9 @@ impl InputCapture {
         self.virtual_cursor = None;
         self.pending_begin_cursor = None;
         self.pending_motion = (0.0, 0.0);
+        // Cancel any deferred AutoRelease — release() / handover have
+        // taken responsibility for the transition.
+        self.wall_press_pending_at = None;
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -508,10 +534,12 @@ impl InputCapture {
     }
 
     /// Update the wall-press accumulator from one event coming up
-    /// from the backend. Returns true if the threshold was reached
-    /// and an `AutoRelease` should be synthesized for the active
-    /// capture position.
-    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
+    /// from the backend. Sets `wall_press_pending_at` (and arms the
+    /// timer) when the threshold is first crossed; the actual
+    /// `AutoRelease` synthesis happens in `poll_next` once the
+    /// deadline elapses without a peer Leave clearing the pending
+    /// flag.
+    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) {
         match event {
             CaptureEvent::Begin { cursor } => {
                 self.capture_pos = Some(pos);
@@ -528,20 +556,18 @@ impl InputCapture {
                     self.peer_bounds.get(&pos).copied(),
                     self.virtual_cursor,
                 );
-                false
             }
             CaptureEvent::AutoRelease => {
                 // Don't reset virtual_cursor here — release() needs it
                 // to compute the host-side warp target. The wrapper's
                 // release() resets state after consuming it.
-                false
             }
             CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
                 let Some(active_pos) = self.capture_pos else {
-                    return false;
+                    return;
                 };
                 if active_pos != pos {
-                    return false;
+                    return;
                 }
 
                 // Track guest-space cursor for the on-release warp
@@ -576,7 +602,7 @@ impl InputCapture {
                 }
 
                 if self.release_threshold_px == 0 {
-                    return false;
+                    return;
                 }
 
                 let delta = entry_axis_delta(active_pos, *dx, *dy);
@@ -604,20 +630,37 @@ impl InputCapture {
                     // by motion deeper into the guest doesn't combine
                     // with a later wall-press to fire spuriously.
                     self.wall_pressure = 0.0;
+                    if self.wall_press_pending_at.take().is_some() {
+                        log::info!(
+                            "wall-press deferred AutoRelease cancelled (cursor moved away from entry edge)"
+                        );
+                    }
                 }
 
-                if self.wall_pressure >= f64::from(self.release_threshold_px) {
+                if self.wall_pressure >= f64::from(self.release_threshold_px)
+                    && self.wall_press_pending_at.is_none()
+                {
+                    let now = Instant::now();
+                    self.wall_press_pending_at = Some(now);
+                    self.wall_press_timer
+                        .as_mut()
+                        .reset(tokio::time::Instant::from_std(
+                            now + self.wall_press_deadline,
+                        ));
                     log::info!(
-                        "auto-release: {:.0}px wall-press past entry edge ({}px threshold)",
+                        "wall-press threshold reached ({:.0}px past entry edge, {}px threshold) — \
+                         deferring AutoRelease for {}ms pending peer Leave",
                         self.wall_pressure,
-                        self.release_threshold_px
+                        self.release_threshold_px,
+                        self.wall_press_deadline.as_millis(),
                     );
-                    self.reset_wall_press_state();
-                    return true;
                 }
-                false
+                // Fire is now driven by the timer in `poll_next`, not
+                // directly from this event — keeps the behavior gated
+                // on "peer didn't claim handover in time" instead of
+                // racing the peer's Leave.
             }
-            _ => false,
+            _ => {}
         }
     }
 
@@ -656,6 +699,9 @@ impl InputCapture {
             pending_begin_cursor: None,
             pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
+            wall_press_pending_at: None,
+            wall_press_deadline: Duration::from_millis(150),
+            wall_press_timer: Box::pin(tokio::time::sleep(Duration::from_secs(0))),
         })
     }
 
@@ -686,6 +732,35 @@ impl Stream for InputCapture {
             return Poll::Ready(Some(Ok(e)));
         }
 
+        // Deferred wall-press fallback. If the threshold was crossed
+        // and the deadline elapsed without a peer Leave clearing
+        // `wall_press_pending_at` (release_no_host_warp →
+        // reset_wall_press_state), synthesize AutoRelease for every
+        // capture handle at the active position. Polled before the
+        // backend so a fire still happens when the user pinned the
+        // cursor against the wall and stopped moving (no further
+        // backend events, but the deadline still has to elapse).
+        if self.wall_press_pending_at.is_some()
+            && self.wall_press_timer.as_mut().poll(cx).is_ready()
+        {
+            self.wall_press_pending_at = None;
+            log::info!(
+                "wall-press deadline elapsed ({}ms) — firing AutoRelease (no peer Leave; \
+                 assuming peer-side capture is unavailable, e.g. lock screen)",
+                self.wall_press_deadline.as_millis(),
+            );
+            if let Some(pos) = self.capture_pos {
+                if let Some(ids) = self.position_map.get(&pos).cloned() {
+                    for id in ids {
+                        self.pending.push_back((id, CaptureEvent::AutoRelease));
+                    }
+                }
+            }
+            if let Some(e) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(e)));
+            }
+        }
+
         // ready
         let event = ready!(self.capture.poll_next_unpin(cx));
 
@@ -708,8 +783,10 @@ impl Stream for InputCapture {
 
         // wall-press auto-release tracking. Runs against every event
         // before routing so a single global accumulator stays consistent
-        // regardless of how many handles exist at this position.
-        let auto_release = self.track_wall_press(pos, &event);
+        // regardless of how many handles exist at this position. The
+        // fire itself is deferred and driven by `wall_press_timer`
+        // above so the peer's Leave can cancel it.
+        self.track_wall_press(pos, &event);
 
         let len = self
             .position_map
@@ -721,12 +798,6 @@ impl Stream for InputCapture {
             0 => Poll::Pending,
             1 => {
                 let id = self.position_map.get(&pos).expect("no id")[0];
-                if auto_release {
-                    // Deliver the original motion first; queue the
-                    // synthesized AutoRelease so the next poll picks
-                    // it up.
-                    self.pending.push_back((id, CaptureEvent::AutoRelease));
-                }
                 Poll::Ready(Some(Ok((id, event))))
             }
             _ => {
@@ -735,9 +806,6 @@ impl Stream for InputCapture {
                 {
                     for &id in position_map.get(&pos).expect("position") {
                         self.pending.push_back((id, event));
-                        if auto_release {
-                            self.pending.push_back((id, CaptureEvent::AutoRelease));
-                        }
                     }
                 }
                 swap(&mut self.position_map, &mut position_map);

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -417,7 +417,10 @@ async fn do_capture_session(
                     current_pos.replace(Some(pos));
 
                     // client entered => send event
-                    event_tx.send((pos, CaptureEvent::Begin)).await.expect("no channel");
+                    event_tx
+                        .send((pos, CaptureEvent::Begin { cursor: None }))
+                        .await
+                        .expect("no channel");
 
                     tokio::select! {
                         _ = notify_release.notified() => { /* capture release */

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -592,7 +592,7 @@ impl LanMouseInputCapture for LibeiInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         self.notify_release.notify_waiters();
         Ok(())
     }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -430,15 +430,6 @@ fn get_events(
             //
             // Net result: wire is consistently classic-feel regardless
             // of the Mac's preference. Receivers can re-invert.
-            log::info!(
-                "[SCROLL-DEBUG capture] continuous={} natural={} delta=({},{}) point_delta=({},{})",
-                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS),
-                natural_scrolling_enabled(),
-                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1),
-                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2),
-                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1),
-                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2),
-            );
             let sign: i64 = if natural_scrolling_enabled() { 1 } else { -1 };
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
                 let v = sign

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -658,7 +658,6 @@ fn event_tap_thread(
     log::debug!("event tap thread exiting!...");
 
     unsafe {
-
         CGDisplayRemoveReconfigurationCallback(display_reconfiguration_callback, display_user_info);
         // Reclaim the leaked sender Box so we don't leak a tokio
         // channel sender on every capture create/destroy cycle.

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -840,6 +840,31 @@ impl Capture for MacOSInputCapture {
         }
         Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
     }
+
+    fn display_origin(&self) -> (i32, i32) {
+        // Top-left of the union of all active displays. Matters when
+        // a secondary monitor is positioned LEFT of (or ABOVE) the
+        // primary — the global pointer-coordinate system is anchored
+        // at the primary's top-left, so a left-attached external
+        // gives cursor x ∈ [-w, 0). Without this offset,
+        // host_normalized_cursor / peer_warp_target's clamp(0, 1)
+        // silently maps every point on the external to "left edge"
+        // and the receiver warps to the wrong column.
+        let Ok(displays) = CGDisplay::active_displays() else {
+            return (0, 0);
+        };
+        let mut xmin = f64::INFINITY;
+        let mut ymin = f64::INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            ymin = ymin.min(bounds.origin.y);
+        }
+        if xmin.is_infinite() || ymin.is_infinite() {
+            return (0, 0);
+        }
+        (xmin as i32, ymin as i32)
+    }
 }
 
 impl Stream for MacOSInputCapture {

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -519,10 +519,17 @@ fn create_event_tap<'a>(
             // Did we cross a barrier?
             if let Some(new_pos) = state.crossed(cg_ev) {
                 capture_position = Some(new_pos);
+                // Snapshot the cursor's screen-space position at the
+                // instant of crossing — before start_capture's
+                // reset_cursor() snaps it to the edge. The peer uses
+                // this for the visually-corresponding warp on Enter
+                // so the cursor doesn't jump to the entry-edge midpoint.
+                let cross_loc = cg_ev.location();
+                let cursor = Some((cross_loc.x as i32, cross_loc.y as i32));
                 state
                     .start_capture(cg_ev, new_pos)
                     .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin);
+                res_events.push(CaptureEvent::Begin { cursor });
                 notify_tx
                     .blocking_send(ProducerEvent::Grab(new_pos))
                     .expect("Failed to send notification");
@@ -783,6 +790,29 @@ impl Capture for MacOSInputCapture {
 
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
+    }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Mirror the InputEmulation-side implementation: the union of
+        // every active display's rectangle, in points (which match
+        // the units used by CGEvent.location() so the
+        // MotionAbsolute math stays internally consistent).
+        let displays = CGDisplay::active_displays().ok()?;
+        let mut xmin = f64::INFINITY;
+        let mut xmax = f64::NEG_INFINITY;
+        let mut ymin = f64::INFINITY;
+        let mut ymax = f64::NEG_INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            xmax = xmax.max(bounds.origin.x + bounds.size.width);
+            ymin = ymin.min(bounds.origin.y);
+            ymax = ymax.max(bounds.origin.y + bounds.size.height);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
     }
 }
 

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -5,7 +5,7 @@ use core_foundation::{
     base::{CFRelease, TCFType, kCFAllocatorDefault},
     date::CFTimeInterval,
     number::{CFBooleanRef, kCFBooleanTrue},
-    runloop::{CFRunLoop, CFRunLoopSource, kCFRunLoopCommonModes},
+    runloop::{CFRunLoop, CFRunLoopSource, CFRunLoopSourceRef, kCFRunLoopCommonModes},
     string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8},
 };
 use core_graphics::{
@@ -664,13 +664,46 @@ fn event_tap_thread(
     // callback runs on this thread's CFRunLoop. Box-leak the sender
     // so the C side has a stable user_info pointer; reclaim it after
     // the run loop exits.
-    let display_user_info = Box::into_raw(Box::new(display_notify_tx)) as *mut c_void;
+    let display_user_info = Box::into_raw(Box::new(display_notify_tx.clone())) as *mut c_void;
     unsafe {
         CGDisplayRegisterReconfigurationCallback(
             display_reconfiguration_callback,
             display_user_info,
         );
     }
+
+    // Also subscribe to system-power events so we recover from
+    // sleep/wake, where the Quartz reconfigure callback may not
+    // fire (or fires before our run loop is processing again, e.g.
+    // clamshell-disconnect → lid-open). On wake we send the same
+    // DisplayReconfigured event the existing handler consumes, so
+    // bounds get refreshed for free.
+    let mut power_notifier_object: u32 = 0;
+    let mut power_notification_port: *mut c_void = std::ptr::null_mut();
+    let power_ctx = Box::into_raw(Box::new(PowerCtx {
+        sender: display_notify_tx,
+        root_port: 0,
+    }));
+    let power_root_port = unsafe {
+        let port = IORegisterForSystemPower(
+            power_ctx as *mut c_void,
+            &mut power_notification_port,
+            power_callback,
+            &mut power_notifier_object,
+        );
+        // Stash the root port for the callback's IOAllowPowerChange
+        // ack — we couldn't know it at Box-construction time because
+        // it's the registration's return value.
+        (*power_ctx).root_port = port;
+        if !power_notification_port.is_null() {
+            let src_ref = IONotificationPortGetRunLoopSource(power_notification_port);
+            if !src_ref.is_null() {
+                let src = CFRunLoopSource::wrap_under_get_rule(src_ref);
+                CFRunLoop::get_current().add_source(&src, kCFRunLoopCommonModes);
+            }
+        }
+        port
+    };
 
     log::debug!("running CFRunLoop...");
     CFRunLoop::run_current();
@@ -683,6 +716,15 @@ fn event_tap_thread(
         drop(Box::from_raw(
             display_user_info as *mut Sender<ProducerEvent>,
         ));
+
+        if power_notifier_object != 0 {
+            let _ = IODeregisterForSystemPower(&mut power_notifier_object);
+        }
+        if !power_notification_port.is_null() {
+            IONotificationPortDestroy(power_notification_port);
+        }
+        let _ = power_root_port;
+        drop(Box::from_raw(power_ctx));
     }
 
     let _ = exit.send(());
@@ -717,6 +759,65 @@ fn is_screen_locked() -> bool {
         CFRelease(key as *const c_void);
     }
     locked
+}
+
+/// Refcon for the IOKit system-power callback. Bundles the channel
+/// sender (so the callback can post `DisplayReconfigured` on wake)
+/// and the `io_connect_t` root port (so the callback can ack
+/// sleep-related messages with `IOAllowPowerChange`). Built on the
+/// event-tap thread, used only by the callback on the same thread —
+/// never crosses thread boundaries, so no Send/Sync needed.
+struct PowerCtx {
+    sender: Sender<ProducerEvent>,
+    root_port: u32,
+}
+
+/// IOKit system-power callback. Fires for every power-management
+/// transition (CanSleep, WillSleep, WillPowerOn, HasPoweredOn).
+/// We only care about `kIOMessageSystemHasPoweredOn` (post-wake);
+/// for the sleep-pending messages we just ack so the kernel doesn't
+/// hold the system in its "waiting for clients" state for the full
+/// 30-second timeout.
+extern "C" fn power_callback(
+    refcon: *mut c_void,
+    _service: u32,
+    msg_type: u32,
+    msg_arg: *mut c_void,
+) {
+    const K_IO_MESSAGE_CAN_SYSTEM_SLEEP: u32 = 0xE000_0270;
+    const K_IO_MESSAGE_SYSTEM_WILL_SLEEP: u32 = 0xE000_0280;
+    const K_IO_MESSAGE_SYSTEM_HAS_POWERED_ON: u32 = 0xE000_0300;
+
+    if refcon.is_null() {
+        return;
+    }
+    // SAFETY: `refcon` is `Box::into_raw(Box::new(PowerCtx))` owned by
+    // `event_tap_thread`; valid until the run loop exits and the box
+    // is reclaimed. The callback only fires while the run loop runs
+    // on that thread, so the box is live here.
+    let ctx = unsafe { &*(refcon as *const PowerCtx) };
+    match msg_type {
+        K_IO_MESSAGE_CAN_SYSTEM_SLEEP | K_IO_MESSAGE_SYSTEM_WILL_SLEEP => {
+            // Ack so the OS doesn't stall on its 30s default timeout.
+            // `msg_arg` carries the notification ID (an `intptr_t`);
+            // pass it through verbatim.
+            unsafe {
+                IOAllowPowerChange(ctx.root_port, msg_arg as isize);
+            }
+        }
+        K_IO_MESSAGE_SYSTEM_HAS_POWERED_ON => {
+            // Bounce a DisplayReconfigured into the producer so
+            // `update_bounds()` runs. Covers the case where Quartz's
+            // own reconfigure callback didn't fire (or fired during
+            // the sleep window) — e.g. clamshell-disconnect →
+            // lid-open transitions.
+            log::info!("system woke from sleep; refreshing display bounds");
+            if let Err(e) = ctx.sender.blocking_send(ProducerEvent::DisplayReconfigured) {
+                log::warn!("failed to post wake → DisplayReconfigured: {e}");
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Quartz display-reconfiguration callback. Fires twice per change:
@@ -991,6 +1092,31 @@ extern "C" {
         callback: extern "C" fn(u32, u32, *mut c_void),
         user_info: *mut c_void,
     ) -> CGError;
+}
+
+#[link(name = "IOKit", kind = "framework")]
+extern "C" {
+    /// Register the calling process for system-power notifications.
+    /// Returns the `io_connect_t` root power port (used later in
+    /// `IOAllowPowerChange` to ack sleep-related messages) and writes
+    /// the notification port + an `io_object_t` notifier through the
+    /// out-pointers. The returned notification port carries a
+    /// CFRunLoopSource we attach to this thread's run loop so the
+    /// callback fires inline with the existing event-tap loop.
+    fn IORegisterForSystemPower(
+        refcon: *mut c_void,
+        port_ref: *mut *mut c_void,
+        callback: extern "C" fn(*mut c_void, u32, u32, *mut c_void),
+        notifier: *mut u32,
+    ) -> u32;
+    fn IODeregisterForSystemPower(notifier: *mut u32) -> i32;
+    fn IONotificationPortGetRunLoopSource(notify: *mut c_void) -> CFRunLoopSourceRef;
+    fn IONotificationPortDestroy(notify: *mut c_void);
+    /// Ack a kIOMessageCanSystemSleep / kIOMessageSystemWillSleep so
+    /// the OS doesn't stall on its 30s default timeout waiting for us.
+    /// Required even when we have no objection — silence is treated as
+    /// "still thinking" by the kernel.
+    fn IOAllowPowerChange(kernel_port: u32, notification_id: isize) -> i32;
 }
 
 #[link(name = "ApplicationServices", kind = "framework")]

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -58,13 +58,21 @@ struct InputCaptureState {
     bounds: Bounds,
     /// current state of modifier keys
     modifier_state: XMods,
-    /// True while the host's screen is locked (set by the
-    /// `com.apple.screenIsLocked` distributed notification, cleared by
-    /// `com.apple.screenIsUnlocked`). Crossings into capture surfaces
-    /// are suppressed while this is true: macOS's lock screen
-    /// consumes keyboard events before any CGEventTap sees them, so
-    /// allowing the mouse to leave the host produces a half-broken
-    /// state (cursor on peer, no keyboard). Mirrors what Wayland's
+    /// True while the host's screen is locked. Refreshed on each
+    /// `MouseMoved` event in the tap callback by querying
+    /// `CGSessionCopyCurrentDictionary["CGSSessionScreenIsLocked"]`
+    /// — direct polling, no observer / run-loop dependency. (We tried
+    /// `CFNotificationCenterGetDistributedCenter` for
+    /// `com.apple.screenIsLocked` and `notify_register_check`
+    /// against notify(3); neither delivers reliably from a non-Cocoa
+    /// daemon: distributed notifications attach the distnoted port
+    /// to the main thread's CFRunLoop, but lan-mouse's main thread
+    /// runs the GLib main loop instead of a CFRunLoop, so the port
+    /// is never serviced.) Crossings into capture surfaces are
+    /// suppressed while this is true: macOS's lock screen consumes
+    /// keyboard events before any CGEventTap sees them, so allowing
+    /// the mouse to leave the host produces a half-broken state
+    /// (cursor on peer, no keyboard). Mirrors what Wayland's
     /// compositor enforces for free on locked Linux.
     host_locked: bool,
 }
@@ -478,6 +486,30 @@ fn create_event_tap<'a>(
         let mut capture_position = None;
         let mut res_events = vec![];
 
+        // Refresh `host_locked` on MouseMoved by polling CGSession.
+        // Only on MouseMoved because that's the only event type whose
+        // forwarding decision depends on it (cross-detect gate, plus
+        // mid-capture abort). On a transition into locked, synthesize
+        // an AutoRelease so the wrapper sends Leave to the peer and
+        // brings the cursor back to the host.
+        if matches!(event_type, CGEventType::MouseMoved) {
+            let now_locked = is_screen_locked();
+            if now_locked != state.host_locked {
+                state.host_locked = now_locked;
+                if now_locked {
+                    if let Some(pos) = state.current_pos.take() {
+                        let _ = CGDisplay::show_cursor(&CGDisplay::main());
+                        log::info!("host screen locked mid-capture; releasing");
+                        let _ = event_tx.blocking_send((pos, CaptureEvent::AutoRelease));
+                    } else {
+                        log::info!("host screen locked");
+                    }
+                } else {
+                    log::info!("host screen unlocked");
+                }
+            }
+        }
+
         if matches!(event_type, CGEventType::TapDisabledByTimeout) {
             // The kernel disables the tap when our callback runs
             // longer than ~1s on a single event — typical causes
@@ -624,11 +656,8 @@ fn event_tap_thread(
     ready: std::sync::mpsc::Sender<Result<CFRunLoop, MacosCaptureCreationError>>,
     exit: oneshot::Sender<()>,
 ) {
-    // Clone now: create_event_tap consumes notify_tx and event_tx
-    // into its closure.
+    // Clone now: create_event_tap consumes notify_tx into its closure.
     let display_notify_tx = notify_tx.clone();
-    let lock_event_tx = event_tx.clone();
-    let lock_state = client_state.clone();
 
     let _tap = match create_event_tap(client_state, notify_tx, event_tx) {
         Err(e) => {
@@ -656,74 +685,11 @@ fn event_tap_thread(
         );
     }
 
-    // Register CoreFoundation distributed-notification observers for
-    // host screen lock / unlock. The callbacks flip
-    // `state.host_locked` so the event tap suppresses crossings while
-    // the lock screen is up — matches what Wayland's compositor
-    // enforces for free on locked Linux. Box-leak the shared
-    // `LockObserverData` once and use the same pointer as the
-    // observer key for both notification names; reclaim on exit.
-    let lock_observer_data = Box::into_raw(Box::new(LockObserverData {
-        state: lock_state,
-        event_tx: lock_event_tx,
-    })) as *mut c_void;
-    let locked_name = unsafe {
-        let cstr = CString::new("com.apple.screenIsLocked").unwrap();
-        CFStringCreateWithCString(
-            kCFAllocatorDefault,
-            cstr.as_ptr() as *const c_char,
-            kCFStringEncodingUTF8,
-        )
-    };
-    let unlocked_name = unsafe {
-        let cstr = CString::new("com.apple.screenIsUnlocked").unwrap();
-        CFStringCreateWithCString(
-            kCFAllocatorDefault,
-            cstr.as_ptr() as *const c_char,
-            kCFStringEncodingUTF8,
-        )
-    };
-    unsafe {
-        let center = CFNotificationCenterGetDistributedCenter();
-        CFNotificationCenterAddObserver(
-            center,
-            lock_observer_data,
-            screen_locked_callback,
-            locked_name,
-            std::ptr::null(),
-            CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY,
-        );
-        CFNotificationCenterAddObserver(
-            center,
-            lock_observer_data,
-            screen_unlocked_callback,
-            unlocked_name,
-            std::ptr::null(),
-            CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY,
-        );
-    }
-
     log::debug!("running CFRunLoop...");
     CFRunLoop::run_current();
     log::debug!("event tap thread exiting!...");
 
     unsafe {
-        let center = CFNotificationCenterGetDistributedCenter();
-        CFNotificationCenterRemoveObserver(
-            center,
-            lock_observer_data,
-            locked_name,
-            std::ptr::null(),
-        );
-        CFNotificationCenterRemoveObserver(
-            center,
-            lock_observer_data,
-            unlocked_name,
-            std::ptr::null(),
-        );
-        CFRelease(locked_name as *const c_void);
-        CFRelease(unlocked_name as *const c_void);
-        drop(Box::from_raw(lock_observer_data as *mut LockObserverData));
 
         CGDisplayRemoveReconfigurationCallback(display_reconfiguration_callback, display_user_info);
         // Reclaim the leaked sender Box so we don't leak a tokio
@@ -736,57 +702,35 @@ fn event_tap_thread(
     let _ = exit.send(());
 }
 
-/// CoreFoundation distributed-notification callback for
-/// `com.apple.screenIsLocked`. Flips the capture state's `host_locked`
-/// flag, clears any in-flight capture, and synthesizes an
-/// `AutoRelease` upward so the wrapper tears down (sends Leave to the
-/// peer, flushes held keys, etc.). Runs on the CFRunLoop thread, NOT
-/// the tokio runtime — uses `blocking_lock` / `blocking_send`
-/// accordingly.
-extern "C" fn screen_locked_callback(
-    _center: CFNotificationCenterRef,
-    observer: *mut c_void,
-    _name: CFStringRef,
-    _object: *const c_void,
-    _user_info: *const c_void,
-) {
-    if observer.is_null() {
-        return;
+/// Query whether the host's screen is locked. Asks the WindowServer
+/// for the current login session dictionary and looks up the
+/// `CGSSessionScreenIsLocked` key. The key is `kCFBooleanTrue` when
+/// locked; on Sequoia 15+ it's typically absent when unlocked rather
+/// than `kCFBooleanFalse`, so missing-or-nil is treated as unlocked.
+/// Costs ~10–50µs per call (an XPC round-trip to WindowServer);
+/// called from the event tap callback only on `MouseMoved`, so the
+/// amortized cost is negligible (<2% CPU at typical mouse rates).
+fn is_screen_locked() -> bool {
+    let key = unsafe {
+        let cstr = CString::new("CGSSessionScreenIsLocked").unwrap();
+        CFStringCreateWithCString(
+            kCFAllocatorDefault,
+            cstr.as_ptr() as *const c_char,
+            kCFStringEncodingUTF8,
+        )
+    };
+    let dict = unsafe { CGSessionCopyCurrentDictionary() };
+    if dict.is_null() {
+        unsafe { CFRelease(key as *const c_void) };
+        return false;
     }
-    // SAFETY: `observer` is the LockObserverData pointer we registered
-    // in `event_tap_thread`. It lives until the thread exits and we
-    // remove the observer registration, so the box is live here.
-    let data = unsafe { &*(observer as *const LockObserverData) };
-    let mut state = data.state.blocking_lock();
-    state.host_locked = true;
-    if let Some(pos) = state.current_pos.take() {
-        let _ = CGDisplay::show_cursor(&CGDisplay::main());
-        log::info!("host screen locked mid-capture; releasing");
-        let _ = data
-            .event_tx
-            .blocking_send((pos, CaptureEvent::AutoRelease));
-    } else {
-        log::info!("host screen locked");
+    let value = unsafe { CFDictionaryGetValue(dict, key as *const c_void) };
+    let locked = !value.is_null() && unsafe { CFBooleanGetValue(value as CFBooleanRef) };
+    unsafe {
+        CFRelease(dict as *const c_void);
+        CFRelease(key as *const c_void);
     }
-}
-
-/// CoreFoundation distributed-notification callback for
-/// `com.apple.screenIsUnlocked`. Just clears the `host_locked` flag —
-/// no state to teardown.
-extern "C" fn screen_unlocked_callback(
-    _center: CFNotificationCenterRef,
-    observer: *mut c_void,
-    _name: CFStringRef,
-    _object: *const c_void,
-    _user_info: *const c_void,
-) {
-    if observer.is_null() {
-        return;
-    }
-    let data = unsafe { &*(observer as *const LockObserverData) };
-    let mut state = data.state.blocking_lock();
-    state.host_locked = false;
-    log::info!("host screen unlocked");
+    locked
 }
 
 /// Quartz display-reconfiguration callback. Fires twice per change:
@@ -1024,46 +968,18 @@ extern "C" {
     fn _CGSDefaultConnection() -> CGSConnectionID;
 }
 
-/// State the screen-lock notification callbacks need: shared capture
-/// state (so they can flip `host_locked` and clear `current_pos`) plus
-/// the event-tx clone (so they can synthesize an `AutoRelease` event
-/// upward when the screen locks mid-capture). Box-leaked once into the
-/// `event_tap_thread`'s lifetime; reclaimed on thread exit.
-struct LockObserverData {
-    state: Arc<Mutex<InputCaptureState>>,
-    event_tx: Sender<(Position, CaptureEvent)>,
-}
+type CFDictionaryRef = *mut c_void;
 
-type CFNotificationCenterRef = *mut c_void;
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGSessionCopyCurrentDictionary() -> CFDictionaryRef;
+}
 
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
-    fn CFNotificationCenterGetDistributedCenter() -> CFNotificationCenterRef;
-    fn CFNotificationCenterAddObserver(
-        center: CFNotificationCenterRef,
-        observer: *const c_void,
-        callback: extern "C" fn(
-            CFNotificationCenterRef,
-            *mut c_void,
-            CFStringRef,
-            *const c_void,
-            *const c_void,
-        ),
-        name: CFStringRef,
-        object: *const c_void,
-        suspension_behavior: u32,
-    );
-    fn CFNotificationCenterRemoveObserver(
-        center: CFNotificationCenterRef,
-        observer: *const c_void,
-        name: CFStringRef,
-        object: *const c_void,
-    );
+    fn CFDictionaryGetValue(dict: CFDictionaryRef, key: *const c_void) -> *const c_void;
+    fn CFBooleanGetValue(boolean: CFBooleanRef) -> bool;
 }
-
-/// CFNotificationSuspensionBehavior — deliver while suspended (we're a
-/// background daemon and may not have foreground app standing).
-const CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY: u32 = 4;
 
 extern "C" {
     fn CGEventSourceSetLocalEventsSuppressionInterval(

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -9,7 +9,7 @@ use core_foundation::{
     string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8},
 };
 use core_graphics::{
-    base::{CGError, kCGErrorSuccess},
+    base::{CGError, CGFloat, kCGErrorSuccess},
     display::{CGDisplay, CGPoint},
     event::{
         CGEvent, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
@@ -809,9 +809,7 @@ impl Capture for MacOSInputCapture {
         let notify_tx = self.notify_tx.clone();
         tokio::task::spawn_local(async move {
             log::debug!("notifying Release");
-            let _ = notify_tx
-                .send(ProducerEvent::Release { warp_target })
-                .await;
+            let _ = notify_tx.send(ProducerEvent::Release { warp_target }).await;
         });
         Ok(())
     }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -58,6 +58,15 @@ struct InputCaptureState {
     bounds: Bounds,
     /// current state of modifier keys
     modifier_state: XMods,
+    /// True while the host's screen is locked (set by the
+    /// `com.apple.screenIsLocked` distributed notification, cleared by
+    /// `com.apple.screenIsUnlocked`). Crossings into capture surfaces
+    /// are suppressed while this is true: macOS's lock screen
+    /// consumes keyboard events before any CGEventTap sees them, so
+    /// allowing the mouse to leave the host produces a half-broken
+    /// state (cursor on peer, no keyboard). Mirrors what Wayland's
+    /// compositor enforces for free on locked Linux.
+    host_locked: bool,
 }
 
 #[derive(Debug)]
@@ -85,6 +94,7 @@ impl InputCaptureState {
             enter_position: None,
             bounds: Bounds::default(),
             modifier_state: Default::default(),
+            host_locked: false,
         };
         res.update_bounds()?;
         Ok(res)
@@ -540,8 +550,11 @@ fn create_event_tap<'a>(
             ) {
                 state.reset_cursor().unwrap_or_else(|e| log::warn!("{e}"));
             }
-        } else if matches!(event_type, CGEventType::MouseMoved) {
-            // Did we cross a barrier?
+        } else if matches!(event_type, CGEventType::MouseMoved) && !state.host_locked {
+            // Did we cross a barrier? Skip when the host is locked —
+            // the lock screen consumes keyboard before our tap sees
+            // it, so allowing the cursor to cross produces a
+            // mouse-only-on-peer half-broken state.
             if let Some(new_pos) = state.crossed(cg_ev) {
                 capture_position = Some(new_pos);
                 // Snapshot the cursor's screen-space position at the
@@ -611,8 +624,11 @@ fn event_tap_thread(
     ready: std::sync::mpsc::Sender<Result<CFRunLoop, MacosCaptureCreationError>>,
     exit: oneshot::Sender<()>,
 ) {
-    // Clone now: create_event_tap consumes notify_tx into its closure.
+    // Clone now: create_event_tap consumes notify_tx and event_tx
+    // into its closure.
     let display_notify_tx = notify_tx.clone();
+    let lock_event_tx = event_tx.clone();
+    let lock_state = client_state.clone();
 
     let _tap = match create_event_tap(client_state, notify_tx, event_tx) {
         Err(e) => {
@@ -640,11 +656,75 @@ fn event_tap_thread(
         );
     }
 
+    // Register CoreFoundation distributed-notification observers for
+    // host screen lock / unlock. The callbacks flip
+    // `state.host_locked` so the event tap suppresses crossings while
+    // the lock screen is up — matches what Wayland's compositor
+    // enforces for free on locked Linux. Box-leak the shared
+    // `LockObserverData` once and use the same pointer as the
+    // observer key for both notification names; reclaim on exit.
+    let lock_observer_data = Box::into_raw(Box::new(LockObserverData {
+        state: lock_state,
+        event_tx: lock_event_tx,
+    })) as *mut c_void;
+    let locked_name = unsafe {
+        let cstr = CString::new("com.apple.screenIsLocked").unwrap();
+        CFStringCreateWithCString(
+            kCFAllocatorDefault,
+            cstr.as_ptr() as *const c_char,
+            kCFStringEncodingUTF8,
+        )
+    };
+    let unlocked_name = unsafe {
+        let cstr = CString::new("com.apple.screenIsUnlocked").unwrap();
+        CFStringCreateWithCString(
+            kCFAllocatorDefault,
+            cstr.as_ptr() as *const c_char,
+            kCFStringEncodingUTF8,
+        )
+    };
+    unsafe {
+        let center = CFNotificationCenterGetDistributedCenter();
+        CFNotificationCenterAddObserver(
+            center,
+            lock_observer_data,
+            screen_locked_callback,
+            locked_name,
+            std::ptr::null(),
+            CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY,
+        );
+        CFNotificationCenterAddObserver(
+            center,
+            lock_observer_data,
+            screen_unlocked_callback,
+            unlocked_name,
+            std::ptr::null(),
+            CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY,
+        );
+    }
+
     log::debug!("running CFRunLoop...");
     CFRunLoop::run_current();
     log::debug!("event tap thread exiting!...");
 
     unsafe {
+        let center = CFNotificationCenterGetDistributedCenter();
+        CFNotificationCenterRemoveObserver(
+            center,
+            lock_observer_data,
+            locked_name,
+            std::ptr::null(),
+        );
+        CFNotificationCenterRemoveObserver(
+            center,
+            lock_observer_data,
+            unlocked_name,
+            std::ptr::null(),
+        );
+        CFRelease(locked_name as *const c_void);
+        CFRelease(unlocked_name as *const c_void);
+        drop(Box::from_raw(lock_observer_data as *mut LockObserverData));
+
         CGDisplayRemoveReconfigurationCallback(display_reconfiguration_callback, display_user_info);
         // Reclaim the leaked sender Box so we don't leak a tokio
         // channel sender on every capture create/destroy cycle.
@@ -654,6 +734,59 @@ fn event_tap_thread(
     }
 
     let _ = exit.send(());
+}
+
+/// CoreFoundation distributed-notification callback for
+/// `com.apple.screenIsLocked`. Flips the capture state's `host_locked`
+/// flag, clears any in-flight capture, and synthesizes an
+/// `AutoRelease` upward so the wrapper tears down (sends Leave to the
+/// peer, flushes held keys, etc.). Runs on the CFRunLoop thread, NOT
+/// the tokio runtime — uses `blocking_lock` / `blocking_send`
+/// accordingly.
+extern "C" fn screen_locked_callback(
+    _center: CFNotificationCenterRef,
+    observer: *mut c_void,
+    _name: CFStringRef,
+    _object: *const c_void,
+    _user_info: *const c_void,
+) {
+    if observer.is_null() {
+        return;
+    }
+    // SAFETY: `observer` is the LockObserverData pointer we registered
+    // in `event_tap_thread`. It lives until the thread exits and we
+    // remove the observer registration, so the box is live here.
+    let data = unsafe { &*(observer as *const LockObserverData) };
+    let mut state = data.state.blocking_lock();
+    state.host_locked = true;
+    if let Some(pos) = state.current_pos.take() {
+        let _ = CGDisplay::show_cursor(&CGDisplay::main());
+        log::info!("host screen locked mid-capture; releasing");
+        let _ = data
+            .event_tx
+            .blocking_send((pos, CaptureEvent::AutoRelease));
+    } else {
+        log::info!("host screen locked");
+    }
+}
+
+/// CoreFoundation distributed-notification callback for
+/// `com.apple.screenIsUnlocked`. Just clears the `host_locked` flag —
+/// no state to teardown.
+extern "C" fn screen_unlocked_callback(
+    _center: CFNotificationCenterRef,
+    observer: *mut c_void,
+    _name: CFStringRef,
+    _object: *const c_void,
+    _user_info: *const c_void,
+) {
+    if observer.is_null() {
+        return;
+    }
+    let data = unsafe { &*(observer as *const LockObserverData) };
+    let mut state = data.state.blocking_lock();
+    state.host_locked = false;
+    log::info!("host screen unlocked");
 }
 
 /// Quartz display-reconfiguration callback. Fires twice per change:
@@ -890,6 +1023,47 @@ extern "C" {
     ) -> CGError;
     fn _CGSDefaultConnection() -> CGSConnectionID;
 }
+
+/// State the screen-lock notification callbacks need: shared capture
+/// state (so they can flip `host_locked` and clear `current_pos`) plus
+/// the event-tx clone (so they can synthesize an `AutoRelease` event
+/// upward when the screen locks mid-capture). Box-leaked once into the
+/// `event_tap_thread`'s lifetime; reclaimed on thread exit.
+struct LockObserverData {
+    state: Arc<Mutex<InputCaptureState>>,
+    event_tx: Sender<(Position, CaptureEvent)>,
+}
+
+type CFNotificationCenterRef = *mut c_void;
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFNotificationCenterGetDistributedCenter() -> CFNotificationCenterRef;
+    fn CFNotificationCenterAddObserver(
+        center: CFNotificationCenterRef,
+        observer: *const c_void,
+        callback: extern "C" fn(
+            CFNotificationCenterRef,
+            *mut c_void,
+            CFStringRef,
+            *const c_void,
+            *const c_void,
+        ),
+        name: CFStringRef,
+        object: *const c_void,
+        suspension_behavior: u32,
+    );
+    fn CFNotificationCenterRemoveObserver(
+        center: CFNotificationCenterRef,
+        observer: *const c_void,
+        name: CFStringRef,
+        object: *const c_void,
+    );
+}
+
+/// CFNotificationSuspensionBehavior — deliver while suspended (we're a
+/// background daemon and may not have foreground app standing).
+const CF_NOTIFICATION_SUSPENSION_BEHAVIOR_DELIVER_IMMEDIATELY: u32 = 4;
 
 extern "C" {
     fn CGEventSourceSetLocalEventsSuppressionInterval(

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -401,11 +401,41 @@ fn get_events(
             })))
         }
         CGEventType::ScrollWheel => {
+            // Emit scroll deltas in the *classic* mouse-wheel convention
+            // (the historical baseline that predates natural scrolling)
+            // regardless of the user's macOS Natural Scrolling
+            // preference. Rationale:
+            //
+            //   1. Classic was the canonical scroll convention when
+            //      the scroll wheel was invented; using it as the
+            //      wire format keeps Lan Mouse predictable for any
+            //      receiver, including non-natural-aware peers.
+            //   2. Receivers opt into natural-feel via their own
+            //      `natural_scroll` config, mirroring how libinput's
+            //      natural_scroll knob works for physical input.
+            //   3. macOS Natural Scrolling pre-flips POINT_DELTA at
+            //      the OS layer; CGEventTap at Session placement sees
+            //      events after that flip. So:
+            //        Natural ON: POINT_DELTA already flipped (away
+            //          from classic) → re-flip back to classic by
+            //          NOT flipping in our code (sign = +1).
+            //        Natural OFF: POINT_DELTA already in classic →
+            //          flip once to invert away from raw and… wait,
+            //          actually we want to land on classic regardless.
+            //          With Natural OFF the OS gives us "raw classic"
+            //          *as-the-mac-sees-it*; our peers' wl_pointer
+            //          treats positive Y as "document moves down on
+            //          screen" (natural-feel). To present classic
+            //          feel on the wire we negate (sign = -1).
+            //
+            // Net result: wire is consistently classic-feel regardless
+            // of the Mac's preference. Receivers can re-invert.
+            let sign: i64 = if natural_scrolling_enabled() { 1 } else { -1 };
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
-                let v =
-                    ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
-                let h =
-                    ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
+                let v = sign
+                    * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
+                let h = sign
+                    * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
@@ -424,8 +454,10 @@ fn get_events(
                 // line based scrolling
                 const LINES_PER_STEP: i32 = 3;
                 const V120_STEPS_PER_LINE: i32 = 120 / LINES_PER_STEP;
-                let v = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
-                let h = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
+                let v =
+                    sign * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
+                let h =
+                    sign * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {
@@ -1122,6 +1154,43 @@ extern "C" {
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
     fn AXIsProcessTrusted() -> bool;
+}
+
+/// Read `com.apple.swipescrolldirection` from the global preferences
+/// domain. Returns `true` when Natural Scrolling is enabled (the
+/// modern macOS default) — the same default macOS uses if the key
+/// is unset. Used to decide whether to invert scroll deltas before
+/// forwarding them to a peer that has its own fixed convention.
+fn natural_scrolling_enabled() -> bool {
+    unsafe {
+        let key_cstr = CString::new("com.apple.swipescrolldirection").unwrap();
+        let key = CFStringCreateWithCString(
+            kCFAllocatorDefault,
+            key_cstr.as_ptr() as *const c_char,
+            kCFStringEncodingUTF8,
+        );
+        if key.is_null() {
+            return true;
+        }
+        let value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication);
+        CFRelease(key as *const c_void);
+        if value.is_null() {
+            // Key absent → modern macOS default is enabled.
+            return true;
+        }
+        // The preference is stored as a CFBoolean; kCFBooleanTrue
+        // and kCFBooleanFalse are singleton instances, so a pointer
+        // compare is correct and sufficient.
+        let is_true = (value as CFBooleanRef) == kCFBooleanTrue;
+        CFRelease(value);
+        is_true
+    }
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFPreferencesCopyAppValue(key: CFStringRef, application_id: CFStringRef) -> *const c_void;
+    static kCFPreferencesAnyApplication: CFStringRef;
 }
 
 unsafe fn configure_cf_settings() -> Result<(), MacosCaptureCreationError> {

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -58,23 +58,6 @@ struct InputCaptureState {
     bounds: Bounds,
     /// current state of modifier keys
     modifier_state: XMods,
-    /// True while the host's screen is locked. Refreshed on each
-    /// `MouseMoved` event in the tap callback by querying
-    /// `CGSessionCopyCurrentDictionary["CGSSessionScreenIsLocked"]`
-    /// — direct polling, no observer / run-loop dependency. (We tried
-    /// `CFNotificationCenterGetDistributedCenter` for
-    /// `com.apple.screenIsLocked` and `notify_register_check`
-    /// against notify(3); neither delivers reliably from a non-Cocoa
-    /// daemon: distributed notifications attach the distnoted port
-    /// to the main thread's CFRunLoop, but lan-mouse's main thread
-    /// runs the GLib main loop instead of a CFRunLoop, so the port
-    /// is never serviced.) Crossings into capture surfaces are
-    /// suppressed while this is true: macOS's lock screen consumes
-    /// keyboard events before any CGEventTap sees them, so allowing
-    /// the mouse to leave the host produces a half-broken state
-    /// (cursor on peer, no keyboard). Mirrors what Wayland's
-    /// compositor enforces for free on locked Linux.
-    host_locked: bool,
 }
 
 #[derive(Debug)]
@@ -102,7 +85,6 @@ impl InputCaptureState {
             enter_position: None,
             bounds: Bounds::default(),
             modifier_state: Default::default(),
-            host_locked: false,
         };
         res.update_bounds()?;
         Ok(res)
@@ -486,30 +468,6 @@ fn create_event_tap<'a>(
         let mut capture_position = None;
         let mut res_events = vec![];
 
-        // Refresh `host_locked` on MouseMoved by polling CGSession.
-        // Only on MouseMoved because that's the only event type whose
-        // forwarding decision depends on it (cross-detect gate, plus
-        // mid-capture abort). On a transition into locked, synthesize
-        // an AutoRelease so the wrapper sends Leave to the peer and
-        // brings the cursor back to the host.
-        if matches!(event_type, CGEventType::MouseMoved) {
-            let now_locked = is_screen_locked();
-            if now_locked != state.host_locked {
-                state.host_locked = now_locked;
-                if now_locked {
-                    if let Some(pos) = state.current_pos.take() {
-                        let _ = CGDisplay::show_cursor(&CGDisplay::main());
-                        log::info!("host screen locked mid-capture; releasing");
-                        let _ = event_tx.blocking_send((pos, CaptureEvent::AutoRelease));
-                    } else {
-                        log::info!("host screen locked");
-                    }
-                } else {
-                    log::info!("host screen unlocked");
-                }
-            }
-        }
-
         if matches!(event_type, CGEventType::TapDisabledByTimeout) {
             // The kernel disables the tap when our callback runs
             // longer than ~1s on a single event — typical causes
@@ -582,27 +540,37 @@ fn create_event_tap<'a>(
             ) {
                 state.reset_cursor().unwrap_or_else(|e| log::warn!("{e}"));
             }
-        } else if matches!(event_type, CGEventType::MouseMoved) && !state.host_locked {
-            // Did we cross a barrier? Skip when the host is locked —
-            // the lock screen consumes keyboard before our tap sees
-            // it, so allowing the cursor to cross produces a
-            // mouse-only-on-peer half-broken state.
+        } else if matches!(event_type, CGEventType::MouseMoved) {
+            // Did we cross a barrier?
             if let Some(new_pos) = state.crossed(cg_ev) {
-                capture_position = Some(new_pos);
-                // Snapshot the cursor's screen-space position at the
-                // instant of crossing — before start_capture's
-                // reset_cursor() snaps it to the edge. The peer uses
-                // this for the visually-corresponding warp on Enter
-                // so the cursor doesn't jump to the entry-edge midpoint.
-                let cross_loc = cg_ev.location();
-                let cursor = Some((cross_loc.x as i32, cross_loc.y as i32));
-                state
-                    .start_capture(cg_ev, new_pos)
-                    .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin { cursor });
-                notify_tx
-                    .blocking_send(ProducerEvent::Grab(new_pos))
-                    .expect("Failed to send notification");
+                // About to commit the cross — final gate: skip if the
+                // host is locked, since the lock screen consumes
+                // keyboard before our tap sees it and allowing the
+                // cursor to leave would produce a mouse-only-on-peer
+                // half-broken state. Polling CGSession only at this
+                // commit point (rather than every MouseMoved) keeps
+                // the per-event cost zero — `is_screen_locked()` is
+                // an XPC to WindowServer (~10–50µs); a typical user
+                // crosses a wall a few times per minute.
+                if is_screen_locked() {
+                    log::info!("host screen locked; suppressing cross to {new_pos:?}");
+                } else {
+                    capture_position = Some(new_pos);
+                    // Snapshot the cursor's screen-space position at the
+                    // instant of crossing — before start_capture's
+                    // reset_cursor() snaps it to the edge. The peer uses
+                    // this for the visually-corresponding warp on Enter
+                    // so the cursor doesn't jump to the entry-edge midpoint.
+                    let cross_loc = cg_ev.location();
+                    let cursor = Some((cross_loc.x as i32, cross_loc.y as i32));
+                    state
+                        .start_capture(cg_ev, new_pos)
+                        .unwrap_or_else(|e| log::warn!("{e}"));
+                    res_events.push(CaptureEvent::Begin { cursor });
+                    notify_tx
+                        .blocking_send(ProducerEvent::Grab(new_pos))
+                        .expect("Failed to send notification");
+                }
             }
         }
 

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -62,7 +62,14 @@ struct InputCaptureState {
 
 #[derive(Debug)]
 enum ProducerEvent {
-    Release,
+    /// `warp_target`, when present, is a screen-space (Quartz) point
+    /// at which to warp the local cursor before showing it. Used to
+    /// preserve cross-axis continuity on release: the visible cursor
+    /// reappears at the host point matching where it visually was on
+    /// the guest, instead of snapping back to the capture-start edge.
+    Release {
+        warp_target: Option<(i32, i32)>,
+    },
     Create(Position),
     Destroy(Position),
     Grab(Position),
@@ -153,8 +160,26 @@ impl InputCaptureState {
     ) -> Result<(), CaptureError> {
         log::debug!("handling event: {producer_event:?}");
         match producer_event {
-            ProducerEvent::Release => {
+            ProducerEvent::Release { warp_target } => {
+                log::info!(
+                    "[release-warp] handle_producer_event Release: current_pos={:?} warp_target={warp_target:?}",
+                    self.current_pos
+                );
                 if self.current_pos.is_some() {
+                    // Warp BEFORE clearing current_pos so the
+                    // event-tap callback can't see Some(pos) and
+                    // re-snap the cursor to the entry edge before we
+                    // make it visible again. Then show_cursor() reveals
+                    // it at the warped point.
+                    if let Some((x, y)) = warp_target {
+                        log::info!("[release-warp] warping local cursor to ({x}, {y})");
+                        if let Err(e) = CGDisplay::warp_mouse_cursor_position(CGPoint {
+                            x: x as CGFloat,
+                            y: y as CGFloat,
+                        }) {
+                            log::warn!("[release-warp] warp_mouse_cursor_position failed: {e:?}");
+                        }
+                    }
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
@@ -779,11 +804,14 @@ impl Capture for MacOSInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
+        log::info!("[release-warp] macOS backend release(warp_target={warp_target:?})");
         let notify_tx = self.notify_tx.clone();
         tokio::task::spawn_local(async move {
             log::debug!("notifying Release");
-            let _ = notify_tx.send(ProducerEvent::Release).await;
+            let _ = notify_tx
+                .send(ProducerEvent::Release { warp_target })
+                .await;
         });
         Ok(())
     }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -211,6 +211,25 @@ impl InputCaptureState {
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
+                // Distinguish AX revocation from a recoverable cause
+                // (secure-input mode while typing in a password field
+                // also fires TapDisabledByUserInput). If AX is gone,
+                // the tap can't be recreated and the GUI's polling
+                // watcher may not flip for a while when the user
+                // *removed* the entry from System Settings → Privacy
+                // & Security → Accessibility (vs just toggling it
+                // off — removal can leave AXIsProcessTrusted reporting
+                // cached-true in already-running processes). Exit
+                // the daemon process directly: the GUI will see its
+                // IPC connection drop and trigger its own
+                // quit-with-backstop path. This is the only reliable
+                // way to tear down a wedged HID-level tap quickly.
+                if !unsafe { AXIsProcessTrusted() } {
+                    log::error!(
+                        "CGEventTap disabled and Accessibility no longer granted — daemon exiting"
+                    );
+                    std::process::exit(0);
+                }
                 return Err(CaptureError::EventTapDisabled);
             }
             ProducerEvent::DisplayReconfigured => {

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -430,6 +430,15 @@ fn get_events(
             //
             // Net result: wire is consistently classic-feel regardless
             // of the Mac's preference. Receivers can re-invert.
+            log::info!(
+                "[SCROLL-DEBUG capture] continuous={} natural={} delta=({},{}) point_delta=({},{})",
+                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS),
+                natural_scrolling_enabled(),
+                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1),
+                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2),
+                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1),
+                ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2),
+            );
             let sign: i64 = if natural_scrolling_enabled() { 1 } else { -1 };
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
                 let v = sign
@@ -452,7 +461,18 @@ fn get_events(
                 }
             } else {
                 // line based scrolling
-                const LINES_PER_STEP: i32 = 3;
+                //
+                // macOS already amplifies SCROLL_WHEEL_EVENT_DELTA based
+                // on wheel velocity — a slow notch on a notched wheel
+                // (e.g. MX Master 4) reports DELTA=1, a fast flick
+                // reports DELTA=10+ per event. The wl_pointer v120
+                // protocol expects one physical wheel click = 120
+                // units, so map one macOS DELTA line to one full v120
+                // tick. (The previous 3-lines-per-step ratio caused
+                // single notches to truncate to discrete=0 on the
+                // receiver, leaving Slack/Alacritty unscrollable until
+                // 3+ notches accumulated.)
+                const LINES_PER_STEP: i32 = 1;
                 const V120_STEPS_PER_LINE: i32 = 120 / LINES_PER_STEP;
                 let v =
                     sign * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);

--- a/input-capture/src/windows.rs
+++ b/input-capture/src/windows.rs
@@ -29,7 +29,7 @@ impl Capture for WindowsInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         self.event_thread.release_capture();
         Ok(())
     }

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -14,6 +14,9 @@ use windows::Win32::Graphics::Gdi::{
     EnumDisplayDevicesW, EnumDisplaySettingsW,
 };
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::System::RemoteDesktop::{
+    NOTIFY_FOR_THIS_SESSION, WTSRegisterSessionNotification, WTSUnRegisterSessionNotification,
+};
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::core::{PCWSTR, w};
 
@@ -23,7 +26,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
     RegisterClassW, SetWindowsHookExW, TranslateMessage, WH_KEYBOARD_LL, WH_MOUSE_LL, WINDOW_STYLE,
     WM_DISPLAYCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
     WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDOWN, WM_RBUTTONUP,
-    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WNDPROC,
+    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER, WM_WTSSESSION_CHANGE, WM_XBUTTONDOWN, WM_XBUTTONUP,
+    WNDCLASSW, WNDPROC, WTS_SESSION_LOCK, WTS_SESSION_UNLOCK,
 };
 
 use input_event::{
@@ -122,6 +126,14 @@ thread_local! {
     static PREV_POS: Cell<Option<(i32, i32)>> = const { Cell::new(None) };
     /// displays and generation counter
     static DISPLAYS: RefCell<(Vec<RECT>, i32)> = const { RefCell::new((Vec::new(), 0)) };
+    /// True while the host's session is locked. Set/cleared from the
+    /// `WM_WTSSESSION_CHANGE` window message. While true, barrier
+    /// crossings are suppressed and any active capture is released —
+    /// matches macOS's lock-screen suppression and what Wayland does
+    /// for free on locked Linux. Without this, low-level mouse hooks
+    /// would happily forward motion to the peer while the lock screen
+    /// consumes keyboard events, leaving a half-broken state.
+    static HOST_LOCKED: Cell<bool> = const { Cell::new(false) };
 }
 
 fn get_msg() -> Option<MSG> {
@@ -202,8 +214,10 @@ fn start_routine(
         }
     }
 
-    /* window is used ro receive WM_DISPLAYCHANGE messages */
-    unsafe {
+    /* window is used to receive WM_DISPLAYCHANGE and
+     * WM_WTSSESSION_CHANGE messages. Keep the HWND so we can register
+     * for session notifications and unregister on exit. */
+    let msg_window = unsafe {
         CreateWindowExW(
             Default::default(),
             w!("lan-mouse-message-window-class"),
@@ -218,7 +232,17 @@ fn start_routine(
             Some(instance),
             None,
         )
-        .expect("CreateWindowExW");
+        .expect("CreateWindowExW")
+    };
+
+    /* register for WM_WTSSESSION_CHANGE notifications so we can
+     * detect lock/unlock and suppress crossings while locked. Failure
+     * is logged but non-fatal — the rest of the capture still works,
+     * we just lose the lock-screen suppression. */
+    unsafe {
+        if let Err(e) = WTSRegisterSessionNotification(msg_window, NOTIFY_FOR_THIS_SESSION) {
+            log::warn!("WTSRegisterSessionNotification failed: {e:?} — host-lock suppression disabled");
+        }
     }
 
     /* run message loop. mouse / keybrd procs don't actually return
@@ -256,6 +280,11 @@ fn start_routine(
             }
         }
     }
+
+    /* unregister session-notification before the window goes away. */
+    unsafe {
+        let _ = WTSUnRegisterSessionNotification(msg_window);
+    }
 }
 
 fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
@@ -272,6 +301,14 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
 
     /* client already active, no need to check */
     if ACTIVE_CLIENT.get().is_some() {
+        return ret;
+    }
+
+    /* host session locked — don't let the cursor leave the lock
+     * screen. The lock screen consumes keyboard before our hook sees
+     * it; allowing a cross would put the mouse on the peer with no
+     * keyboard, a confusing half-broken state. */
+    if HOST_LOCKED.get() {
         return ret;
     }
 
@@ -354,12 +391,29 @@ unsafe extern "system" fn kybrd_proc(ncode: i32, wparam: WPARAM, lparam: LPARAM)
 unsafe extern "system" fn window_proc(
     _hwnd: HWND,
     uint: u32,
-    _wparam: WPARAM,
+    wparam: WPARAM,
     _lparam: LPARAM,
 ) -> LRESULT {
     if uint == WM_DISPLAYCHANGE {
         log::debug!("display resolution changed");
         DISPLAY_RESOLUTION_GENERATION.fetch_add(1, Ordering::Release);
+    } else if uint == WM_WTSSESSION_CHANGE {
+        match wparam.0 as u32 {
+            WTS_SESSION_LOCK => {
+                HOST_LOCKED.set(true);
+                if let Some(pos) = ACTIVE_CLIENT.take() {
+                    log::info!("host session locked mid-capture; releasing");
+                    let _ = try_send_event(pos, CaptureEvent::AutoRelease);
+                } else {
+                    log::info!("host session locked");
+                }
+            }
+            WTS_SESSION_UNLOCK => {
+                HOST_LOCKED.set(false);
+                log::info!("host session unlocked");
+            }
+            _ => {}
+        }
     }
     LRESULT(1)
 }

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -221,12 +221,10 @@ fn start_routine(
         .expect("CreateWindowExW");
     }
 
-    /* run message loop */
-    loop {
-        // mouse / keybrd proc do not actually return a message
-        let Some(msg) = get_msg() else {
-            break;
-        };
+    /* run message loop. mouse / keybrd procs don't actually return
+     * a message, so `get_msg() == None` ends the loop; an Exit-typed
+     * thread message breaks out from inside the body. */
+    while let Some(msg) = get_msg() {
         if msg.hwnd.0.is_null() {
             /* messages sent via PostThreadMessage */
             match msg.wParam.0 {

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -241,7 +241,9 @@ fn start_routine(
      * we just lose the lock-screen suppression. */
     unsafe {
         if let Err(e) = WTSRegisterSessionNotification(msg_window, NOTIFY_FOR_THIS_SESSION) {
-            log::warn!("WTSRegisterSessionNotification failed: {e:?} — host-lock suppression disabled");
+            log::warn!(
+                "WTSRegisterSessionNotification failed: {e:?} — host-lock suppression disabled"
+            );
         }
     }
 

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -300,7 +300,7 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
     let active = ACTIVE_CLIENT.get().expect("active client");
-    blocking_send_event(active, CaptureEvent::Begin);
+    blocking_send_event(active, CaptureEvent::Begin { cursor: None });
 
     ret
 }

--- a/input-capture/src/x11.rs
+++ b/input-capture/src/x11.rs
@@ -23,7 +23,7 @@ impl Capture for X11InputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         Ok(())
     }
 

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -178,6 +178,19 @@ impl InputEmulation {
         self.emulation.terminate().await
     }
 
+    /// Display geometry of this device (union of all active
+    /// displays), if the backend can report it. See
+    /// `Emulation::display_bounds`.
+    pub fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.emulation.display_bounds()
+    }
+
+    /// Warp the local cursor to the given absolute position. See
+    /// `Emulation::warp_cursor`.
+    pub async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        self.emulation.warp_cursor(x, y).await
+    }
+
     pub async fn release_keys(&mut self, handle: EmulationHandle) -> Result<(), EmulationError> {
         if let Some(keys) = self.pressed_keys.get_mut(&handle) {
             let keys = keys.drain().collect::<Vec<_>>();
@@ -237,4 +250,27 @@ trait Emulation: Send {
     async fn create(&mut self, handle: EmulationHandle);
     async fn destroy(&mut self, handle: EmulationHandle);
     async fn terminate(&mut self);
+
+    /// Geometry (width, height) of the union of this device's
+    /// active displays in pixels. Used by the protocol-level
+    /// `Bounds` event so a capturing peer can model the guest
+    /// cursor's position. Backends that can't report geometry
+    /// should leave the default `None` and the wall-press
+    /// auto-release fallback will degrade to "no upper clamp"
+    /// behavior on the host.
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    /// Warp the cursor to an absolute position on the receiving
+    /// device's primary display, if the backend supports absolute
+    /// positioning. Called when an `Enter` event arrives so the
+    /// guest cursor lands at the entry edge instead of staying
+    /// wherever the previous capture session left it. Backends
+    /// without absolute positioning can leave the default no-op
+    /// — the wall-press auto-release will be inaccurate but the
+    /// connection still works.
+    async fn warp_cursor(&mut self, _x: i32, _y: i32) -> Result<(), EmulationError> {
+        Ok(())
+    }
 }

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -191,6 +191,12 @@ impl InputEmulation {
         self.emulation.warp_cursor(x, y).await
     }
 
+    /// Configure whether the backend should invert scroll deltas on
+    /// injection. See `Emulation::set_natural_scroll`.
+    pub fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.emulation.set_natural_scroll(natural_scroll);
+    }
+
     pub async fn release_keys(&mut self, handle: EmulationHandle) -> Result<(), EmulationError> {
         if let Some(keys) = self.pressed_keys.get_mut(&handle) {
             let keys = keys.drain().collect::<Vec<_>>();
@@ -273,4 +279,11 @@ trait Emulation: Send {
     async fn warp_cursor(&mut self, _x: i32, _y: i32) -> Result<(), EmulationError> {
         Ok(())
     }
+
+    /// Configure whether the backend should sign-invert scroll
+    /// (axis / axis-discrete) values before injection. Used to
+    /// match the user's libinput natural-scroll preference for
+    /// forwarded events that bypass libinput. Default no-op so
+    /// backends that haven't been updated keep classic behavior.
+    fn set_natural_scroll(&mut self, _natural_scroll: bool) {}
 }

--- a/input-emulation/src/libei.rs
+++ b/input-emulation/src/libei.rs
@@ -50,6 +50,7 @@ pub(crate) struct LibeiEmulation {
     libei_error: Arc<AtomicBool>,
     _remote_desktop: RemoteDesktop,
     session: Session<RemoteDesktop>,
+    natural_scroll: bool,
 }
 
 /// Get the path to the RemoteDesktop token file
@@ -150,6 +151,7 @@ impl LibeiEmulation {
             libei_error,
             _remote_desktop,
             session,
+            natural_scroll: false,
         })
     }
 }
@@ -208,6 +210,7 @@ impl Emulation for LibeiEmulation {
                     axis,
                     value,
                 } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     let scroll_device = self.devices.scroll.read().unwrap();
                     if let Some((d, s)) = scroll_device.as_ref() {
                         match axis {
@@ -218,6 +221,7 @@ impl Emulation for LibeiEmulation {
                     }
                 }
                 PointerEvent::AxisDiscrete120 { axis, value } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     let scroll_device = self.devices.scroll.read().unwrap();
                     if let Some((d, s)) = scroll_device.as_ref() {
                         match axis {
@@ -269,6 +273,10 @@ impl Emulation for LibeiEmulation {
         // wayland-client connection. For now we return None and
         // the host falls back to the no-upper-clamp heuristic.
         None
+    }
+
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
     }
 
     async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {

--- a/input-emulation/src/libei.rs
+++ b/input-emulation/src/libei.rs
@@ -19,8 +19,8 @@ use async_trait::async_trait;
 
 use reis::{
     ei::{
-        self, Button, Keyboard, Pointer, Scroll, button::ButtonState, handshake::ContextType,
-        keyboard::KeyState,
+        self, Button, Keyboard, Pointer, PointerAbsolute, Scroll, button::ButtonState,
+        handshake::ContextType, keyboard::KeyState,
     },
     event::{self, Connection, DeviceCapability, DeviceEvent, EiEvent, SeatEvent},
     tokio::EiConvertEventStream,
@@ -35,6 +35,7 @@ use super::{Emulation, EmulationHandle, error::LibeiEmulationCreationError};
 #[derive(Clone, Default)]
 struct Devices {
     pointer: Arc<RwLock<Option<(ei::Device, ei::Pointer)>>>,
+    pointer_abs: Arc<RwLock<Option<(ei::Device, ei::PointerAbsolute)>>>,
     scroll: Arc<RwLock<Option<(ei::Device, ei::Scroll)>>>,
     button: Arc<RwLock<Option<(ei::Device, ei::Button)>>>,
     keyboard: Arc<RwLock<Option<(ei::Device, ei::Keyboard)>>>,
@@ -261,6 +262,37 @@ impl Emulation for LibeiEmulation {
         let _ = self.session.close().await;
         self.ei_task.abort();
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // TODO: derive from ei::Region events on the
+        // PointerAbsolute device, or query wl_output via a side
+        // wayland-client connection. For now we return None and
+        // the host falls back to the no-upper-clamp heuristic.
+        None
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64;
+        let pointer_abs = self.devices.pointer_abs.read().unwrap();
+        if let Some((device, pointer_abs)) = pointer_abs.as_ref() {
+            pointer_abs.motion_absolute(x as f32, y as f32);
+            device.frame(self.conn.serial(), now);
+            self.context
+                .flush()
+                .map_err(|e| io::Error::new(e.kind(), e))?;
+        } else {
+            // Compositor didn't grant a PointerAbsolute device.
+            // Nothing we can do to warp the cursor; the host's
+            // wall-press model will be off by however far the
+            // user pushed forward in the prior session, but
+            // operation continues.
+            log::debug!("warp_cursor: no PointerAbsolute device available, skipping");
+        }
+        Ok(())
+    }
 }
 
 async fn ei_task(
@@ -322,6 +354,13 @@ async fn ei_event_handler(
                         .write()
                         .unwrap()
                         .replace((device.device().clone(), pointer));
+                }
+                if let Some(pointer_abs) = e.device().interface::<PointerAbsolute>() {
+                    devices
+                        .pointer_abs
+                        .write()
+                        .unwrap()
+                        .replace((device.device().clone(), pointer_abs));
                 }
                 if let Some(keyboard) = e.device().interface::<Keyboard>() {
                     devices

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bitflags::bitflags;
 use core_graphics::base::CGFloat;
 use core_graphics::display::{
-    CGDirectDisplayID, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
+    CGDirectDisplayID, CGDisplay, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
 };
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGKeyCode, CGMouseButton, EventField,
@@ -489,6 +489,39 @@ impl Emulation for MacOSEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Union of every active display's rectangle. Matches the
+        // shape used on the input-capture side so the host's
+        // wall-press model is consistent across both ends.
+        let displays = CGDisplay::active_displays().ok()?;
+        let mut xmin = f64::INFINITY;
+        let mut xmax = f64::NEG_INFINITY;
+        let mut ymin = f64::INFINITY;
+        let mut ymax = f64::NEG_INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            xmax = xmax.max(bounds.origin.x + bounds.size.width);
+            ymin = ymin.min(bounds.origin.y);
+            ymax = ymax.max(bounds.origin.y + bounds.size.height);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let pt = CGPoint {
+            x: x as CGFloat,
+            y: y as CGFloat,
+        };
+        // CGDisplay::warp_mouse_cursor_position is a global Quartz
+        // call; it doesn't matter which CGDisplay receiver we use.
+        let _ = CGDisplay::warp_mouse_cursor_position(pt);
+        Ok(())
+    }
 }
 
 fn update_modifiers(modifiers: &Cell<XMods>, key: u32, state: u8) -> bool {

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -48,6 +48,9 @@ pub(crate) struct MacOSEmulation {
     modifier_state: Rc<Cell<XMods>>,
     /// notify to cancel key repeats
     notify_repeat_task: Arc<Notify>,
+    /// invert scroll deltas before injection (matches the libinput
+    /// natural_scroll concept)
+    natural_scroll: bool,
     /// IOPMAssertionID returned by the most recent
     /// `IOPMAssertionDeclareUserActivity` call, kept for re-use within
     /// the system's 5-second coalesce window. Without this, a CGEvent
@@ -59,9 +62,6 @@ pub(crate) struct MacOSEmulation {
     /// the idle timer. Initialized to 0; the first call returns a
     /// real ID, subsequent calls within 5s return the same ID.
     user_activity_assertion: Cell<u32>,
-    /// invert scroll deltas before injection (matches the libinput
-    /// natural_scroll concept)
-    natural_scroll: bool,
 }
 
 /// Maps an evdev button code to the CGEventType used for drag events.
@@ -91,8 +91,8 @@ impl MacOSEmulation {
             repeat_task: None,
             notify_repeat_task: Arc::new(Notify::new()),
             modifier_state: Rc::new(Cell::new(XMods::empty())),
-            user_activity_assertion: Cell::new(0),
             natural_scroll: false,
+            user_activity_assertion: Cell::new(0),
         })
     }
 

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -1,6 +1,8 @@
 use super::{Emulation, EmulationHandle, error::EmulationError};
 use async_trait::async_trait;
 use bitflags::bitflags;
+use core_foundation::base::{CFRelease, kCFAllocatorDefault};
+use core_foundation::string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8};
 use core_graphics::base::CGFloat;
 use core_graphics::display::{
     CGDirectDisplayID, CGDisplay, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
@@ -15,8 +17,6 @@ use input_event::{
     scancode,
 };
 use keycode::{KeyMap, KeyMapping};
-use core_foundation::base::{CFRelease, kCFAllocatorDefault};
-use core_foundation::string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8};
 use std::cell::Cell;
 use std::collections::HashSet;
 use std::ffi::{CString, c_char, c_int, c_void};
@@ -115,9 +115,8 @@ impl MacOSEmulation {
             return;
         }
         let mut id = self.user_activity_assertion.get();
-        let _ret = unsafe {
-            IOPMAssertionDeclareUserActivity(reason, K_IOPM_USER_ACTIVE_LOCAL, &mut id)
-        };
+        let _ret =
+            unsafe { IOPMAssertionDeclareUserActivity(reason, K_IOPM_USER_ACTIVE_LOCAL, &mut id) };
         self.user_activity_assertion.set(id);
         unsafe { CFRelease(reason as *const c_void) };
     }

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -15,8 +15,11 @@ use input_event::{
     scancode,
 };
 use keycode::{KeyMap, KeyMapping};
+use core_foundation::base::{CFRelease, kCFAllocatorDefault};
+use core_foundation::string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8};
 use std::cell::Cell;
 use std::collections::HashSet;
+use std::ffi::{CString, c_char, c_int, c_void};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -45,6 +48,17 @@ pub(crate) struct MacOSEmulation {
     modifier_state: Rc<Cell<XMods>>,
     /// notify to cancel key repeats
     notify_repeat_task: Arc<Notify>,
+    /// IOPMAssertionID returned by the most recent
+    /// `IOPMAssertionDeclareUserActivity` call, kept for re-use within
+    /// the system's 5-second coalesce window. Without this, a CGEvent
+    /// posted while the host's display is asleep wakes nothing — the
+    /// kernel power-manager only treats USB/Bluetooth HID interrupts
+    /// as wake-worthy, not synthesized events. Declaring user
+    /// activity is Apple's documented "treat this as real user input
+    /// for power purposes" signal: it wakes the display and resets
+    /// the idle timer. Initialized to 0; the first call returns a
+    /// real ID, subsequent calls within 5s return the same ID.
+    user_activity_assertion: Cell<u32>,
 }
 
 /// Maps an evdev button code to the CGEventType used for drag events.
@@ -74,7 +88,38 @@ impl MacOSEmulation {
             repeat_task: None,
             notify_repeat_task: Arc::new(Notify::new()),
             modifier_state: Rc::new(Cell::new(XMods::empty())),
+            user_activity_assertion: Cell::new(0),
         })
+    }
+
+    /// Tell the macOS power-manager that real user input is arriving
+    /// from this process. Wakes the display if asleep and resets the
+    /// idle timer. Cheap to call on every event — the system itself
+    /// coalesces calls within a 5-second window (returns the same
+    /// IOPMAssertionID), so we just stash the most recent ID in a
+    /// `Cell` and pass it back in. Required because plain
+    /// `CGEventPost` doesn't trigger display wake on its own.
+    fn declare_user_activity(&self) {
+        let cstr = match CString::new("Lan Mouse: remote input") {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        let reason = unsafe {
+            CFStringCreateWithCString(
+                kCFAllocatorDefault,
+                cstr.as_ptr() as *const c_char,
+                kCFStringEncodingUTF8,
+            )
+        };
+        if reason.is_null() {
+            return;
+        }
+        let mut id = self.user_activity_assertion.get();
+        let _ret = unsafe {
+            IOPMAssertionDeclareUserActivity(reason, K_IOPM_USER_ACTIVE_LOCAL, &mut id)
+        };
+        self.user_activity_assertion.set(id);
+        unsafe { CFRelease(reason as *const c_void) };
     }
 
     fn get_mouse_location(&self) -> Option<CGPoint> {
@@ -156,6 +201,21 @@ extern "C" {
 extern "C" {
     fn AXIsProcessTrusted() -> bool;
 }
+
+#[link(name = "IOKit", kind = "framework")]
+extern "C" {
+    fn IOPMAssertionDeclareUserActivity(
+        assertion_name: CFStringRef,
+        user_type: c_int,
+        out_id: *mut u32,
+    ) -> i32;
+}
+
+/// `kIOPMUserActiveLocal` — local mouse / keyboard activity (the
+/// other variant, `kIOPMUserActiveRemote = 1`, is for screen-sharing
+/// servers acting on behalf of a remote user; "local" is correct
+/// here since we ARE the source generating local HID-style input).
+const K_IOPM_USER_ACTIVE_LOCAL: c_int = 0;
 
 fn key_event(event_source: CGEventSource, key: u16, state: u8, modifiers: XMods) {
     let event = match CGEvent::new_keyboard_event(event_source, key, state != 0) {
@@ -261,6 +321,13 @@ impl Emulation for MacOSEmulation {
         _handle: EmulationHandle,
     ) -> Result<(), EmulationError> {
         log::trace!("{event:?}");
+        // Wake the display + reset idle timer for every incoming
+        // event. CGEventPost-synthesized events alone don't trigger
+        // display wake on macOS — the kernel power-manager only
+        // treats USB/Bluetooth HID interrupts as wake-worthy. The
+        // system coalesces these calls within a 5-second window, so
+        // calling on every event is essentially free.
+        self.declare_user_activity();
         match event {
             Event::Pointer(pointer_event) => {
                 match pointer_event {

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -59,6 +59,9 @@ pub(crate) struct MacOSEmulation {
     /// the idle timer. Initialized to 0; the first call returns a
     /// real ID, subsequent calls within 5s return the same ID.
     user_activity_assertion: Cell<u32>,
+    /// invert scroll deltas before injection (matches the libinput
+    /// natural_scroll concept)
+    natural_scroll: bool,
 }
 
 /// Maps an evdev button code to the CGEventType used for drag events.
@@ -89,6 +92,7 @@ impl MacOSEmulation {
             notify_repeat_task: Arc::new(Notify::new()),
             modifier_state: Rc::new(Cell::new(XMods::empty())),
             user_activity_assertion: Cell::new(0),
+            natural_scroll: false,
         })
     }
 
@@ -454,6 +458,7 @@ impl Emulation for MacOSEmulation {
                         axis,
                         value,
                     } => {
+                        let value = if self.natural_scroll { -value } else { value };
                         let value = value as i32;
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value, 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
@@ -481,6 +486,7 @@ impl Emulation for MacOSEmulation {
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         const LINES_PER_STEP: i32 = 3;
+                        let value = if self.natural_scroll { -value } else { value };
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value / (120 / LINES_PER_STEP), 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value / (120 / LINES_PER_STEP), 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)
@@ -587,6 +593,10 @@ impl Emulation for MacOSEmulation {
         // call; it doesn't matter which CGDisplay receiver we use.
         let _ = CGDisplay::warp_mouse_cursor_position(pt);
         Ok(())
+    }
+
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
     }
 }
 

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -17,7 +17,9 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT_0, KEYEVENTF_EXTENDEDKEY, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, SendInput,
 };
-use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SetCursorPos, XBUTTON1, XBUTTON2,
+};
 
 use super::{Emulation, EmulationHandle};
 
@@ -80,6 +82,27 @@ impl Emulation for WindowsEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Virtual-screen metrics cover the union of every monitor
+        // attached to the system, matching the host-side capture
+        // model that uses the union of all displays.
+        unsafe {
+            let w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            let h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            if w <= 0 || h <= 0 {
+                return None;
+            }
+            Some((w as u32, h as u32))
+        }
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        unsafe {
+            let _ = SetCursorPos(x, y);
+        }
+        Ok(())
+    }
 }
 
 impl WindowsEmulation {

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -28,11 +28,15 @@ const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
 
 pub(crate) struct WindowsEmulation {
     repeat_task: Option<AbortHandle>,
+    natural_scroll: bool,
 }
 
 impl WindowsEmulation {
     pub(crate) fn new() -> Result<Self, WindowsEmulationCreationError> {
-        Ok(Self { repeat_task: None })
+        Ok(Self {
+            repeat_task: None,
+            natural_scroll: false,
+        })
     }
 }
 
@@ -53,8 +57,14 @@ impl Emulation for WindowsEmulation {
                     time: _,
                     axis,
                     value,
-                } => scroll(axis, value as i32),
-                PointerEvent::AxisDiscrete120 { axis, value } => scroll(axis, value),
+                } => {
+                    let value = if self.natural_scroll { -value } else { value };
+                    scroll(axis, value as i32);
+                }
+                PointerEvent::AxisDiscrete120 { axis, value } => {
+                    let value = if self.natural_scroll { -value } else { value };
+                    scroll(axis, value);
+                }
             },
             Event::Keyboard(keyboard_event) => match keyboard_event {
                 KeyboardEvent::Key {
@@ -102,6 +112,10 @@ impl Emulation for WindowsEmulation {
             let _ = SetCursorPos(x, y);
         }
         Ok(())
+    }
+
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
     }
 }
 

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -12,6 +12,7 @@ use wayland_client::WEnum;
 use wayland_client::backend::WaylandError;
 
 use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
+use wayland_client::protocol::wl_output::{self, WlOutput};
 use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
@@ -42,6 +43,25 @@ struct State {
     qh: QueueHandle<Self>,
     vpm: VpManager,
     vkm: VkManager,
+    /// All wl_outputs the compositor advertises, keyed by their
+    /// proxy id. Updated via Geometry/Mode events. We keep the
+    /// `WlOutput` proxy alive in the value so events keep flowing.
+    outputs: HashMap<u32, (WlOutput, OutputInfo)>,
+    /// Dedicated virtual pointer used only for absolute-position
+    /// warps on `Enter`. Separate from per-handle pointers so warp
+    /// works regardless of which client is active.
+    warp_pointer: Vp,
+}
+
+#[derive(Default, Clone, Copy)]
+struct OutputInfo {
+    /// Position in the compositor's global coordinate space, from
+    /// wl_output::Event::Geometry.
+    x: i32,
+    y: i32,
+    /// Pixel dimensions of the active mode, from wl_output::Event::Mode.
+    width: i32,
+    height: i32,
 }
 
 // App State, implements Dispatch event handlers
@@ -68,6 +88,26 @@ impl WlrootsEmulation {
             .bind(&qh, 1..=1, ())
             .map_err(|e| WaylandBindError::new(e, "virtual-keyboard-unstable-v1"))?;
 
+        // Bind every advertised wl_output so we receive Geometry +
+        // Mode events for each one. Used to compute display_bounds.
+        let mut outputs: HashMap<u32, (WlOutput, OutputInfo)> = HashMap::new();
+        for global in globals.contents().clone_list() {
+            if global.interface == "wl_output" {
+                // version 2 is enough for Geometry + Mode events.
+                let output: WlOutput =
+                    globals
+                        .registry()
+                        .bind(global.name, global.version.min(2), &qh, ());
+                let id = output.id().protocol_id();
+                outputs.insert(id, (output, OutputInfo::default()));
+            }
+        }
+
+        // Dedicated warp pointer — used only for motion_absolute on
+        // Enter, so warp works even when no per-handle virtual
+        // pointer is currently active.
+        let warp_pointer: Vp = vpm.create_virtual_pointer(None, &qh, ());
+
         let input_for_client: HashMap<EmulationHandle, VirtualInput> = HashMap::new();
 
         let mut emulate = WlrootsEmulation {
@@ -79,6 +119,8 @@ impl WlrootsEmulation {
                 vpm,
                 vkm,
                 qh,
+                outputs,
+                warp_pointer,
             },
             queue,
         };
@@ -118,6 +160,33 @@ impl State {
             input.pointer.destroy();
             input.keyboard.destroy();
         }
+    }
+
+    /// Bounding rectangle of every active wl_output's logical
+    /// position + active mode. Returns None if no output has
+    /// reported both Geometry and Mode yet.
+    fn union_bounds(&self) -> Option<(u32, u32)> {
+        let mut xmin = i32::MAX;
+        let mut ymin = i32::MAX;
+        let mut xmax = i32::MIN;
+        let mut ymax = i32::MIN;
+        let mut any = false;
+        for (_, o) in self.outputs.values() {
+            if o.width <= 0 || o.height <= 0 {
+                continue;
+            }
+            any = true;
+            xmin = xmin.min(o.x);
+            ymin = ymin.min(o.y);
+            xmax = xmax.max(o.x + o.width);
+            ymax = ymax.max(o.y + o.height);
+        }
+        if !any {
+            return None;
+        }
+        let w = (xmax - xmin) as u32;
+        let h = (ymax - ymin) as u32;
+        Some((w, h))
     }
 }
 
@@ -172,7 +241,31 @@ impl Emulation for WlrootsEmulation {
         }
     }
     async fn terminate(&mut self) {
-        /* nothing to do */
+        self.state.warp_pointer.destroy();
+    }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.state.union_bounds()
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let Some((width, height)) = self.state.union_bounds() else {
+            return Ok(());
+        };
+        let now: u32 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u32;
+        let cx = x.clamp(0, width as i32) as u32;
+        let cy = y.clamp(0, height as i32) as u32;
+        self.state
+            .warp_pointer
+            .motion_absolute(now, cx, cy, width, height);
+        self.state.warp_pointer.frame();
+        if let Err(e) = self.queue.flush() {
+            log::warn!("warp_cursor flush failed: {e}");
+        }
+        Ok(())
     }
 }
 
@@ -278,6 +371,38 @@ impl Dispatch<WlKeyboard, ()> for State {
     ) {
         if let wl_keyboard::Event::Keymap { format, fd, size } = event {
             state.keymap = Some((u32::from(format), fd, size));
+        }
+    }
+}
+
+impl Dispatch<WlOutput, ()> for State {
+    fn event(
+        state: &mut Self,
+        output: &WlOutput,
+        event: <WlOutput as wayland_client::Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let id = output.id().protocol_id();
+        let Some((_, info)) = state.outputs.get_mut(&id) else {
+            return;
+        };
+        match event {
+            wl_output::Event::Geometry { x, y, .. } => {
+                info.x = x;
+                info.y = y;
+            }
+            wl_output::Event::Mode {
+                flags: WEnum::Value(flags),
+                width,
+                height,
+                ..
+            } if flags.contains(wl_output::Mode::Current) => {
+                info.width = width;
+                info.height = height;
+            }
+            _ => {}
         }
     }
 }

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -31,7 +31,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
 };
 
 use wayland_client::{
-    Connection, Dispatch, EventQueue, QueueHandle, delegate_noop,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
     globals::{GlobalListContents, registry_queue_init},
     protocol::{wl_registry, wl_seat},
 };

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -31,7 +31,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
 };
 
 use wayland_client::{
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
+    Connection, Dispatch, EventQueue, QueueHandle, delegate_noop,
     globals::{GlobalListContents, registry_queue_init},
     protocol::{wl_registry, wl_seat},
 };

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -31,7 +31,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
 };
 
 use wayland_client::{
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
+    Connection, Dispatch, EventQueue, QueueHandle, delegate_noop,
     globals::{GlobalListContents, registry_queue_init},
     protocol::{wl_registry, wl_seat},
 };
@@ -355,26 +355,14 @@ impl VirtualInput {
                         // local `now` timestamp because the upstream
                         // CGEventTap path passes time=0 and some
                         // compositors filter zero-time events.
-                        let axis_n: u8 = axis;
                         let axis: Axis = (axis as u32).try_into()?;
-                        let injected = scroll_sign * value;
-                        log::info!(
-                            "[SCROLL-DEBUG emit Axis] axis={} wire_value={:.3} scroll_sign={:.1} injected={:.3}",
-                            axis_n, value, scroll_sign, injected,
-                        );
-                        self.pointer.axis(now, axis, injected);
+                        self.pointer.axis(now, axis, scroll_sign * value);
                         self.pointer.axis_source(AxisSource::Finger);
                         self.pointer.frame();
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
-                        let axis_n: u8 = axis;
-                        let wire_value = value;
                         let axis: Axis = (axis as u32).try_into()?;
                         let value = (scroll_sign as i32) * value;
-                        log::info!(
-                            "[SCROLL-DEBUG emit AxisDiscrete120] axis={} wire_value={} scroll_sign={:.1} after_sign={} cont_f64={:.3} discrete_i32={}",
-                            axis_n, wire_value, scroll_sign, value, value as f64 / 8., value / 120,
-                        );
                         self.pointer
                             .axis_discrete(now, axis, value as f64 / 8., value / 120);
                         self.pointer.axis_source(AxisSource::Wheel);

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -355,14 +355,26 @@ impl VirtualInput {
                         // local `now` timestamp because the upstream
                         // CGEventTap path passes time=0 and some
                         // compositors filter zero-time events.
+                        let axis_n: u8 = axis;
                         let axis: Axis = (axis as u32).try_into()?;
-                        self.pointer.axis(now, axis, scroll_sign * value);
+                        let injected = scroll_sign * value;
+                        log::info!(
+                            "[SCROLL-DEBUG emit Axis] axis={} wire_value={:.3} scroll_sign={:.1} injected={:.3}",
+                            axis_n, value, scroll_sign, injected,
+                        );
+                        self.pointer.axis(now, axis, injected);
                         self.pointer.axis_source(AxisSource::Finger);
                         self.pointer.frame();
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
+                        let axis_n: u8 = axis;
+                        let wire_value = value;
                         let axis: Axis = (axis as u32).try_into()?;
                         let value = (scroll_sign as i32) * value;
+                        log::info!(
+                            "[SCROLL-DEBUG emit AxisDiscrete120] axis={} wire_value={} scroll_sign={:.1} after_sign={} cont_f64={:.3} discrete_i32={}",
+                            axis_n, wire_value, scroll_sign, value, value as f64 / 8., value / 120,
+                        );
                         self.pointer
                             .axis_discrete(now, axis, value as f64 / 8., value / 120);
                         self.pointer.axis_source(AxisSource::Wheel);

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -26,7 +26,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
 };
 
 use wayland_client::{
-    Connection, Dispatch, EventQueue, QueueHandle, delegate_noop,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
     globals::{GlobalListContents, registry_queue_init},
     protocol::{wl_registry, wl_seat},
 };

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -15,6 +15,10 @@ use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
 use wayland_client::protocol::wl_output::{self, WlOutput};
 use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::wl_seat::WlSeat;
+use wayland_protocols::xdg::xdg_output::zv1::client::{
+    zxdg_output_manager_v1::ZxdgOutputManagerV1,
+    zxdg_output_v1::{self, ZxdgOutputV1},
+};
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
     zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1 as VpManager,
     zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1 as Vp,
@@ -46,7 +50,7 @@ struct State {
     /// All wl_outputs the compositor advertises, keyed by their
     /// proxy id. Updated via Geometry/Mode events. We keep the
     /// `WlOutput` proxy alive in the value so events keep flowing.
-    outputs: HashMap<u32, (WlOutput, OutputInfo)>,
+    outputs: HashMap<u32, (WlOutput, OutputInfo, Option<ZxdgOutputV1>)>,
     /// Dedicated virtual pointer used only for absolute-position
     /// warps on `Enter`. Separate from per-handle pointers so warp
     /// works regardless of which client is active.
@@ -56,12 +60,25 @@ struct State {
 #[derive(Default, Clone, Copy)]
 struct OutputInfo {
     /// Position in the compositor's global coordinate space, from
-    /// wl_output::Event::Geometry.
+    /// wl_output::Event::Geometry. Raw-pixel coordinates.
     x: i32,
     y: i32,
     /// Pixel dimensions of the active mode, from wl_output::Event::Mode.
     width: i32,
     height: i32,
+    /// Logical position in the compositor's coordinate space, from
+    /// zxdg_output_v1::Event::LogicalPosition. Reflects software
+    /// scaling (e.g. fractional or HiDPI). Falls back to (x, y) when
+    /// xdg-output isn't available.
+    logical_x: Option<i32>,
+    logical_y: Option<i32>,
+    /// Logical dimensions, from zxdg_output_v1::Event::LogicalSize.
+    /// This is the coordinate space the compositor uses for cursor
+    /// positions and the same one the capture side uses, so we
+    /// prefer it for `display_bounds()` to keep both sides in sync.
+    /// Falls back to (width, height) when xdg-output isn't available.
+    logical_width: Option<i32>,
+    logical_height: Option<i32>,
 }
 
 // App State, implements Dispatch event handlers
@@ -87,10 +104,20 @@ impl WlrootsEmulation {
         let vkm: VkManager = globals
             .bind(&qh, 1..=1, ())
             .map_err(|e| WaylandBindError::new(e, "virtual-keyboard-unstable-v1"))?;
+        // xdg-output gives us LogicalSize/LogicalPosition — the
+        // coordinate space the compositor actually uses (with
+        // software/fractional scaling applied). The capture side
+        // already reports bounds in this space, so emulation needs
+        // it too or warps land on different proportions than the
+        // sender computed. Optional: if the compositor doesn't
+        // advertise xdg_output_manager we fall back to wl_output's
+        // raw mode dimensions.
+        let xdg_output_manager: Option<ZxdgOutputManagerV1> = globals.bind(&qh, 1..=3, ()).ok();
 
         // Bind every advertised wl_output so we receive Geometry +
         // Mode events for each one. Used to compute display_bounds.
-        let mut outputs: HashMap<u32, (WlOutput, OutputInfo)> = HashMap::new();
+        let mut outputs: HashMap<u32, (WlOutput, OutputInfo, Option<ZxdgOutputV1>)> =
+            HashMap::new();
         for global in globals.contents().clone_list() {
             if global.interface == "wl_output" {
                 // version 2 is enough for Geometry + Mode events.
@@ -99,7 +126,10 @@ impl WlrootsEmulation {
                         .registry()
                         .bind(global.name, global.version.min(2), &qh, ());
                 let id = output.id().protocol_id();
-                outputs.insert(id, (output, OutputInfo::default()));
+                let xdg_output = xdg_output_manager
+                    .as_ref()
+                    .map(|mgr| mgr.get_xdg_output(&output, &qh, id));
+                outputs.insert(id, (output, OutputInfo::default(), xdg_output));
             }
         }
 
@@ -162,24 +192,30 @@ impl State {
         }
     }
 
-    /// Bounding rectangle of every active wl_output's logical
-    /// position + active mode. Returns None if no output has
-    /// reported both Geometry and Mode yet.
+    /// Bounding rectangle of every active wl_output in the
+    /// compositor's logical coordinate space (with software /
+    /// fractional scaling applied). Falls back per-output to raw
+    /// mode dimensions when xdg-output is unavailable. Returns
+    /// None if no output has reported usable size info yet.
     fn union_bounds(&self) -> Option<(u32, u32)> {
         let mut xmin = i32::MAX;
         let mut ymin = i32::MAX;
         let mut xmax = i32::MIN;
         let mut ymax = i32::MIN;
         let mut any = false;
-        for (_, o) in self.outputs.values() {
-            if o.width <= 0 || o.height <= 0 {
+        for (_, o, _) in self.outputs.values() {
+            let w = o.logical_width.unwrap_or(o.width);
+            let h = o.logical_height.unwrap_or(o.height);
+            if w <= 0 || h <= 0 {
                 continue;
             }
+            let ox = o.logical_x.unwrap_or(o.x);
+            let oy = o.logical_y.unwrap_or(o.y);
             any = true;
-            xmin = xmin.min(o.x);
-            ymin = ymin.min(o.y);
-            xmax = xmax.max(o.x + o.width);
-            ymax = ymax.max(o.y + o.height);
+            xmin = xmin.min(ox);
+            ymin = ymin.min(oy);
+            xmax = xmax.max(ox + w);
+            ymax = ymax.max(oy + h);
         }
         if !any {
             return None;
@@ -347,6 +383,33 @@ delegate_noop!(State: Vp);
 delegate_noop!(State: Vk);
 delegate_noop!(State: VpManager);
 delegate_noop!(State: VkManager);
+delegate_noop!(State: ZxdgOutputManagerV1);
+
+impl Dispatch<ZxdgOutputV1, u32> for State {
+    fn event(
+        state: &mut Self,
+        _: &ZxdgOutputV1,
+        event: <ZxdgOutputV1 as wayland_client::Proxy>::Event,
+        id: &u32,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some((_, info, _)) = state.outputs.get_mut(id) else {
+            return;
+        };
+        match event {
+            zxdg_output_v1::Event::LogicalPosition { x, y } => {
+                info.logical_x = Some(x);
+                info.logical_y = Some(y);
+            }
+            zxdg_output_v1::Event::LogicalSize { width, height } => {
+                info.logical_width = Some(width);
+                info.logical_height = Some(height);
+            }
+            _ => {}
+        }
+    }
+}
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
     fn event(
@@ -385,7 +448,7 @@ impl Dispatch<WlOutput, ()> for State {
         _: &QueueHandle<Self>,
     ) {
         let id = output.id().protocol_id();
-        let Some((_, info)) = state.outputs.get_mut(&id) else {
+        let Some((_, info, _)) = state.outputs.get_mut(&id) else {
             return;
         };
         match event {

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::os::fd::{AsFd, OwnedFd};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
+use wayland_client::Proxy;
 use wayland_client::WEnum;
 use wayland_client::backend::WaylandError;
 
@@ -330,9 +331,24 @@ impl VirtualInput {
                         let state: ButtonState = state.try_into()?;
                         self.pointer.button(time, button, state);
                     }
-                    PointerEvent::Axis { time, axis, value } => {
+                    PointerEvent::Axis {
+                        time: _,
+                        axis,
+                        value,
+                    } => {
+                        // wl_pointer requires `axis_source` to be sent
+                        // alongside the axis event; without it many
+                        // compositors (Hyprland, Sway, …) silently
+                        // drop continuous scroll. AxisSource::Finger
+                        // matches a Mac trackpad gesture, which is the
+                        // typical source for continuous scroll
+                        // forwarded by Lan Mouse. We also use the
+                        // local `now` timestamp because the upstream
+                        // CGEventTap path passes time=0 and some
+                        // compositors filter zero-time events.
                         let axis: Axis = (axis as u32).try_into()?;
-                        self.pointer.axis(time, axis, value);
+                        self.pointer.axis(now, axis, value);
+                        self.pointer.axis_source(AxisSource::Finger);
                         self.pointer.frame();
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -87,6 +87,9 @@ pub(crate) struct WlrootsEmulation {
     last_flush_failed: bool,
     state: State,
     queue: EventQueue<State>,
+    /// Whether forwarded scroll deltas should be sign-inverted.
+    /// Set via Emulation::set_natural_scroll. Default false.
+    natural_scroll: bool,
 }
 
 impl WlrootsEmulation {
@@ -154,6 +157,7 @@ impl WlrootsEmulation {
                 warp_pointer,
             },
             queue,
+            natural_scroll: false,
         };
         while emulate.state.keymap.is_none() {
             emulate.queue.blocking_dispatch(&mut emulate.state)?;
@@ -250,7 +254,7 @@ impl Emulation for WlrootsEmulation {
                 }
             }
             virtual_input
-                .consume_event(event)
+                .consume_event(event, self.natural_scroll)
                 .unwrap_or_else(|_| panic!("failed to convert event: {event:?}"));
             match self.queue.flush() {
                 Err(WaylandError::Io(e)) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -285,6 +289,10 @@ impl Emulation for WlrootsEmulation {
         self.state.union_bounds()
     }
 
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
+    }
+
     async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
         let Some((width, height)) = self.state.union_bounds() else {
             return Ok(());
@@ -313,7 +321,8 @@ struct VirtualInput {
 }
 
 impl VirtualInput {
-    fn consume_event(&self, event: Event) -> Result<(), ()> {
+    fn consume_event(&self, event: Event, natural_scroll: bool) -> Result<(), ()> {
+        let scroll_sign = if natural_scroll { -1.0 } else { 1.0 };
         let now: u32 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -347,12 +356,13 @@ impl VirtualInput {
                         // CGEventTap path passes time=0 and some
                         // compositors filter zero-time events.
                         let axis: Axis = (axis as u32).try_into()?;
-                        self.pointer.axis(now, axis, value);
+                        self.pointer.axis(now, axis, scroll_sign * value);
                         self.pointer.axis_source(AxisSource::Finger);
                         self.pointer.frame();
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         let axis: Axis = (axis as u32).try_into()?;
+                        let value = (scroll_sign as i32) * value;
                         self.pointer
                             .axis_discrete(now, axis, value as f64 / 8., value / 120);
                         self.pointer.axis_source(AxisSource::Wheel);

--- a/input-emulation/src/x11.rs
+++ b/input-emulation/src/x11.rs
@@ -15,6 +15,7 @@ use super::{Emulation, EmulationHandle, error::X11EmulationCreationError};
 
 pub(crate) struct X11Emulation {
     display: *mut xlib::Display,
+    natural_scroll: bool,
 }
 
 unsafe impl Send for X11Emulation {}
@@ -29,7 +30,10 @@ impl X11Emulation {
                 display => Ok(display),
             }
         }?;
-        Ok(Self { display })
+        Ok(Self {
+            display,
+            natural_scroll: false,
+        })
     }
 
     fn relative_motion(&self, dx: i32, dy: i32) {
@@ -118,9 +122,11 @@ impl Emulation for X11Emulation {
                     axis,
                     value,
                 } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     self.emulate_scroll(axis, value);
                 }
                 PointerEvent::AxisDiscrete120 { axis, value } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     self.emulate_scroll(axis, value as f64);
                 }
             },
@@ -177,5 +183,9 @@ impl Emulation for X11Emulation {
             xlib::XFlush(self.display);
         }
         Ok(())
+    }
+
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
     }
 }

--- a/input-emulation/src/x11.rs
+++ b/input-emulation/src/x11.rs
@@ -151,4 +151,31 @@ impl Emulation for X11Emulation {
     async fn terminate(&mut self) {
         /* nothing to do */
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        unsafe {
+            // DisplayWidth/DisplayHeight on the default screen
+            // returns the union extent of the X server's logical
+            // screen across all monitors (Xinerama / RandR).
+            let screen = xlib::XDefaultScreen(self.display);
+            let w = xlib::XDisplayWidth(self.display, screen);
+            let h = xlib::XDisplayHeight(self.display, screen);
+            if w <= 0 || h <= 0 {
+                return None;
+            }
+            Some((w as u32, h as u32))
+        }
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        unsafe {
+            let root = xlib::XDefaultRootWindow(self.display);
+            // XWarpPointer with src_w = 0 means "no source window",
+            // so the cursor moves to (x, y) relative to dest_w
+            // (the root window) regardless of where it currently is.
+            xlib::XWarpPointer(self.display, 0, root, 0, 0, 0, 0, x, y);
+            xlib::XFlush(self.display);
+        }
+        Ok(())
+    }
 }

--- a/input-emulation/src/xdg_desktop_portal.rs
+++ b/input-emulation/src/xdg_desktop_portal.rs
@@ -23,6 +23,7 @@ use super::{Emulation, EmulationHandle, error::XdpEmulationCreationError};
 pub(crate) struct DesktopPortalEmulation {
     proxy: RemoteDesktop,
     session: Session<RemoteDesktop>,
+    natural_scroll: bool,
 }
 
 impl DesktopPortalEmulation {
@@ -49,7 +50,11 @@ impl DesktopPortalEmulation {
         log::debug!("started session");
         let session = session;
 
-        Ok(Self { proxy, session })
+        Ok(Self {
+            proxy,
+            session,
+            natural_scroll: false,
+        })
     }
 }
 
@@ -86,6 +91,7 @@ impl Emulation for DesktopPortalEmulation {
                         .await?;
                 }
                 PointerEvent::AxisDiscrete120 { axis, value } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     let axis = match axis {
                         0 => Axis::Vertical,
                         _ => Axis::Horizontal,
@@ -104,6 +110,7 @@ impl Emulation for DesktopPortalEmulation {
                     axis,
                     value,
                 } => {
+                    let value = if self.natural_scroll { -value } else { value };
                     let axis = match axis {
                         0 => Axis::Vertical,
                         _ => Axis::Horizontal,
@@ -153,6 +160,11 @@ impl Emulation for DesktopPortalEmulation {
 
     async fn create(&mut self, _client: EmulationHandle) {}
     async fn destroy(&mut self, _client: EmulationHandle) {}
+
+    fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        self.natural_scroll = natural_scroll;
+    }
+
     async fn terminate(&mut self) {
         if let Err(e) = self.session.close().await {
             log::warn!("session.close(): {e}");

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -37,7 +37,7 @@
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title">sha256 fingerprint</property>
+                <property name="title">SHA-256 fingerprint</property>
                 <child>
                   <object class="AdwActionRow">
                     <property name="child">

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -4,20 +4,24 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="AuthorizationWindow" parent="AdwWindow">
     <property name="modal">True</property>
+    <property name="resizable">False</property>
     <property name="width-request">280</property>
     <property name="default-width">460</property>
-    <property name="height-request">320</property>
-    <property name="default-height">320</property>
     <property name="title" translatable="yes">Unauthorized Device</property>
     <property name="content">
       <object class="AdwToolbarView">
         <child type="top">
-            <object class="AdwHeaderBar"/>
+            <object class="AdwHeaderBar">
+              <style>
+                <class name="flat"/>
+              </style>
+            </object>
         </child>
         <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">800</property>
             <property name="tightening-threshold">0</property>
+            <property name="valign">start</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="orientation">vertical</property>

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -4,10 +4,10 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="AuthorizationWindow" parent="AdwWindow">
     <property name="modal">True</property>
-    <property name="width-request">180</property>
-    <property name="default-width">180</property>
-    <property name="height-request">180</property>
-    <property name="default-height">180</property>
+    <property name="width-request">560</property>
+    <property name="default-width">560</property>
+    <property name="height-request">320</property>
+    <property name="default-height">320</property>
     <property name="title" translatable="yes">Unauthorized Device</property>
     <property name="content">
       <object class="GtkBox">

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -10,92 +10,84 @@
     <property name="default-height">320</property>
     <property name="title" translatable="yes">Unauthorized Device</property>
     <property name="content">
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="vexpand">True</property>
+      <object class="AdwToolbarView">
         <child type="top">
-          <object class="AdwHeaderBar">
-            <style>
-              <class name="flat"/>
-            </style>
-          </object>
+            <object class="AdwHeaderBar"/>
         </child>
-        <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">30</property>
-            <property name="margin-start">30</property>
-            <property name="margin-end">30</property>
-            <property name="margin-top">30</property>
-            <property name="margin-bottom">30</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label">An unauthorized Device is trying to connect. Do you want to authorize this Device?</property>
-                <property name="width-request">100</property>
-                <property name="wrap">word-wrap</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwPreferencesGroup">
-                <property name="title">SHA-256 Fingerprint</property>
+        <property name="content">
+          <object class="AdwClamp">
+            <property name="maximum-size">800</property>
+            <property name="tightening-threshold">0</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="spacing">18</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
                 <child>
-                  <object class="AdwActionRow">
-                    <property name="child">
-                      <object class="GtkLabel" id="fingerprint">
-                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-                        <property name="vexpand">True</property>
-                        <property name="hexpand">False</property>
-                        <property name="wrap">True</property>
-                        <property name="wrap-mode">word-char</property>
-                        <property name="justify">center</property>
-                        <property name="xalign">0.5</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">10</property>
-                        <property name="margin-start">10</property>
-                        <property name="margin-end">10</property>
-                        <property name="width-chars">64</property>
+                  <object class="GtkLabel">
+                    <property name="label">An unauthorized Device is trying to connect. Do you want to authorize this Device?</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">SHA-256 Fingerprint</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="heading"/>
+                        </style>
                       </object>
-                    </property>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="fingerprint">
+                        <property name="editable">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">horizontal</property>
+                    <property name="spacing">12</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkButton" id="cancel_button">
+                        <signal name="clicked" handler="handle_cancel" swapped="true"/>
+                        <property name="label" translatable="yes">Cancel</property>
+                        <property name="can-shrink">True</property>
+                        <style>
+                          <class name="pill"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="confirm_button">
+                        <signal name="clicked" handler="handle_confirm" swapped="true"/>
+                        <property name="label" translatable="yes">Authorize</property>
+                        <property name="can-shrink">True</property>
+                        <style>
+                          <class name="pill"/>
+                          <class name="destructive-action"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
-            </child>
+            </property>
           </object>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="margin-start">30</property>
-            <property name="margin-end">30</property>
-            <property name="margin-top">30</property>
-            <property name="margin-bottom">30</property>
-            <property name="orientation">horizontal</property>
-            <property name="spacing">30</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="valign">end</property>
-            <child>
-              <object class="GtkButton" id="cancel_button">
-                <signal name="clicked" handler="handle_cancel" swapped="true"/>
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="can-shrink">True</property>
-                <property name="height-request">50</property>
-                <property name="hexpand">True</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="confirm_button">
-                <signal name="clicked" handler="handle_confirm" swapped="true"/>
-                <property name="label" translatable="yes">Authorize</property>
-                <property name="can-shrink">True</property>
-                <property name="height-request">50</property>
-                <property name="hexpand">True</property>
-                <style>
-                  <class name="destructive-action"/>
-                </style>
-              </object>
-            </child>
-          </object>
-        </child>
+        </property>
       </object>
     </property>
   </template>

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -37,7 +37,7 @@
             </child>
             <child>
               <object class="AdwPreferencesGroup">
-                <property name="title">SHA-256 fingerprint</property>
+                <property name="title">SHA-256 Fingerprint</property>
                 <child>
                   <object class="AdwActionRow">
                     <property name="child">

--- a/lan-mouse-gtk/resources/authorization_window.ui
+++ b/lan-mouse-gtk/resources/authorization_window.ui
@@ -4,8 +4,8 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="AuthorizationWindow" parent="AdwWindow">
     <property name="modal">True</property>
-    <property name="width-request">560</property>
-    <property name="default-width">560</property>
+    <property name="width-request">280</property>
+    <property name="default-width">460</property>
     <property name="height-request">320</property>
     <property name="default-height">320</property>
     <property name="title" translatable="yes">Unauthorized Device</property>

--- a/lan-mouse-gtk/resources/client_row.ui
+++ b/lan-mouse-gtk/resources/client_row.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
 	<template class="ClientRow" parent="AdwExpanderRow">
-		<property name="title">hostname</property>
+		<property name="title">Hostname</property>
 		<!-- enabled -->
 		<child type="prefix">
 			<object class="GtkSwitch" id="enable_switch">
 				<property name="valign">center</property>
 				<property name="halign">end</property>
-				<property name="tooltip-text" translatable="yes">enable</property>
+				<property name="tooltip-text" translatable="yes">Enable</property>
 			</object>
 		</child>
 		<child type="suffix">
@@ -17,7 +17,7 @@
 				<property name="icon-name">network-wired-symbolic</property>
 				<property name="valign">center</property>
 				<property name="halign">end</property>
-				<property name="tooltip-text" translatable="yes">resolve host</property>
+				<property name="tooltip-text" translatable="yes">Resolve host</property>
 			</object>
 		</child>
 		<child type="suffix">
@@ -27,15 +27,15 @@
 		<!-- host -->
 		<child>
 			<object class="AdwActionRow">
-				<property name="title">hostname</property>
-				<property name="subtitle">port</property>
+				<property name="title">Hostname</property>
+				<property name="subtitle">Port</property>
 				<!-- hostname -->
 				<child>
 					<object class="GtkEntry" id="hostname">
 						<!-- <property name="title" translatable="yes">hostname</property> -->
 						<property name="xalign">0.5</property>
 						<property name="valign">center</property>
-						<property name="placeholder-text">hostname</property>
+						<property name="placeholder-text">Hostname</property>
 						<property name="width-chars">-1</property>
 					</object>
 				</child>
@@ -56,7 +56,7 @@
 		<!-- position -->
 		<child>
 			<object class="AdwComboRow" id="position">
-				<property name="title" translatable="yes">position</property>
+				<property name="title" translatable="yes">Position</property>
 				<property name="model">
 					<object class="GtkStringList">
 						<items>
@@ -72,7 +72,7 @@
 		<!-- delete button -->
 		<child>
 			<object class="AdwActionRow" id="delete_row">
-				<property name="title">delete this client</property>
+				<property name="title">Delete this client</property>
 				<child>
 					<object class="GtkButton" id="delete_button">
 						<signal name="activate" handler="handle_client_delete" object="delete_row" swapped="true"/>

--- a/lan-mouse-gtk/resources/client_row.ui
+++ b/lan-mouse-gtk/resources/client_row.ui
@@ -24,26 +24,28 @@
 			<object class="GtkSpinner" id="dns_loading_indicator">
 			</object>
 		</child>
-		<!-- host -->
+		<!-- hostname -->
 		<child>
 			<object class="AdwActionRow">
-				<property name="title">Hostname</property>
-				<property name="subtitle">Port</property>
-				<!-- hostname -->
+				<property name="title" translatable="yes">Hostname</property>
+				<property name="subtitle" translatable="yes">IP address or DNS hostname</property>
 				<child>
 					<object class="GtkEntry" id="hostname">
-						<!-- <property name="title" translatable="yes">hostname</property> -->
 						<property name="xalign">0.5</property>
 						<property name="valign">center</property>
-						<property name="placeholder-text">Hostname</property>
+						<property name="placeholder-text">192.168.1.42</property>
 						<property name="width-chars">-1</property>
 					</object>
 				</child>
-				<!-- port -->
+			</object>
+		</child>
+		<!-- port -->
+		<child>
+			<object class="AdwActionRow">
+				<property name="title" translatable="yes">Port</property>
 				<child>
 					<object class="GtkEntry" id="port">
-						<!-- <property name="title" translatable="yes">port</property> -->
-                        <property name="max-width-chars">5</property>
+						<property name="max-width-chars">5</property>
 						<property name="input_purpose">GTK_INPUT_PURPOSE_NUMBER</property>
 						<property name="xalign">0.5</property>
 						<property name="valign">center</property>

--- a/lan-mouse-gtk/resources/client_row.ui
+++ b/lan-mouse-gtk/resources/client_row.ui
@@ -59,6 +59,7 @@
 		<child>
 			<object class="AdwComboRow" id="position">
 				<property name="title" translatable="yes">Position</property>
+				<property name="subtitle" translatable="yes">Where this device sits relative to your screen.</property>
 				<property name="model">
 					<object class="GtkStringList">
 						<items>
@@ -74,7 +75,7 @@
 		<!-- delete button -->
 		<child>
 			<object class="AdwActionRow" id="delete_row">
-				<property name="title">Delete this client</property>
+				<property name="title">Delete This Client</property>
 				<child>
 					<object class="GtkButton" id="delete_button">
 						<signal name="activate" handler="handle_client_delete" object="delete_row" swapped="true"/>

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -34,7 +34,7 @@
                 </child>
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title">description</property>
+                    <property name="title">Description</property>
                     <child>
                       <object class="AdwActionRow">
                         <property name="child">
@@ -55,7 +55,7 @@
                 </child>
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title">sha256 fingerprint</property>
+                    <property name="title">SHA-256 fingerprint</property>
                     <child>
                       <object class="AdwActionRow">
                         <property name="child">

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -29,7 +29,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="label">You can find it under the `General` section of the device you want to connect</property>
+                    <property name="label">You can find it under the `General` section of the device you want to connect.</property>
                   </object>
                 </child>
                 <child>
@@ -55,7 +55,7 @@
                 </child>
                 <child>
                   <object class="AdwPreferencesGroup">
-                    <property name="title">SHA-256 fingerprint</property>
+                    <property name="title">SHA-256 Fingerprint</property>
                     <child>
                       <object class="AdwActionRow">
                         <property name="child">

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -4,20 +4,24 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="FingerprintWindow" parent="AdwWindow">
     <property name="modal">True</property>
+    <property name="resizable">False</property>
     <property name="width-request">280</property>
     <property name="default-width">460</property>
-    <property name="height-request">380</property>
-    <property name="default-height">380</property>
     <property name="title" translatable="yes">Add Certificate Fingerprint</property>
     <property name="content">
       <object class="AdwToolbarView">
         <child type="top">
-            <object class="AdwHeaderBar"/>
+            <object class="AdwHeaderBar">
+              <style>
+                <class name="flat"/>
+              </style>
+            </object>
         </child>
         <property name="content">
           <object class="AdwClamp">
             <property name="maximum-size">800</property>
             <property name="tightening-threshold">0</property>
+            <property name="valign">start</property>
             <property name="child">
               <object class="GtkBox">
                 <property name="orientation">vertical</property>
@@ -46,6 +50,7 @@
                   <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
+                    <property name="margin-top">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="label">Description</property>

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -4,8 +4,8 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="FingerprintWindow" parent="AdwWindow">
     <property name="modal">True</property>
-    <property name="width-request">560</property>
-    <property name="default-width">560</property>
+    <property name="width-request">280</property>
+    <property name="default-width">460</property>
     <property name="height-request">380</property>
     <property name="default-height">380</property>
     <property name="title" translatable="yes">Add Certificate Fingerprint</property>

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -22,54 +22,64 @@
               <object class="GtkBox">
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="label">The certificate fingerprint serves as a unique identifier for your device.</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="xalign">0</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
                     <property name="label">You can find it under the `General` section of the device you want to connect.</property>
+                    <property name="wrap">True</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="xalign">0</property>
                   </object>
                 </child>
                 <child>
-                  <object class="AdwPreferencesGroup">
-                    <property name="title">Description</property>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="AdwActionRow">
-                        <property name="child">
-                          <object class="GtkText" id="description">
-                            <property name="margin-top">10</property>
-                            <property name="margin-bottom">10</property>
-                            <property name="margin-start">10</property>
-                            <property name="margin-end">10</property>
-                            <property name="enable-undo">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="max-length">0</property>
-                          </object>
-                        </property>
+                      <object class="GtkLabel">
+                        <property name="label">Description</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="heading"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="description">
+                        <property name="enable-undo">True</property>
+                        <property name="hexpand">True</property>
                       </object>
                     </child>
                   </object>
                 </child>
                 <child>
-                  <object class="AdwPreferencesGroup">
-                    <property name="title">SHA-256 Fingerprint</property>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="AdwActionRow">
-                        <property name="child">
-                          <object class="GtkText" id="fingerprint">
-                            <property name="margin-top">10</property>
-                            <property name="margin-bottom">10</property>
-                            <property name="margin-start">10</property>
-                            <property name="margin-end">10</property>
-                            <property name="enable-undo">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="max-length">0</property>
-                          </object>
-                        </property>
+                      <object class="GtkLabel">
+                        <property name="label">SHA-256 Fingerprint</property>
+                        <property name="xalign">0</property>
+                        <style>
+                          <class name="heading"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="fingerprint">
+                        <property name="enable-undo">True</property>
+                        <property name="hexpand">True</property>
                       </object>
                     </child>
                   </object>

--- a/lan-mouse-gtk/resources/fingerprint_window.ui
+++ b/lan-mouse-gtk/resources/fingerprint_window.ui
@@ -4,8 +4,8 @@
   <requires lib="libadwaita" version="1.0"/>
   <template class="FingerprintWindow" parent="AdwWindow">
     <property name="modal">True</property>
-    <property name="width-request">880</property>
-    <property name="default-width">880</property>
+    <property name="width-request">560</property>
+    <property name="default-width">560</property>
     <property name="height-request">380</property>
     <property name="default-height">380</property>
     <property name="title" translatable="yes">Add Certificate Fingerprint</property>
@@ -16,7 +16,7 @@
         </child>
         <property name="content">
           <object class="AdwClamp">
-            <property name="maximum-size">770</property>
+            <property name="maximum-size">800</property>
             <property name="tightening-threshold">0</property>
             <property name="child">
               <object class="GtkBox">

--- a/lan-mouse-gtk/resources/key_row.ui
+++ b/lan-mouse-gtk/resources/key_row.ui
@@ -5,7 +5,7 @@
 			<object class="GtkButton" id="delete_button">
 				<property name="valign">center</property>
 				<property name="halign">end</property>
-				<property name="tooltip-text" translatable="yes">revoke authorization</property>
+				<property name="tooltip-text" translatable="yes">Revoke authorization</property>
                 <property name="icon-name">edit-delete-symbolic</property>
 				<style>
                     <class name="flat"/>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -10,7 +10,7 @@
   </menu>
   <template class="LanMouseWindow" parent="AdwApplicationWindow">
     <property name="default-width">600</property>
-    <property name="default-height">700</property>
+    <property name="default-height">1400</property>
     <property name="title" translatable="yes">Lan Mouse</property>
     <property name="show-menubar">True</property>
     <property name="content">

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -32,11 +32,18 @@
         <child>
           <object class="AdwToastOverlay" id="toast_overlay">
             <child>
-              <object class="AdwStatusPage">
-                <property name="title" translatable="yes">Lan Mouse</property>
-                <property name="description" translatable="yes">easily use your mouse and keyboard on multiple computers</property>
-                <property name="icon-name">de.feschber.LanMouse</property>
-                <property name="child">
+              <object class="GtkScrolledWindow">
+                <property name="vexpand">true</property>
+                <property name="hexpand">true</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">automatic</property>
+                <property name="propagate-natural-height">true</property>
+                <child>
+                  <object class="AdwStatusPage">
+                    <property name="title" translatable="yes">Lan Mouse</property>
+                    <property name="description" translatable="yes">easily use your mouse and keyboard on multiple computers</property>
+                    <property name="icon-name">de.feschber.LanMouse</property>
+                    <property name="child">
                   <object class="AdwClamp">
                   <property name="maximum-size">600</property>
                   <property name="tightening-threshold">0</property>
@@ -320,6 +327,8 @@
                   </property>
                   </object>
                 </property>
+              </object>
+                </child>
               </object>
             </child>
           </object>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -200,6 +200,58 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Auto-release</property>
+                        <property name="description" translatable="yes">Auto-release capture when the cursor reaches the host-adjacent edge of the guest and you keep pushing. 0 disables; rely on the release-bind chord or a peer-side leave event.</property>
+                        <child>
+                          <object class="AdwActionRow" id="release_threshold_row">
+                            <property name="title" translatable="yes">Release threshold</property>
+                            <property name="subtitle" translatable="yes">pixels of wall-press past the entry edge before auto-release fires</property>
+                            <child type="suffix">
+                              <object class="GtkLabel" id="release_threshold_value">
+                                <property name="label">disabled</property>
+                                <property name="valign">center</property>
+                                <property name="width-chars">8</property>
+                                <property name="xalign">1.0</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                  <class name="numeric"/>
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="release_threshold_scale">
+                            <property name="orientation">horizontal</property>
+                            <property name="hexpand">true</property>
+                            <property name="draw-value">false</property>
+                            <property name="round-digits">0</property>
+                            <property name="margin-start">12</property>
+                            <property name="margin-end">12</property>
+                            <property name="margin-top">4</property>
+                            <property name="margin-bottom">8</property>
+                            <property name="adjustment">
+                              <object class="GtkAdjustment" id="release_threshold_adjustment">
+                                <property name="lower">0</property>
+                                <property name="upper">500</property>
+                                <property name="step-increment">10</property>
+                                <property name="page-increment">50</property>
+                                <property name="value">0</property>
+                              </object>
+                            </property>
+                            <marks>
+                              <mark value="0" position="bottom">off</mark>
+                              <mark value="50" position="bottom">50</mark>
+                              <mark value="100" position="bottom">100</mark>
+                              <mark value="200" position="bottom">200</mark>
+                              <mark value="500" position="bottom">500</mark>
+                            </marks>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Connections</property>
                         <property name="header-suffix">
                           <object class="GtkButton">

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -9,8 +9,8 @@
     </item>
   </menu>
   <template class="LanMouseWindow" parent="AdwApplicationWindow">
-    <property name="width-request">600</property>
-    <property name="height-request">700</property>
+    <property name="default-width">600</property>
+    <property name="default-height">700</property>
     <property name="title" translatable="yes">Lan Mouse</property>
     <property name="show-menubar">True</property>
     <property name="content">
@@ -37,7 +37,6 @@
                 <property name="hexpand">true</property>
                 <property name="hscrollbar-policy">never</property>
                 <property name="vscrollbar-policy">automatic</property>
-                <property name="propagate-natural-height">true</property>
                 <child>
                   <object class="AdwStatusPage">
                     <property name="title" translatable="yes">Lan Mouse</property>
@@ -51,6 +50,7 @@
                     <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <property name="spacing">12</property>
+                    <property name="margin-bottom">36</property>
                     <child>
                       <object class="AdwPreferencesGroup" id="capture_emulation_group">
                       <property name="title" translatable="yes">Capture / Emulation Status</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -49,7 +49,7 @@
                   <property name="child">
                     <object class="GtkBox">
                     <property name="orientation">vertical</property>
-                    <property name="spacing">12</property>
+                    <property name="spacing">24</property>
                     <property name="margin-bottom">36</property>
                     <child>
                       <object class="AdwPreferencesGroup" id="capture_emulation_group">
@@ -233,6 +233,7 @@
                             <property name="hexpand">true</property>
                             <property name="draw-value">false</property>
                             <property name="round-digits">0</property>
+                            <property name="margin-top">12</property>
                             <property name="adjustment">
                               <object class="GtkAdjustment" id="release_threshold_adjustment">
                                 <property name="lower">0</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -258,11 +258,10 @@
                     <child>
                       <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Scroll</property>
-                        <property name="description" translatable="yes">Behavior of scroll events received from peer machines. Mirrors the libinput natural_scroll preference for forwarded events, which bypass libinput on Wayland.</property>
                         <child>
                           <object class="AdwActionRow" id="natural_scroll_row">
                             <property name="title" translatable="yes">Natural scrolling</property>
-                            <property name="subtitle" translatable="yes">invert the direction of forwarded scroll events to match a natural-scroll setup</property>
+                            <property name="subtitle" translatable="yes">invert the direction of forwarded scroll events</property>
                             <child type="suffix">
                               <object class="GtkSwitch" id="natural_scroll_switch">
                                 <property name="valign">center</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -257,22 +257,6 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Scroll</property>
-                        <child>
-                          <object class="AdwActionRow" id="natural_scroll_row">
-                            <property name="title" translatable="yes">Natural scrolling</property>
-                            <property name="subtitle" translatable="yes">invert the direction of forwarded scroll events</property>
-                            <child type="suffix">
-                              <object class="GtkSwitch" id="natural_scroll_switch">
-                                <property name="valign">center</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Outgoing Connections</property>
                         <property name="header-suffix">
                           <object class="GtkButton">
@@ -333,6 +317,23 @@
                             <style>
                               <class name="boxed-list" />
                             </style>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Scroll Direction</property>
+                        <property name="description" translatable="yes">Forwarded scroll events bypass OS-level preferences. Choose a scroll direction below.</property>
+                        <child>
+                          <object class="AdwActionRow" id="natural_scroll_row">
+                            <property name="title" translatable="yes">Natural Scrolling</property>
+                            <property name="subtitle" translatable="yes">Invert the direction of forwarded scroll events.</property>
+                            <child type="suffix">
+                              <object class="GtkSwitch" id="natural_scroll_switch">
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -37,6 +37,7 @@
                 <property name="hexpand">true</property>
                 <property name="hscrollbar-policy">never</property>
                 <property name="vscrollbar-policy">automatic</property>
+                <property name="propagate-natural-height">true</property>
                 <child>
                   <object class="AdwStatusPage">
                     <property name="title" translatable="yes">Lan Mouse</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -44,7 +44,7 @@
                     <property name="icon-name">de.feschber.LanMouse</property>
                     <property name="child">
                   <object class="AdwClamp">
-                  <property name="maximum-size">600</property>
+                  <property name="maximum-size">800</property>
                   <property name="tightening-threshold">0</property>
                   <property name="child">
                     <object class="GtkBox">
@@ -128,7 +128,7 @@
                         -->
                         <child>
                           <object class="AdwActionRow">
-                            <property name="title">Hostname &#38;amp; port</property>
+                            <property name="title">Hostname &#38;amp; Port</property>
                             <child>
                               <object class="GtkButton" id="copy-hostname-button">
                                     <!--<property name="icon-name">edit-copy-symbolic</property>-->
@@ -192,7 +192,7 @@
                         </child>
                         <child>
                           <object class="AdwActionRow" id="fingerprint_row">
-                            <property name="title">Certificate fingerprint</property>
+                            <property name="title">Certificate Fingerprint</property>
                             <property name="icon-name">auth-fingerprint-symbolic</property>
                             <child>
                               <object class="GtkButton" id="copy-fingerprint-button">
@@ -211,7 +211,7 @@
                         <property name="description" translatable="yes">Fallback release when the peer can't tell us the cursor reached its edge — typically because the peer's screen is locked. No effect on peers that release themselves; the cursor-release keybind still works either way.</property>
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
-                            <property name="title" translatable="yes">Release threshold</property>
+                            <property name="title" translatable="yes">Release Threshold</property>
                             <property name="subtitle" translatable="yes">Pixels of wall-press past the entry edge before auto-release fires</property>
                             <child type="suffix">
                               <object class="GtkLabel" id="release_threshold_value">
@@ -255,7 +255,7 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Connections</property>
+                        <property name="title" translatable="yes">Outgoing Connections</property>
                         <property name="header-suffix">
                           <object class="GtkButton">
                             <signal name="clicked" handler="handle_add_client_pressed" swapped="true"/>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -200,8 +200,8 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Auto-release</property>
-                        <property name="description" translatable="yes">Auto-release capture when the cursor reaches the host-adjacent edge of the guest and you keep pushing. 0 disables; rely on the release-bind chord or a peer-side leave event.</property>
+                        <property name="title" translatable="yes">Outgoing Auto-Release</property>
+                        <property name="description" translatable="yes">When this machine is capturing input for a peer, releases capture automatically once the cursor pushes past the host-adjacent edge. With the slider off, release still happens via the bind chord or a peer-side leave event. Useful when crossing one or more lock screens between machines.</property>
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release threshold</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -56,8 +56,8 @@
                       <property name="title" translatable="yes">Capture / Emulation Status</property>
                         <child>
                           <object class="AdwActionRow" id="capture_status_row">
-                            <property name="title">Input capture is disabled</property>
-                            <property name="subtitle">Required for outgoing and incoming connections</property>
+                            <property name="title">Input Capture Disabled</property>
+                            <property name="subtitle">Required for outgoing and incoming connections.</property>
                             <property name="icon-name">dialog-warning-symbolic</property>
                             <child>
                               <object class="GtkButton" id="input_capture_button">
@@ -82,8 +82,8 @@
                         </child>
                         <child>
                           <object class="AdwActionRow" id="emulation_status_row">
-                            <property name="title">Input emulation is disabled</property>
-                            <property name="subtitle">Required for incoming connections</property>
+                            <property name="title">Input Emulation Disabled</property>
+                            <property name="subtitle">Required for incoming connections.</property>
                             <property name="icon-name">dialog-warning-symbolic</property>
                             <child>
                               <object class="GtkButton" id="input_emulation_button">
@@ -212,7 +212,7 @@
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release Threshold</property>
-                            <property name="subtitle" translatable="yes">Pixels of wall-press past the entry edge before auto-release fires</property>
+                            <property name="subtitle" translatable="yes">Pixels of wall-press past the entry edge before auto-release fires.</property>
                             <child type="suffix">
                               <object class="GtkLabel" id="release_threshold_value">
                                 <property name="label">Disabled</property>
@@ -276,8 +276,8 @@
                             <property name="selection-mode">none</property>
                             <child type="placeholder">
                               <object class="AdwActionRow" id="client_placeholder">
-                                <property name="title">No connections!</property>
-                                <property name="subtitle">Add a new client via the + button</property>
+                                <property name="title">No Connections</property>
+                                <property name="subtitle">Add a new client via the + button.</property>
                               </object>
                             </child>
                             <style>
@@ -309,8 +309,8 @@
                             <property name="selection-mode">none</property>
                             <child type="placeholder">
                               <object class="AdwActionRow" id="authorized_placeholder">
-                                <property name="title">No devices registered</property>
-                                <property name="subtitle">Authorize a new device via the "Authorize" button</property>
+                                <property name="title">No Devices Registered</property>
+                                <property name="subtitle">Authorize a new device via the "Authorize" button.</property>
                               </object>
                             </child>
                             <style>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -323,6 +323,23 @@
                         </child>
                       </object>
                     </child>
+                    <child>
+                      <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Network Discovery</property>
+                        <property name="description" translatable="yes">Advertise (and consume) Bonjour records so peers can pick the OS-preferred interface on multi-homed hosts. Turn off on networks where mDNS multicast is firewalled.</property>
+                        <child>
+                          <object class="AdwActionRow" id="mdns_discovery_row">
+                            <property name="title" translatable="yes">mDNS Discovery</property>
+                            <property name="subtitle" translatable="yes">Use _lan-mouse._udp.local. for service order hints.</property>
+                            <child type="suffix">
+                              <object class="GtkSwitch" id="mdns_discovery_switch">
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                     </object>
                   </property>
                   </object>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -201,7 +201,7 @@
                     <child>
                       <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Outgoing Auto-Release</property>
-                        <property name="description" translatable="yes">When this machine is capturing input for a peer, releases capture automatically once the cursor pushes past the host-adjacent edge. With the slider off, release still happens via the bind chord or a peer-side leave event. Useful when crossing one or more lock screens between machines.</property>
+                        <property name="description" translatable="yes">Fallback release when the peer can't tell us the cursor reached its edge — typically because the peer's screen is locked. No effect on peers that release themselves; the cursor-release keybind still works either way.</property>
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release threshold</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -37,7 +37,6 @@
                 <property name="hexpand">true</property>
                 <property name="hscrollbar-policy">never</property>
                 <property name="vscrollbar-policy">automatic</property>
-                <property name="propagate-natural-height">true</property>
                 <child>
                   <object class="AdwStatusPage">
                     <property name="title" translatable="yes">Lan Mouse</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -41,7 +41,7 @@
                 <child>
                   <object class="AdwStatusPage">
                     <property name="title" translatable="yes">Lan Mouse</property>
-                    <property name="description" translatable="yes">easily use your mouse and keyboard on multiple computers</property>
+                    <property name="description" translatable="yes">Easily use your mouse and keyboard on multiple computers.</property>
                     <property name="icon-name">de.feschber.LanMouse</property>
                     <property name="child">
                   <object class="AdwClamp">
@@ -56,8 +56,8 @@
                       <property name="title" translatable="yes">Capture / Emulation Status</property>
                         <child>
                           <object class="AdwActionRow" id="capture_status_row">
-                            <property name="title">input capture is disabled</property>
-                            <property name="subtitle">required for outgoing and incoming connections</property>
+                            <property name="title">Input capture is disabled</property>
+                            <property name="subtitle">Required for outgoing and incoming connections</property>
                             <property name="icon-name">dialog-warning-symbolic</property>
                             <child>
                               <object class="GtkButton" id="input_capture_button">
@@ -82,8 +82,8 @@
                         </child>
                         <child>
                           <object class="AdwActionRow" id="emulation_status_row">
-                            <property name="title">input emulation is disabled</property>
-                            <property name="subtitle">required for incoming connections</property>
+                            <property name="title">Input emulation is disabled</property>
+                            <property name="subtitle">Required for incoming connections</property>
                             <property name="icon-name">dialog-warning-symbolic</property>
                             <child>
                               <object class="GtkButton" id="input_emulation_button">
@@ -128,7 +128,7 @@
                         -->
                         <child>
                           <object class="AdwActionRow">
-                            <property name="title">hostname &#38;amp; port</property>
+                            <property name="title">Hostname &#38;amp; port</property>
                             <child>
                               <object class="GtkButton" id="copy-hostname-button">
                                     <!--<property name="icon-name">edit-copy-symbolic</property>-->
@@ -192,7 +192,7 @@
                         </child>
                         <child>
                           <object class="AdwActionRow" id="fingerprint_row">
-                            <property name="title">certificate fingerprint</property>
+                            <property name="title">Certificate fingerprint</property>
                             <property name="icon-name">auth-fingerprint-symbolic</property>
                             <child>
                               <object class="GtkButton" id="copy-fingerprint-button">
@@ -212,10 +212,10 @@
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release threshold</property>
-                            <property name="subtitle" translatable="yes">pixels of wall-press past the entry edge before auto-release fires</property>
+                            <property name="subtitle" translatable="yes">Pixels of wall-press past the entry edge before auto-release fires</property>
                             <child type="suffix">
                               <object class="GtkLabel" id="release_threshold_value">
-                                <property name="label">disabled</property>
+                                <property name="label">Disabled</property>
                                 <property name="valign">center</property>
                                 <property name="width-chars">8</property>
                                 <property name="xalign">1.0</property>
@@ -233,10 +233,6 @@
                             <property name="hexpand">true</property>
                             <property name="draw-value">false</property>
                             <property name="round-digits">0</property>
-                            <property name="margin-start">12</property>
-                            <property name="margin-end">12</property>
-                            <property name="margin-top">4</property>
-                            <property name="margin-bottom">8</property>
                             <property name="adjustment">
                               <object class="GtkAdjustment" id="release_threshold_adjustment">
                                 <property name="lower">0</property>
@@ -280,7 +276,7 @@
                             <child type="placeholder">
                               <object class="AdwActionRow" id="client_placeholder">
                                 <property name="title">No connections!</property>
-                                <property name="subtitle">add a new client via the + button</property>
+                                <property name="subtitle">Add a new client via the + button</property>
                               </object>
                             </child>
                             <style>
@@ -312,8 +308,8 @@
                             <property name="selection-mode">none</property>
                             <child type="placeholder">
                               <object class="AdwActionRow" id="authorized_placeholder">
-                                <property name="title">no devices registered!</property>
-                                <property name="subtitle">authorize a new device via the "Authorize" button</property>
+                                <property name="title">No devices registered</property>
+                                <property name="subtitle">Authorize a new device via the "Authorize" button</property>
                               </object>
                             </child>
                             <style>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -257,6 +257,23 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Scroll</property>
+                        <property name="description" translatable="yes">Behavior of scroll events received from peer machines. Mirrors the libinput natural_scroll preference for forwarded events, which bypass libinput on Wayland.</property>
+                        <child>
+                          <object class="AdwActionRow" id="natural_scroll_row">
+                            <property name="title" translatable="yes">Natural scrolling</property>
+                            <property name="subtitle" translatable="yes">invert the direction of forwarded scroll events to match a natural-scroll setup</property>
+                            <child type="suffix">
+                              <object class="GtkSwitch" id="natural_scroll_switch">
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Outgoing Connections</property>
                         <property name="header-suffix">
                           <object class="GtkButton">

--- a/lan-mouse-gtk/src/authorization_window/imp.rs
+++ b/lan-mouse-gtk/src/authorization_window/imp.rs
@@ -4,8 +4,8 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::subclass::InitializingObject;
 use gtk::{
-    Button, CompositeTemplate, Entry,
-    glib::{self, subclass::Signal},
+    Button, CompositeTemplate, Entry, EventControllerKey, gdk,
+    glib::{self, Propagation, subclass::Signal},
     template_callbacks,
 };
 
@@ -67,6 +67,26 @@ impl ObjectImpl for AuthorizationWindow {
                 Signal::builder("cancel-clicked").build(),
             ]
         })
+    }
+
+    fn constructed(&self) {
+        self.parent_constructed();
+
+        // Close on Escape — same affordance as the fingerprint dialog.
+        let obj = self.obj();
+        let key = EventControllerKey::new();
+        let weak_close = obj.downgrade();
+        key.connect_key_pressed(move |_, keyval, _, _| {
+            if keyval == gdk::Key::Escape {
+                if let Some(w) = weak_close.upgrade() {
+                    w.close();
+                }
+                Propagation::Stop
+            } else {
+                Propagation::Proceed
+            }
+        });
+        obj.add_controller(key);
     }
 }
 

--- a/lan-mouse-gtk/src/authorization_window/imp.rs
+++ b/lan-mouse-gtk/src/authorization_window/imp.rs
@@ -4,7 +4,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::subclass::InitializingObject;
 use gtk::{
-    Button, CompositeTemplate, Label,
+    Button, CompositeTemplate, Entry,
     glib::{self, subclass::Signal},
     template_callbacks,
 };
@@ -13,7 +13,7 @@ use gtk::{
 #[template(resource = "/de/feschber/LanMouse/authorization_window.ui")]
 pub struct AuthorizationWindow {
     #[template_child]
-    pub fingerprint: TemplateChild<Label>,
+    pub fingerprint: TemplateChild<Entry>,
     #[template_child]
     pub cancel_button: TemplateChild<Button>,
     #[template_child]

--- a/lan-mouse-gtk/src/client_object.rs
+++ b/lan-mouse-gtk/src/client_object.rs
@@ -26,12 +26,21 @@ impl ClientObject {
                     .collect::<Vec<_>>(),
             )
             .property("resolving", state.resolving)
+            .property("peer-commit", peer_commit_to_string(state.peer_commit))
             .build()
     }
 
     pub fn get_data(&self) -> ClientData {
         self.imp().data.borrow().clone()
     }
+}
+
+/// Render the 8-byte ASCII commit hash carried in
+/// [`lan_mouse_ipc::ClientState::peer_commit`] as a `String`. `None`
+/// in → `None` out (peer hasn't sent a Hello yet, or speaks an older
+/// proto).
+pub fn peer_commit_to_string(commit: Option<[u8; 8]>) -> Option<String> {
+    commit.and_then(|c| std::str::from_utf8(&c).ok().map(str::to_string))
 }
 
 #[derive(Default, Clone)]
@@ -43,4 +52,5 @@ pub struct ClientData {
     pub position: String,
     pub resolving: bool,
     pub ips: Vec<String>,
+    pub peer_commit: Option<String>,
 }

--- a/lan-mouse-gtk/src/client_object/imp.rs
+++ b/lan-mouse-gtk/src/client_object/imp.rs
@@ -19,6 +19,7 @@ pub struct ClientObject {
     #[property(name = "position", get, set, type = String, member = position)]
     #[property(name = "resolving", get, set, type = bool, member = resolving)]
     #[property(name = "ips", get, set, type = Vec<String>, member = ips)]
+    #[property(name = "peer-commit", get, set, type = Option<String>, member = peer_commit)]
     pub data: RefCell<ClientData>,
 }
 

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -85,12 +85,11 @@ impl ClientRow {
                 row_for_hostname.set_title(&collapsed_title(hostname, port));
             });
         let row_for_port = self.clone();
-        let port_title_handler =
-            client_object.connect_notify_local(Some("port"), move |obj, _| {
-                let hostname: Option<String> = obj.property("hostname");
-                let port: u32 = obj.property("port");
-                row_for_port.set_title(&collapsed_title(hostname, port));
-            });
+        let port_title_handler = client_object.connect_notify_local(Some("port"), move |obj, _| {
+            let hostname: Option<String> = obj.property("hostname");
+            let port: u32 = obj.property("port");
+            row_for_port.set_title(&collapsed_title(hostname, port));
+        });
         self.set_title(&collapsed_title(
             client_object.property::<Option<String>>("hostname"),
             client_object.property::<u32>("port"),

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -175,13 +175,13 @@ impl ClientRow {
         let local = crate::local_commit_str();
         let markup = match peer.as_deref() {
             None => format!(
-                r##"<span foreground="#ffaa33">peer version: unknown · ours: {local}</span>"##
+                r##"<span foreground="#ffaa33">Peer version: unknown · Ours: {local}</span>"##
             ),
             Some(p) if p == local.as_str() => format!(
-                r##"<span foreground="#33cc66">peer version: {p} · matched</span>"##
+                r##"<span foreground="#33cc66">Peer version: {p} · matched</span>"##
             ),
             Some(p) => format!(
-                r##"<span foreground="#ffaa33">peer version: {p} · ours: {local}</span>"##
+                r##"<span foreground="#ffaa33">Peer version: {p} · Ours: {local}</span>"##
             ),
         };
         self.set_subtitle(&markup);

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -123,6 +123,12 @@ impl ClientRow {
         bindings.push(position_binding);
         bindings.push(resolve_binding);
         bindings.push(ip_binding);
+
+        // Render the initial collapsed subtitle from whatever
+        // peer_commit the ClientObject was created with. Subsequent
+        // changes are pushed by `Window::update_client_state` calling
+        // `refresh_version_status` after writing the new property.
+        self.refresh_version_status();
     }
 
     pub fn unbind(&self) {
@@ -149,5 +155,35 @@ impl ClientRow {
 
     pub fn set_dns_state(&self, resolved: bool) {
         self.imp().set_dns_state(resolved);
+    }
+
+    /// Recompute the collapsed subtitle (Pango markup) based on the
+    /// current `peer-commit` property and the local build's commit.
+    /// Soft-warn semantics: a missing or mismatched peer commit
+    /// surfaces as orange text but never blocks traffic. Called by
+    /// the window after `update_client_state` writes the new
+    /// `peer-commit`. The dns-status icon is left to its existing
+    /// `set_dns_state` handler so the two indicators don't fight
+    /// for the same CSS class.
+    pub fn refresh_version_status(&self) {
+        let peer: Option<String> = self
+            .imp()
+            .client_object
+            .borrow()
+            .as_ref()
+            .and_then(|co| co.property::<Option<String>>("peer-commit"));
+        let local = crate::local_commit_str();
+        let markup = match peer.as_deref() {
+            None => format!(
+                r##"<span foreground="#ffaa33">peer version: unknown · ours: {local}</span>"##
+            ),
+            Some(p) if p == local.as_str() => format!(
+                r##"<span foreground="#33cc66">peer version: {p} · matched</span>"##
+            ),
+            Some(p) => format!(
+                r##"<span foreground="#ffaa33">peer version: {p} · ours: {local}</span>"##
+            ),
+        };
+        self.set_subtitle(&markup);
     }
 }

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -9,7 +9,7 @@ use lan_mouse_ipc::{DEFAULT_PORT, Position};
 use super::ClientObject;
 
 const NO_HOSTNAME_MARKUP: &str =
-    "<span font_style=\"italic\" font_weight=\"light\" foreground=\"darkgrey\">no hostname!</span>";
+    "<span font_style=\"italic\" font_weight=\"light\" foreground=\"darkgrey\">No Hostname</span>";
 
 fn collapsed_title(hostname: Option<String>, port: u32) -> String {
     match hostname.as_deref() {

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -8,6 +8,16 @@ use lan_mouse_ipc::{DEFAULT_PORT, Position};
 
 use super::ClientObject;
 
+const NO_HOSTNAME_MARKUP: &str =
+    "<span font_style=\"italic\" font_weight=\"light\" foreground=\"darkgrey\">no hostname!</span>";
+
+fn collapsed_title(hostname: Option<String>, port: u32) -> String {
+    match hostname.as_deref() {
+        Some(h) if !h.is_empty() => format!("{h}:{port}"),
+        _ => NO_HOSTNAME_MARKUP.to_string(),
+    }
+}
+
 glib::wrapper! {
     pub struct ClientRow(ObjectSubclass<imp::ClientRow>)
     @extends gtk::ListBoxRow, gtk::Widget, adw::PreferencesRow, adw::ExpanderRow,
@@ -53,13 +63,6 @@ impl ClientRow {
             .sync_create()
             .build();
 
-        // bind hostname to title
-        let title_binding = client_object
-            .bind_property("hostname", self, "title")
-            .transform_to(|_, v: Option<String>| v.or(Some("<span font_style=\"italic\" font_weight=\"light\" foreground=\"darkgrey\">no hostname!</span>".to_string())))
-            .sync_create()
-            .build();
-
         // bind port to port edit field
         let port_binding = client_object
             .bind_property("port", &self.imp().port.get(), "text")
@@ -73,11 +76,30 @@ impl ClientRow {
             .sync_create()
             .build();
 
-        // bind port to subtitle
-        let subtitle_binding = client_object
-            .bind_property("port", self, "subtitle")
-            .sync_create()
-            .build();
+        // collapsed title: "hostname:port" (or markup fallback when hostname is empty)
+        let row_for_hostname = self.clone();
+        let hostname_title_handler =
+            client_object.connect_notify_local(Some("hostname"), move |obj, _| {
+                let hostname: Option<String> = obj.property("hostname");
+                let port: u32 = obj.property("port");
+                row_for_hostname.set_title(&collapsed_title(hostname, port));
+            });
+        let row_for_port = self.clone();
+        let port_title_handler =
+            client_object.connect_notify_local(Some("port"), move |obj, _| {
+                let hostname: Option<String> = obj.property("hostname");
+                let port: u32 = obj.property("port");
+                row_for_port.set_title(&collapsed_title(hostname, port));
+            });
+        self.set_title(&collapsed_title(
+            client_object.property::<Option<String>>("hostname"),
+            client_object.property::<u32>("port"),
+        ));
+        self.set_subtitle("");
+        self.imp()
+            .title_handlers
+            .borrow_mut()
+            .extend([hostname_title_handler, port_title_handler]);
 
         // bind position to selected position
         let position_binding = client_object
@@ -117,9 +139,7 @@ impl ClientRow {
         bindings.push(active_binding);
         bindings.push(switch_position_binding);
         bindings.push(hostname_binding);
-        bindings.push(title_binding);
         bindings.push(port_binding);
-        bindings.push(subtitle_binding);
         bindings.push(position_binding);
         bindings.push(resolve_binding);
         bindings.push(ip_binding);
@@ -134,6 +154,11 @@ impl ClientRow {
     pub fn unbind(&self) {
         for binding in self.imp().bindings.borrow_mut().drain(..) {
             binding.unbind();
+        }
+        if let Some(client_object) = self.imp().client_object.borrow().as_ref() {
+            for handler in self.imp().title_handlers.borrow_mut().drain(..) {
+                client_object.disconnect(handler);
+            }
         }
     }
 

--- a/lan-mouse-gtk/src/client_row.rs
+++ b/lan-mouse-gtk/src/client_row.rs
@@ -177,12 +177,12 @@ impl ClientRow {
             None => format!(
                 r##"<span foreground="#ffaa33">Peer version: unknown · Ours: {local}</span>"##
             ),
-            Some(p) if p == local.as_str() => format!(
-                r##"<span foreground="#33cc66">Peer version: {p} · matched</span>"##
-            ),
-            Some(p) => format!(
-                r##"<span foreground="#ffaa33">Peer version: {p} · Ours: {local}</span>"##
-            ),
+            Some(p) if p == local.as_str() => {
+                format!(r##"<span foreground="#33cc66">Peer version: {p} · matched</span>"##)
+            }
+            Some(p) => {
+                format!(r##"<span foreground="#ffaa33">Peer version: {p} · Ours: {local}</span>"##)
+            }
         };
         self.set_subtitle(&markup);
     }

--- a/lan-mouse-gtk/src/client_row/imp.rs
+++ b/lan-mouse-gtk/src/client_row/imp.rs
@@ -31,6 +31,7 @@ pub struct ClientRow {
     #[template_child]
     pub dns_loading_indicator: TemplateChild<gtk::Spinner>,
     pub bindings: RefCell<Vec<Binding>>,
+    pub title_handlers: RefCell<Vec<SignalHandlerId>>,
     hostname_change_handler: RefCell<Option<SignalHandlerId>>,
     port_change_handler: RefCell<Option<SignalHandlerId>>,
     position_change_handler: RefCell<Option<SignalHandlerId>>,

--- a/lan-mouse-gtk/src/fingerprint_window/imp.rs
+++ b/lan-mouse-gtk/src/fingerprint_window/imp.rs
@@ -4,8 +4,8 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::subclass::InitializingObject;
 use gtk::{
-    Button, CompositeTemplate, Entry,
-    glib::{self, subclass::Signal},
+    Button, CompositeTemplate, Entry, EventControllerKey, gdk,
+    glib::{self, Propagation, subclass::Signal},
     template_callbacks,
 };
 
@@ -86,6 +86,21 @@ impl ObjectImpl for FingerprintWindow {
         self.refresh_confirm_sensitivity();
 
         let obj = self.obj();
+
+        // Close on Escape.
+        let key = EventControllerKey::new();
+        let weak_close = obj.downgrade();
+        key.connect_key_pressed(move |_, keyval, _, _| {
+            if keyval == gdk::Key::Escape {
+                if let Some(w) = weak_close.upgrade() {
+                    w.close();
+                }
+                Propagation::Stop
+            } else {
+                Propagation::Proceed
+            }
+        });
+        obj.add_controller(key);
         let weak_desc = obj.downgrade();
         self.description.connect_changed(move |_| {
             if let Some(o) = weak_desc.upgrade() {

--- a/lan-mouse-gtk/src/fingerprint_window/imp.rs
+++ b/lan-mouse-gtk/src/fingerprint_window/imp.rs
@@ -44,7 +44,24 @@ impl FingerprintWindow {
     fn handle_confirm(&self, _button: Button) {
         let desc = self.description.text().as_str().trim().to_owned();
         let fp = self.fingerprint.text().as_str().trim().to_owned();
+        // Defensive guard: the button is wired to be insensitive while
+        // either field is empty (see `constructed`), but a user could
+        // theoretically trigger the action via the keyboard accelerator
+        // before the validity recompute finishes. Drop empty submits.
+        if desc.is_empty() || fp.is_empty() {
+            return;
+        }
         self.obj().emit_by_name("confirm-clicked", &[&desc, &fp])
+    }
+}
+
+impl FingerprintWindow {
+    fn both_filled(&self) -> bool {
+        !self.description.text().trim().is_empty() && !self.fingerprint.text().trim().is_empty()
+    }
+
+    fn refresh_confirm_sensitivity(&self) {
+        self.confirm_button.set_sensitive(self.both_filled());
     }
 }
 
@@ -58,6 +75,29 @@ impl ObjectImpl for FingerprintWindow {
                     .build(),
             ]
         })
+    }
+
+    fn constructed(&self) {
+        self.parent_constructed();
+
+        // Confirm is disabled while either Description or
+        // SHA-256 Fingerprint is empty (after trim). Recompute on
+        // every keystroke via the GtkEditable `changed` signal.
+        self.refresh_confirm_sensitivity();
+
+        let obj = self.obj();
+        let weak_desc = obj.downgrade();
+        self.description.connect_changed(move |_| {
+            if let Some(o) = weak_desc.upgrade() {
+                o.imp().refresh_confirm_sensitivity();
+            }
+        });
+        let weak_fp = obj.downgrade();
+        self.fingerprint.connect_changed(move |_| {
+            if let Some(o) = weak_fp.upgrade() {
+                o.imp().refresh_confirm_sensitivity();
+            }
+        });
     }
 }
 

--- a/lan-mouse-gtk/src/fingerprint_window/imp.rs
+++ b/lan-mouse-gtk/src/fingerprint_window/imp.rs
@@ -4,7 +4,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use glib::subclass::InitializingObject;
 use gtk::{
-    Button, CompositeTemplate, Text,
+    Button, CompositeTemplate, Entry,
     glib::{self, subclass::Signal},
     template_callbacks,
 };
@@ -13,9 +13,9 @@ use gtk::{
 #[template(resource = "/de/feschber/LanMouse/fingerprint_window.ui")]
 pub struct FingerprintWindow {
     #[template_child]
-    pub description: TemplateChild<Text>,
+    pub description: TemplateChild<Entry>,
     #[template_child]
-    pub fingerprint: TemplateChild<Text>,
+    pub fingerprint: TemplateChild<Entry>,
     #[template_child]
     pub confirm_button: TemplateChild<Button>,
 }

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -171,6 +171,17 @@ fn setup_actions(app: &adw::Application) {
         }
     });
     app.add_action(&quit_action);
+
+    // Cmd+W → close the front window. GtkWindow's built-in `close`
+    // action fires `close-request`, which on macOS we've hooked to
+    // hide the window instead of destroying it (see `build_ui`). The
+    // window's connect_hide handler then flips the activation policy
+    // to Accessory — net effect is that Cmd+W collapses the GUI to a
+    // menu-bar-only background helper, freeing focus for whatever the
+    // user does next. Wired only on macOS so we don't override the
+    // native Ctrl+W behavior on Linux/Windows.
+    #[cfg(target_os = "macos")]
+    app.set_accels_for_action("window.close", &["<Meta>w"]);
 }
 
 // Set up a global menu
@@ -180,6 +191,7 @@ fn setup_menu(app: &adw::Application) {
     let menu = gio::Menu::new();
 
     let file_menu = gio::Menu::new();
+    file_menu.append(Some("Close Window"), Some("window.close"));
     file_menu.append(Some("Quit"), Some("app.quit"));
     menu.append_submenu(Some("_File"), &file_menu);
 

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -269,6 +269,9 @@ fn build_ui(app: &Application) {
                     FrontendEvent::IncomingDisconnected(addr) => {
                         window.show_toast(format!("{addr} disconnected").as_str());
                     }
+                    FrontendEvent::ReleaseThreshold(threshold) => {
+                        window.set_release_threshold(threshold);
+                    }
                 }
             }
         }

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) fn request_quit_with_backstop(app: &adw::Application) {
     app.quit();
 }
 
-pub fn run(local_commit: [u8; 8], gui_lock: Option<GuiLock>) -> Result<(), GtkError> {
+pub fn run(gui_lock: Option<GuiLock>, local_commit: [u8; 8]) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
     LOCAL_COMMIT
         .set(local_commit)
@@ -361,9 +361,27 @@ fn build_ui(app: &Application, show_rx: Option<async_channel::Receiver<()>>) {
     glib::spawn_future_local(clone!(
         #[weak]
         window,
+        #[weak]
+        app,
         async move {
             loop {
-                let notify = receiver.recv().await.unwrap_or_else(|_| process::exit(1));
+                // If the daemon-IPC channel drops, the daemon child has
+                // exited (e.g. its CGEventTap died after AX was revoked
+                // — see input-capture/macos.rs ProducerEvent::EventTapDisabled).
+                // Quit the GUI cleanly instead of staying alive with a
+                // dead daemon, and route through the macOS quit-backstop
+                // so a wedged event loop can't leave the process around.
+                let notify = match receiver.recv().await {
+                    Ok(n) => n,
+                    Err(_) => {
+                        log::warn!("daemon IPC closed — quitting GUI");
+                        #[cfg(target_os = "macos")]
+                        request_quit_with_backstop(&app);
+                        #[cfg(not(target_os = "macos"))]
+                        app.quit();
+                        return;
+                    }
+                };
                 match notify {
                     FrontendEvent::Created(handle, client, state) => {
                         window.new_client(handle, client, state)

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) fn local_commit_str() -> String {
         .to_string()
 }
 
-use lan_mouse_ipc::FrontendEvent;
+use lan_mouse_ipc::{FrontendEvent, GuiLock};
 
 use adw::Application;
 use gtk::{IconTheme, gdk::Display, glib::clone, prelude::*};
@@ -84,22 +84,42 @@ pub(crate) fn request_quit_with_backstop(app: &adw::Application) {
     app.quit();
 }
 
-pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
+pub fn run(local_commit: [u8; 8], gui_lock: Option<GuiLock>) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
     LOCAL_COMMIT
         .set(local_commit)
         .expect("local_commit set once");
 
+    // Spawn the GUI lock listener: a blocking thread that waits for
+    // future `lan-mouse` invocations to connect and ask us to show
+    // ourselves. Forwards each request to the GTK main loop via an
+    // async channel. When `gui_lock` is None (lock acquisition failed
+    // earlier — non-fatal) we just don't have a singleton-show path.
+    let show_rx = gui_lock.map(|lock| {
+        let (tx, rx) = async_channel::unbounded::<()>();
+        std::thread::Builder::new()
+            .name("lan-mouse-gui-lock".into())
+            .spawn(move || {
+                while let Some(()) = lock.next_show() {
+                    if tx.send_blocking(()).is_err() {
+                        break;
+                    }
+                }
+            })
+            .expect("spawn gui lock listener");
+        rx
+    });
+
     #[cfg(windows)]
     let ret = std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024) // https://gitlab.gnome.org/GNOME/gtk/-/commit/52dbb3f372b2c3ea339e879689c1de535ba2c2c3 -> caused crash on windows
         .name("gtk".into())
-        .spawn(gtk_main)
+        .spawn(move || gtk_main(show_rx))
         .unwrap()
         .join()
         .unwrap();
     #[cfg(not(windows))]
-    let ret = gtk_main();
+    let ret = gtk_main(show_rx);
 
     match ret {
         glib::ExitCode::SUCCESS => Ok(()),
@@ -107,7 +127,7 @@ pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
     }
 }
 
-fn gtk_main() -> glib::ExitCode {
+fn gtk_main(show_rx: Option<async_channel::Receiver<()>>) -> glib::ExitCode {
     #[cfg(target_os = "macos")]
     {
         configure_macos_bundle_environment();
@@ -125,7 +145,7 @@ fn gtk_main() -> glib::ExitCode {
         setup_actions(app);
         setup_menu(app);
     });
-    app.connect_activate(build_ui);
+    app.connect_activate(move |app| build_ui(app, show_rx.clone()));
 
     let args: Vec<&'static str> = vec![];
     app.run_with_args(&args)
@@ -237,7 +257,16 @@ fn setup_menu(app: &adw::Application) {
     app.set_menubar(Some(&menu))
 }
 
-fn build_ui(app: &Application) {
+fn build_ui(app: &Application, show_rx: Option<async_channel::Receiver<()>>) {
+    // Defense in depth: if `activate` fires a second time in the same
+    // process — the GApplication DBus single-instance hand-off does
+    // this on Linux, and `kAEReopenApplication` does this on macOS —
+    // present the existing window instead of building another one.
+    if let Some(existing) = app.windows().first() {
+        existing.present();
+        return;
+    }
+
     log::debug!("connecting to lan-mouse-socket");
     let (mut frontend_rx, frontend_tx) = match lan_mouse_ipc::connect() {
         Ok(conn) => conn,
@@ -310,6 +339,23 @@ fn build_ui(app: &Application) {
                 }
             }
         });
+    }
+
+    // Wire up the GUI singleton: when a later `lan-mouse` invocation
+    // signals us, present (and on macOS also un-hide) the window. The
+    // sender lives on a dedicated std::thread spawned in `run()`.
+    if let Some(show_rx) = show_rx {
+        glib::spawn_future_local(clone!(
+            #[weak]
+            window,
+            async move {
+                while show_rx.recv().await.is_ok() {
+                    log::debug!("show signal from second instance — presenting window");
+                    window.set_visible(true);
+                    window.present();
+                }
+            }
+        ));
     }
 
     glib::spawn_future_local(clone!(

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -10,9 +10,26 @@ mod macos_privacy;
 mod macos_status_item;
 mod window;
 
-use std::{env, process, str};
+use std::{env, process, str, sync::OnceLock};
 
 use window::Window;
+
+/// Local build's commit hash, set once by [`run`] before the GTK
+/// main loop starts. Read by per-row UI to compare against each
+/// peer's [`lan_mouse_ipc::ClientState::peer_commit`] for the
+/// soft-warn version-mismatch indicator.
+pub(crate) static LOCAL_COMMIT: OnceLock<[u8; 8]> = OnceLock::new();
+
+/// Convenience: returns the local commit as an 8-char ASCII string,
+/// or a placeholder if unset (which would indicate a programmer
+/// error since [`run`] always sets it).
+pub(crate) fn local_commit_str() -> String {
+    LOCAL_COMMIT
+        .get()
+        .and_then(|c| std::str::from_utf8(c).ok())
+        .unwrap_or("????????")
+        .to_string()
+}
 
 use lan_mouse_ipc::FrontendEvent;
 
@@ -31,8 +48,13 @@ pub enum GtkError {
     NonZeroExitCode(i32),
 }
 
-pub fn run() -> Result<(), GtkError> {
+pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
+    LOCAL_COMMIT
+        .set(local_commit)
+        .expect("local_commit set once");
+
+
     #[cfg(windows)]
     let ret = std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024) // https://gitlab.gnome.org/GNOME/gtk/-/commit/52dbb3f372b2c3ea339e879689c1de535ba2c2c3 -> caused crash on windows

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -54,7 +54,6 @@ pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
         .set(local_commit)
         .expect("local_commit set once");
 
-
     #[cfg(windows)]
     let ret = std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024) // https://gitlab.gnome.org/GNOME/gtk/-/commit/52dbb3f372b2c3ea339e879689c1de535ba2c2c3 -> caused crash on windows

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -293,6 +293,9 @@ fn build_ui(app: &Application) {
                     FrontendEvent::ReleaseThreshold(threshold) => {
                         window.set_release_threshold(threshold);
                     }
+                    FrontendEvent::MdnsDiscovery(enabled) => {
+                        window.set_mdns_discovery(enabled);
+                    }
                 }
             }
         }

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -357,6 +357,9 @@ fn build_ui(app: &Application) {
                     FrontendEvent::ReleaseThreshold(threshold) => {
                         window.set_release_threshold(threshold);
                     }
+                    FrontendEvent::NaturalScroll(natural_scroll) => {
+                        window.set_natural_scroll(natural_scroll);
+                    }
                     FrontendEvent::MdnsDiscovery(enabled) => {
                         window.set_mdns_discovery(enabled);
                     }

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -218,6 +218,19 @@ fn build_ui(app: &Application) {
             window.set_visible(false);
             glib::Propagation::Stop
         });
+        // Toggle the Dock icon based on the window's visibility:
+        // Regular while the window is open (Dock icon shown so the
+        // user has a familiar way back to the app), Accessory while
+        // the window is hidden and only the menu-bar item is around
+        // (matches the LSUIElement-style background-helper feel).
+        window.connect_show(|_| {
+            macos_status_item::set_activation_policy(macos_status_item::ACTIVATION_POLICY_REGULAR);
+        });
+        window.connect_hide(|_| {
+            macos_status_item::set_activation_policy(
+                macos_status_item::ACTIVATION_POLICY_ACCESSORY,
+            );
+        });
         macos_status_item::setup(app, &window);
         // First-launch TCC prompts. No-op when already granted.
         macos_privacy::fire_initial_prompts();

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -48,6 +48,42 @@ pub enum GtkError {
     NonZeroExitCode(i32),
 }
 
+/// Arm a process-level force-exit backstop and request a normal app
+/// quit. macOS-only because shutdown wedges (GTK main loop pumping
+/// pending events while the daemon is also being torn down, a
+/// CGEventTap that hasn't been removed yet, an outgoing IPC write
+/// blocked on a closing socket) only show up on macOS in practice.
+///
+/// The backstop thread sleeps outside the GTK main loop so it fires
+/// even if the loop itself is the thing that's wedged. If normal
+/// cleanup completes first (the usual case) the process exits via
+/// `main` returning and the sleeping backstop thread is killed by
+/// the OS along with everything else — the timer never fires.
+///
+/// Calling this twice in quick succession is a no-op on the second
+/// call so we don't spawn multiple backstops.
+#[cfg(target_os = "macos")]
+pub(crate) fn request_quit_with_backstop(app: &adw::Application) {
+    use std::sync::OnceLock;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static ARMED: OnceLock<AtomicBool> = OnceLock::new();
+    let armed = ARMED.get_or_init(|| AtomicBool::new(false));
+    if armed.swap(true, Ordering::SeqCst) {
+        app.quit();
+        return;
+    }
+
+    std::thread::Builder::new()
+        .name("lan-mouse-quit-backstop".into())
+        .spawn(|| {
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            log::warn!("quit cleanup did not complete in 5s — force-exiting");
+            std::process::exit(0);
+        })
+        .ok();
+    app.quit();
+}
+
 pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
     LOCAL_COMMIT
@@ -167,6 +203,9 @@ fn setup_actions(app: &adw::Application) {
     quit_action.connect_activate({
         let app = app.clone();
         move |_, _| {
+            #[cfg(target_os = "macos")]
+            request_quit_with_backstop(&app);
+            #[cfg(not(target_os = "macos"))]
             app.quit();
         }
     });
@@ -267,7 +306,7 @@ fn build_ui(app: &Application) {
             macos_privacy::AccessibilityChange::Revoked => {
                 log::warn!("Accessibility revoked — quitting to avoid wedging system input");
                 if let Some(app) = app_weak.upgrade() {
-                    app.quit();
+                    request_quit_with_backstop(&app);
                 }
             }
         });

--- a/lan-mouse-gtk/src/macos_status_item.rs
+++ b/lan-mouse-gtk/src/macos_status_item.rs
@@ -241,6 +241,23 @@ fn present_window() {
     });
 }
 
+/// macOS NSApplicationActivationPolicy values.
+/// - `Regular` (0): standard app, Dock icon visible.
+/// - `Accessory` (1): no Dock icon, can have menu-bar item.
+pub(crate) const ACTIVATION_POLICY_REGULAR: usize = 0;
+pub(crate) const ACTIVATION_POLICY_ACCESSORY: usize = 1;
+
+/// Set NSApp's activation policy. Toggle between Regular (Dock
+/// icon shown — used while the main window is visible) and
+/// Accessory (no Dock icon — used while only the menu bar is
+/// visible).
+pub(crate) fn set_activation_policy(policy: usize) {
+    unsafe {
+        let ns_app = msg_send_id(class(c"NSApplication"), sel(c"sharedApplication"));
+        msg_send_bool_usize(ns_app, sel(c"setActivationPolicy:"), policy);
+    }
+}
+
 // Register the status-item delegate as the handler for the
 // kAEReopenApplication Apple Event ('aevt'/'rapp'). NSApplication
 // installs a default handler at -finishLaunching that just delegates to

--- a/lan-mouse-gtk/src/macos_status_item.rs
+++ b/lan-mouse-gtk/src/macos_status_item.rs
@@ -290,7 +290,7 @@ unsafe fn install_reopen_handler(delegate: Id) {
 extern "C" fn quit_lan_mouse(_this: Id, _cmd: Sel, _sender: Id) {
     STATUS_ITEM.with(|item| {
         if let Some(app) = item.borrow().as_ref().and_then(|item| item.app.upgrade()) {
-            app.quit();
+            crate::request_quit_with_backstop(&app);
         }
     });
 }

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -407,6 +407,10 @@ impl Window {
         self.request(FrontendRequest::Create);
     }
 
+    pub(super) fn request_release_threshold(&self, threshold: u32) {
+        self.request(FrontendRequest::SetReleaseThreshold(threshold));
+    }
+
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
@@ -459,6 +463,28 @@ impl Window {
     pub(super) fn set_emulation(&self, active: bool) {
         self.imp().emulation_active.replace(active);
         self.update_capture_emulation_status();
+    }
+
+    pub(super) fn set_release_threshold(&self, threshold: u32) {
+        let imp = self.imp();
+        // Block the value-changed handler so programmatically setting
+        // the slider value (e.g. on Sync from the daemon) doesn't
+        // ricochet back as a SetReleaseThreshold request.
+        let scale = &imp.release_threshold_scale;
+        let handler_id = imp.release_threshold_handler.borrow();
+        if let Some(id) = handler_id.as_ref() {
+            scale.block_signal(id);
+        }
+        scale.set_value(threshold as f64);
+        if let Some(id) = handler_id.as_ref() {
+            scale.unblock_signal(id);
+        }
+        let label = if threshold == 0 {
+            "disabled".to_string()
+        } else {
+            format!("{threshold} px")
+        };
+        imp.release_threshold_value.set_label(&label);
     }
 
     #[cfg(target_os = "macos")]

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -558,13 +558,13 @@ impl Window {
             // AX granted but capture/emulation still off → the daemon
             // subprocess bailed at startup and needs a fresh process to
             // re-initialize with the new grant in place.
-            row.set_title("relaunch required");
-            row.set_subtitle("Accessibility granted — restart to activate capture and emulation");
+            row.set_title("Relaunch Required");
+            row.set_subtitle("Accessibility granted — restart to activate capture and emulation.");
             set_button_content_label(button, "Relaunch");
         } else {
             // AX missing → send the user to System Settings.
-            row.set_title("Input capture is disabled");
-            row.set_subtitle("Grant Accessibility permission to enable");
+            row.set_title("Input Capture Disabled");
+            row.set_subtitle("Grant accessibility permission to enable.");
             set_button_content_label(button, "Grant");
         }
     }

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -505,7 +505,7 @@ impl Window {
             scale.unblock_signal(id);
         }
         let label = if threshold == 0 {
-            "disabled".to_string()
+            "Disabled".to_string()
         } else {
             format!("{threshold} px")
         };
@@ -563,8 +563,8 @@ impl Window {
             set_button_content_label(button, "Relaunch");
         } else {
             // AX missing → send the user to System Settings.
-            row.set_title("input capture is disabled");
-            row.set_subtitle("grant Accessibility permission to enable");
+            row.set_title("Input capture is disabled");
+            row.set_subtitle("Grant Accessibility permission to enable");
             set_button_content_label(button, "Grant");
         }
     }

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -422,7 +422,6 @@ impl Window {
         self.request(FrontendRequest::SetMdnsDiscovery(enabled));
     }
 
-
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
@@ -490,7 +489,6 @@ impl Window {
             switch.unblock_signal(id);
         }
     }
-
 
     pub(super) fn set_release_threshold(&self, threshold: u32) {
         let imp = self.imp();

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -418,12 +418,12 @@ impl Window {
         self.request(FrontendRequest::SetReleaseThreshold(threshold));
     }
 
-    pub(super) fn request_mdns_discovery(&self, enabled: bool) {
-        self.request(FrontendRequest::SetMdnsDiscovery(enabled));
-    }
-
     pub(super) fn request_natural_scroll(&self, natural_scroll: bool) {
         self.request(FrontendRequest::SetNaturalScroll(natural_scroll));
+    }
+
+    pub(super) fn request_mdns_discovery(&self, enabled: bool) {
+        self.request(FrontendRequest::SetMdnsDiscovery(enabled));
     }
 
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
@@ -490,20 +490,6 @@ impl Window {
         self.update_capture_emulation_status();
     }
 
-    pub(super) fn set_mdns_discovery(&self, enabled: bool) {
-        let imp = self.imp();
-        let switch = &imp.mdns_discovery_switch;
-        let handler = imp.mdns_discovery_handler.borrow();
-        if let Some(id) = handler.as_ref() {
-            switch.block_signal(id);
-        }
-        switch.set_active(enabled);
-        switch.set_state(enabled);
-        if let Some(id) = handler.as_ref() {
-            switch.unblock_signal(id);
-        }
-    }
-
     pub(super) fn set_natural_scroll(&self, natural_scroll: bool) {
         let imp = self.imp();
         let switch = &imp.natural_scroll_switch;
@@ -513,6 +499,20 @@ impl Window {
         }
         switch.set_active(natural_scroll);
         switch.set_state(natural_scroll);
+        if let Some(id) = handler.as_ref() {
+            switch.unblock_signal(id);
+        }
+    }
+
+    pub(super) fn set_mdns_discovery(&self, enabled: bool) {
+        let imp = self.imp();
+        let switch = &imp.mdns_discovery_switch;
+        let handler = imp.mdns_discovery_handler.borrow();
+        if let Some(id) = handler.as_ref() {
+            switch.block_signal(id);
+        }
+        switch.set_active(enabled);
+        switch.set_state(enabled);
         if let Some(id) = handler.as_ref() {
             switch.unblock_signal(id);
         }

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -425,6 +425,16 @@ impl Window {
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
+        // Size the popup 40 px narrower than the parent so it stays
+        // fully visible when the parent has been tiled into a narrow
+        // split (Hyprland and similar). Falls back to the XML default
+        // (460 px) when the parent's allocated width isn't yet known
+        // and clamps to the XML width-request floor.
+        let parent_w = self.width();
+        if parent_w > 0 {
+            let popup_w = (parent_w - 40).clamp(280, 460);
+            window.set_default_width(popup_w);
+        }
         window.connect_closure(
             "confirm-clicked",
             false,
@@ -591,6 +601,15 @@ impl Window {
         }
         let window = AuthorizationWindow::new(fingerprint);
         window.set_transient_for(Some(self));
+        // Same parent-relative sizing as the fingerprint dialog —
+        // 40 px narrower than the parent, capped at 460 to match the
+        // Add-Certificate modal, floored at 280 so it doesn't shrink
+        // under content.
+        let parent_w = self.width();
+        if parent_w > 0 {
+            let popup_w = (parent_w - 40).clamp(280, 460);
+            window.set_default_width(popup_w);
+        }
         window.connect_closure(
             "confirm-clicked",
             false,

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -418,6 +418,11 @@ impl Window {
         self.request(FrontendRequest::SetReleaseThreshold(threshold));
     }
 
+    pub(super) fn request_mdns_discovery(&self, enabled: bool) {
+        self.request(FrontendRequest::SetMdnsDiscovery(enabled));
+    }
+
+
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
@@ -471,6 +476,21 @@ impl Window {
         self.imp().emulation_active.replace(active);
         self.update_capture_emulation_status();
     }
+
+    pub(super) fn set_mdns_discovery(&self, enabled: bool) {
+        let imp = self.imp();
+        let switch = &imp.mdns_discovery_switch;
+        let handler = imp.mdns_discovery_handler.borrow();
+        if let Some(id) = handler.as_ref() {
+            switch.block_signal(id);
+        }
+        switch.set_active(enabled);
+        switch.set_state(enabled);
+        if let Some(id) = handler.as_ref() {
+            switch.unblock_signal(id);
+        }
+    }
+
 
     pub(super) fn set_release_threshold(&self, threshold: u32) {
         let imp = self.imp();

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -365,6 +365,13 @@ impl Window {
             .map(|ip| ip.to_string())
             .collect::<Vec<_>>();
         client_object.set_ips(ips);
+
+        /* peer build version (drives the version-match indicator) */
+        client_object.set_property(
+            "peer-commit",
+            crate::client_object::peer_commit_to_string(state.peer_commit),
+        );
+        row.refresh_version_status();
     }
 
     fn client_object_for_handle(&self, handle: ClientHandle) -> Option<ClientObject> {

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -422,6 +422,10 @@ impl Window {
         self.request(FrontendRequest::SetMdnsDiscovery(enabled));
     }
 
+    pub(super) fn request_natural_scroll(&self, natural_scroll: bool) {
+        self.request(FrontendRequest::SetNaturalScroll(natural_scroll));
+    }
+
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
@@ -495,6 +499,20 @@ impl Window {
         }
         switch.set_active(enabled);
         switch.set_state(enabled);
+        if let Some(id) = handler.as_ref() {
+            switch.unblock_signal(id);
+        }
+    }
+
+    pub(super) fn set_natural_scroll(&self, natural_scroll: bool) {
+        let imp = self.imp();
+        let switch = &imp.natural_scroll_switch;
+        let handler = imp.natural_scroll_handler.borrow();
+        if let Some(id) = handler.as_ref() {
+            switch.block_signal(id);
+        }
+        switch.set_active(natural_scroll);
+        switch.set_state(natural_scroll);
         if let Some(id) = handler.as_ref() {
             switch.unblock_signal(id);
         }

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -4,7 +4,7 @@ use adw::subclass::prelude::*;
 use adw::{ActionRow, PreferencesGroup, ToastOverlay, prelude::*};
 use glib::subclass::InitializingObject;
 use gtk::glib::clone;
-use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, gdk, gio, glib};
+use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, Scale, gdk, gio, glib};
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
 
@@ -45,6 +45,12 @@ pub struct Window {
     pub input_capture_button: TemplateChild<Button>,
     #[template_child]
     pub authorized_list: TemplateChild<ListBox>,
+    #[template_child]
+    pub release_threshold_row: TemplateChild<ActionRow>,
+    #[template_child]
+    pub release_threshold_scale: TemplateChild<Scale>,
+    #[template_child]
+    pub release_threshold_value: TemplateChild<Label>,
     pub clients: RefCell<Option<gio::ListStore>>,
     pub authorized: RefCell<Option<gio::ListStore>>,
     pub frontend_request_writer: RefCell<Option<FrontendRequestWriter>>,
@@ -52,6 +58,10 @@ pub struct Window {
     pub capture_active: Cell<bool>,
     pub emulation_active: Cell<bool>,
     pub authorization_window: RefCell<Option<AuthorizationWindow>>,
+    /// Connected handler for the auto-release-threshold scale's
+    /// value-changed signal, so we can block it when programmatically
+    /// updating the slider in response to a Sync event.
+    pub release_threshold_handler: RefCell<Option<glib::SignalHandlerId>>,
 }
 
 #[glib::object_subclass]
@@ -200,6 +210,26 @@ impl ObjectImpl for Window {
         obj.setup_icon();
         obj.setup_clients();
         obj.setup_authorized();
+
+        // Connect the auto-release threshold slider. Stash the handler
+        // id so set_release_threshold() can block the signal when the
+        // daemon-driven Sync sets the value programmatically.
+        let scale = self.release_threshold_scale.clone();
+        let handler_id = scale.connect_value_changed(clone!(
+            #[weak(rename_to = window)]
+            obj,
+            move |scale| {
+                let value = scale.value().round() as u32;
+                let label = if value == 0 {
+                    "disabled".to_string()
+                } else {
+                    format!("{value} px")
+                };
+                window.imp().release_threshold_value.set_label(&label);
+                window.request_release_threshold(value);
+            }
+        ));
+        self.release_threshold_handler.replace(Some(handler_id));
     }
 }
 

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -55,6 +55,10 @@ pub struct Window {
     #[template_child]
     pub release_threshold_value: TemplateChild<Label>,
     #[template_child]
+    pub natural_scroll_row: TemplateChild<ActionRow>,
+    #[template_child]
+    pub natural_scroll_switch: TemplateChild<Switch>,
+    #[template_child]
     pub mdns_discovery_row: TemplateChild<ActionRow>,
     #[template_child]
     pub mdns_discovery_switch: TemplateChild<Switch>,
@@ -69,6 +73,10 @@ pub struct Window {
     /// value-changed signal, so we can block it when programmatically
     /// updating the slider in response to a Sync event.
     pub release_threshold_handler: RefCell<Option<glib::SignalHandlerId>>,
+    /// Connected handler for the natural-scroll switch's
+    /// state-set signal, blocked while the daemon is pushing the
+    /// initial value via Sync.
+    pub natural_scroll_handler: RefCell<Option<glib::SignalHandlerId>>,
     /// Connected handler for the mDNS-discovery switch's state-set
     /// signal, blocked while the daemon is pushing the initial value
     /// via Sync.
@@ -285,8 +293,22 @@ impl ObjectImpl for Window {
         ));
         self.release_threshold_scale.add_controller(scroll_forward);
 
-        // mDNS-discovery switch — connect state-set, stash the handler
-        // so the daemon's Sync push doesn't ricochet back.
+        // Connect the natural-scroll switch. Same pattern: stash the
+        // handler id so the daemon's Sync push doesn't ricochet back.
+        let switch = self.natural_scroll_switch.clone();
+        let switch_handler = switch.connect_state_set(clone!(
+            #[weak(rename_to = window)]
+            obj,
+            #[upgrade_or]
+            glib::Propagation::Proceed,
+            move |_, state| {
+                window.request_natural_scroll(state);
+                glib::Propagation::Proceed
+            }
+        ));
+        self.natural_scroll_handler.replace(Some(switch_handler));
+
+        // mDNS-discovery switch — same pattern.
         let mdns_switch = self.mdns_discovery_switch.clone();
         let mdns_handler = mdns_switch.connect_state_set(clone!(
             #[weak(rename_to = window)]

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -77,9 +77,7 @@ pub struct Window {
     /// state-set signal, blocked while the daemon is pushing the
     /// initial value via Sync.
     pub natural_scroll_handler: RefCell<Option<glib::SignalHandlerId>>,
-    /// Connected handler for the mDNS-discovery switch's state-set
-    /// signal, blocked while the daemon is pushing the initial value
-    /// via Sync.
+    /// Same pattern for the mDNS-discovery switch.
     pub mdns_discovery_handler: RefCell<Option<glib::SignalHandlerId>>,
 }
 
@@ -308,7 +306,7 @@ impl ObjectImpl for Window {
         ));
         self.natural_scroll_handler.replace(Some(switch_handler));
 
-        // mDNS-discovery switch — same pattern.
+        // mDNS-discovery switch — identical pattern.
         let mdns_switch = self.mdns_discovery_switch.clone();
         let mdns_handler = mdns_switch.connect_state_set(clone!(
             #[weak(rename_to = window)]

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -6,7 +6,7 @@ use glib::subclass::InitializingObject;
 use gtk::glib::clone;
 use gtk::{
     Button, CompositeTemplate, Entry, EventControllerScroll, EventControllerScrollFlags, Image,
-    Label, ListBox, PropagationPhase, Scale, gdk, gio, glib,
+    Label, ListBox, PropagationPhase, Scale, ScrolledWindow, gdk, gio, glib,
 };
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
@@ -234,20 +234,48 @@ impl ObjectImpl for Window {
         ));
         self.release_threshold_handler.replace(Some(handler_id));
 
-        // Eat scroll-wheel events on the threshold slider. By default
-        // GtkScale treats vertical scroll as increment / decrement,
-        // which makes the threshold drift any time the user scrolls
-        // the window and the cursor passes over the slider. We
-        // intercept in the capture phase and return Stop so the scale's
-        // own controller never sees the event. Side effect: scrolling
-        // doesn't pass through to the parent ScrolledWindow while the
-        // cursor is on the slider — to scroll, move the cursor off it.
-        let scroll_block = EventControllerScroll::new(
+        // Pass scroll-wheel events on the threshold slider through to
+        // the ancestor ScrolledWindow instead of letting GtkScale's
+        // default handler treat them as increment / decrement (which
+        // would drift the threshold any time the user scrolls past
+        // the slider). Returning `Stop` from a capture-phase handler
+        // suppresses the scale's own scroll-to-adjust handler, but
+        // also stops propagation to the parent — so we additionally
+        // bump the parent ScrolledWindow's vadjustment by hand to
+        // mimic native scroll-passthrough.
+        let scroll_forward = EventControllerScroll::new(
             EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::HORIZONTAL,
         );
-        scroll_block.set_propagation_phase(PropagationPhase::Capture);
-        scroll_block.connect_scroll(|_, _, _| glib::Propagation::Stop);
-        self.release_threshold_scale.add_controller(scroll_block);
+        scroll_forward.set_propagation_phase(PropagationPhase::Capture);
+        scroll_forward.connect_scroll(clone!(
+            #[weak(rename_to = scale)]
+            self.release_threshold_scale,
+            #[upgrade_or]
+            glib::Propagation::Stop,
+            move |_, _dx, dy| {
+                let mut walker = scale.parent();
+                while let Some(w) = walker {
+                    if let Some(scrolled) = w.downcast_ref::<ScrolledWindow>() {
+                        let vadj = scrolled.vadjustment();
+                        // step_increment is the "wheel tick" unit; if
+                        // unset (rare), fall back to a sensible
+                        // pixel default so a single tick still moves.
+                        let step = if vadj.step_increment() > 0.0 {
+                            vadj.step_increment()
+                        } else {
+                            40.0
+                        };
+                        let target = (vadj.value() + dy * step)
+                            .clamp(vadj.lower(), vadj.upper() - vadj.page_size());
+                        vadj.set_value(target);
+                        break;
+                    }
+                    walker = w.parent();
+                }
+                glib::Propagation::Stop
+            }
+        ));
+        self.release_threshold_scale.add_controller(scroll_forward);
     }
 }
 

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -4,7 +4,10 @@ use adw::subclass::prelude::*;
 use adw::{ActionRow, PreferencesGroup, ToastOverlay, prelude::*};
 use glib::subclass::InitializingObject;
 use gtk::glib::clone;
-use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, Scale, gdk, gio, glib};
+use gtk::{
+    Button, CompositeTemplate, Entry, EventControllerScroll, EventControllerScrollFlags, Image,
+    Label, ListBox, PropagationPhase, Scale, gdk, gio, glib,
+};
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
 
@@ -230,6 +233,21 @@ impl ObjectImpl for Window {
             }
         ));
         self.release_threshold_handler.replace(Some(handler_id));
+
+        // Eat scroll-wheel events on the threshold slider. By default
+        // GtkScale treats vertical scroll as increment / decrement,
+        // which makes the threshold drift any time the user scrolls
+        // the window and the cursor passes over the slider. We
+        // intercept in the capture phase and return Stop so the scale's
+        // own controller never sees the event. Side effect: scrolling
+        // doesn't pass through to the parent ScrolledWindow while the
+        // cursor is on the slider — to scroll, move the cursor off it.
+        let scroll_block = EventControllerScroll::new(
+            EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::HORIZONTAL,
+        );
+        scroll_block.set_propagation_phase(PropagationPhase::Capture);
+        scroll_block.connect_scroll(|_, _, _| glib::Propagation::Stop);
+        self.release_threshold_scale.add_controller(scroll_block);
     }
 }
 

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -232,7 +232,7 @@ impl ObjectImpl for Window {
             move |scale| {
                 let value = scale.value().round() as u32;
                 let label = if value == 0 {
-                    "disabled".to_string()
+                    "Disabled".to_string()
                 } else {
                     format!("{value} px")
                 };

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -6,7 +6,7 @@ use glib::subclass::InitializingObject;
 use gtk::glib::clone;
 use gtk::{
     Button, CompositeTemplate, Entry, EventControllerScroll, EventControllerScrollFlags, Image,
-    Label, ListBox, PropagationPhase, Scale, ScrolledWindow, gdk, gio, glib,
+    Label, ListBox, PropagationPhase, Scale, ScrolledWindow, Switch, gdk, gio, glib,
 };
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
@@ -54,6 +54,10 @@ pub struct Window {
     pub release_threshold_scale: TemplateChild<Scale>,
     #[template_child]
     pub release_threshold_value: TemplateChild<Label>,
+    #[template_child]
+    pub mdns_discovery_row: TemplateChild<ActionRow>,
+    #[template_child]
+    pub mdns_discovery_switch: TemplateChild<Switch>,
     pub clients: RefCell<Option<gio::ListStore>>,
     pub authorized: RefCell<Option<gio::ListStore>>,
     pub frontend_request_writer: RefCell<Option<FrontendRequestWriter>>,
@@ -65,6 +69,10 @@ pub struct Window {
     /// value-changed signal, so we can block it when programmatically
     /// updating the slider in response to a Sync event.
     pub release_threshold_handler: RefCell<Option<glib::SignalHandlerId>>,
+    /// Connected handler for the mDNS-discovery switch's state-set
+    /// signal, blocked while the daemon is pushing the initial value
+    /// via Sync.
+    pub mdns_discovery_handler: RefCell<Option<glib::SignalHandlerId>>,
 }
 
 #[glib::object_subclass]
@@ -276,6 +284,21 @@ impl ObjectImpl for Window {
             }
         ));
         self.release_threshold_scale.add_controller(scroll_forward);
+
+        // mDNS-discovery switch — connect state-set, stash the handler
+        // so the daemon's Sync push doesn't ricochet back.
+        let mdns_switch = self.mdns_discovery_switch.clone();
+        let mdns_handler = mdns_switch.connect_state_set(clone!(
+            #[weak(rename_to = window)]
+            obj,
+            #[upgrade_or]
+            glib::Propagation::Proceed,
+            move |_, state| {
+                window.request_mdns_discovery(state);
+                glib::Propagation::Proceed
+            }
+        ));
+        self.mdns_discovery_handler.replace(Some(mdns_handler));
     }
 }
 

--- a/lan-mouse-ipc/src/gui_lock.rs
+++ b/lan-mouse-ipc/src/gui_lock.rs
@@ -1,0 +1,219 @@
+//! Cross-platform GUI singleton.
+//!
+//! Lan Mouse can be launched as: a headless daemon (`lan-mouse daemon`),
+//! or a GUI that owns a child daemon (`lan-mouse` with no args). The
+//! daemon is already a singleton via its IPC socket. This module
+//! provides the *GUI*-side singleton: a separate socket that exists
+//! only while a GUI is running, decoupled from daemon state so the
+//! headless-then-GUI case still works.
+//!
+//! Acquire path: bind the socket. On success, this process is the
+//! primary GUI; spawn a listener on the bound socket and call
+//! `next_show()` to receive show requests from later launches.
+//!
+//! Signal path: if the bind fails because another GUI is already
+//! listening, connect to it, send a single byte, exit cleanly. The
+//! primary GUI's `next_show()` returns `Some(())` and the GUI
+//! presents its window.
+//!
+//! The mechanism is identical on all three platforms — Unix sockets
+//! on Linux/macOS, a localhost TCP listener on Windows — and works
+//! whether the daemon is embedded (`lan-mouse`) or standalone
+//! (`lan-mouse daemon`), because no daemon round-trip is involved.
+
+use std::io::{self, Read, Write};
+
+#[cfg(unix)]
+use std::{
+    os::unix::net::{UnixListener, UnixStream},
+    path::{Path, PathBuf},
+};
+
+#[cfg(windows)]
+use std::net::{TcpListener, TcpStream};
+
+use thiserror::Error;
+
+use crate::SocketPathError;
+
+#[cfg(unix)]
+const LAN_MOUSE_GUI_SOCKET_NAME: &str = "lan-mouse-gui.sock";
+
+#[cfg(windows)]
+const LAN_MOUSE_GUI_TCP: &str = "127.0.0.1:5253";
+
+/// Single-byte message: "show your window".
+const SHOW_BYTE: u8 = 0x01;
+
+#[derive(Debug, Error)]
+pub enum GuiLockError {
+    #[error(transparent)]
+    SocketPath(#[from] SocketPathError),
+    #[error("io error: `{0}`")]
+    Io(#[from] io::Error),
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn gui_socket_path() -> Result<PathBuf, SocketPathError> {
+    let xdg_runtime_dir =
+        std::env::var("XDG_RUNTIME_DIR").map_err(SocketPathError::XdgRuntimeDirNotFound)?;
+    Ok(Path::new(&xdg_runtime_dir).join(LAN_MOUSE_GUI_SOCKET_NAME))
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn gui_socket_path() -> Result<PathBuf, SocketPathError> {
+    let home = std::env::var("HOME").map_err(SocketPathError::HomeDirNotFound)?;
+    Ok(Path::new(&home)
+        .join("Library")
+        .join("Caches")
+        .join(LAN_MOUSE_GUI_SOCKET_NAME))
+}
+
+pub struct GuiLock {
+    #[cfg(unix)]
+    listener: UnixListener,
+    #[cfg(unix)]
+    socket_path: PathBuf,
+    #[cfg(windows)]
+    listener: TcpListener,
+}
+
+impl GuiLock {
+    /// Acquire the GUI singleton, or signal an existing GUI to show
+    /// itself.
+    ///
+    /// Returns `Ok(Some(lock))` when this process is the primary GUI;
+    /// keep the lock alive for the GUI's lifetime. Returns `Ok(None)`
+    /// when another GUI was already listening — the show byte has
+    /// been sent and the caller should exit.
+    pub fn acquire_or_signal() -> Result<Option<Self>, GuiLockError> {
+        #[cfg(unix)]
+        {
+            let socket_path = gui_socket_path()?;
+            if socket_path.exists() {
+                match UnixStream::connect(&socket_path) {
+                    Ok(mut stream) => {
+                        stream.write_all(&[SHOW_BYTE])?;
+                        return Ok(None);
+                    }
+                    Err(_) => {
+                        // Stale socket from a crashed GUI — clear it.
+                        let _ = std::fs::remove_file(&socket_path);
+                    }
+                }
+            }
+            let listener = UnixListener::bind(&socket_path)?;
+            Ok(Some(Self {
+                listener,
+                socket_path,
+            }))
+        }
+        #[cfg(windows)]
+        {
+            if let Ok(mut stream) = TcpStream::connect(LAN_MOUSE_GUI_TCP) {
+                stream.write_all(&[SHOW_BYTE])?;
+                return Ok(None);
+            }
+            let listener = TcpListener::bind(LAN_MOUSE_GUI_TCP)?;
+            Ok(Some(Self { listener }))
+        }
+    }
+
+    /// Block until a show request arrives. Returns `Some(())` for a
+    /// valid show byte, `None` if the listener was closed or a
+    /// malformed message was received (caller should keep looping).
+    pub fn next_show(&self) -> Option<()> {
+        let (mut stream, _) = self.listener.accept().ok()?;
+        let mut buf = [0u8; 1];
+        match stream.read_exact(&mut buf) {
+            Ok(()) if buf[0] == SHOW_BYTE => Some(()),
+            _ => Some(()), // Treat any non-fatal read as a poke.
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for GuiLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Acquire-twice should return Ok(Some) the first time and Ok(None)
+    /// (after sending the show byte) the second time. Drop the lock and
+    /// the next acquire should succeed again.
+    #[test]
+    fn acquire_then_signal_then_re_acquire() {
+        // Use a short path under /tmp so the resulting sockaddr_un fits
+        // in SUN_LEN (108 bytes on Linux, 104 on macOS) — XDG_RUNTIME_DIR
+        // and the macOS HOME/Library/Caches path can both blow past
+        // that when nested inside a tempdir.
+        let dir = std::path::PathBuf::from(format!("/tmp/lmt{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        #[cfg(target_os = "macos")]
+        let original_home = std::env::var("HOME").ok();
+        #[cfg(target_os = "macos")]
+        unsafe {
+            std::env::set_var("HOME", &dir);
+            std::fs::create_dir_all(dir.join("Library").join("Caches")).ok();
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let original = std::env::var("XDG_RUNTIME_DIR").ok();
+        #[cfg(all(unix, not(target_os = "macos")))]
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", &dir);
+        }
+
+        let lock = GuiLock::acquire_or_signal()
+            .expect("first acquire ok")
+            .expect("first acquire is primary");
+
+        // Spawn a thread to wait for the show signal.
+        let handle = std::thread::spawn(move || {
+            let got = lock.next_show();
+            (got, lock)
+        });
+
+        // Tiny sleep so the listener thread is parked in accept().
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Second acquire should signal-and-return-None.
+        let res = GuiLock::acquire_or_signal().expect("second acquire ok");
+        assert!(res.is_none(), "second acquire must signal-and-exit");
+
+        let (got, lock) = handle.join().unwrap();
+        assert_eq!(got, Some(()));
+
+        drop(lock);
+
+        // After dropping, acquire should succeed again as primary.
+        let _lock2 = GuiLock::acquire_or_signal()
+            .expect("third acquire ok")
+            .expect("third acquire primary");
+
+        // Restore env so we don't poison sibling tests.
+        drop(_lock2);
+        #[cfg(target_os = "macos")]
+        unsafe {
+            if let Some(h) = original_home {
+                std::env::set_var("HOME", h);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        unsafe {
+            if let Some(d) = original {
+                std::env::set_var("XDG_RUNTIME_DIR", d);
+            } else {
+                std::env::remove_var("XDG_RUNTIME_DIR");
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -18,10 +18,12 @@ use serde::{Deserialize, Serialize};
 
 mod connect;
 mod connect_async;
+mod gui_lock;
 mod listen;
 
 pub use connect::{FrontendEventReader, FrontendRequestWriter, connect};
 pub use connect_async::{AsyncFrontendEventReader, AsyncFrontendRequestWriter, connect_async};
+pub use gui_lock::{GuiLock, GuiLockError};
 pub use listen::AsyncFrontendListener;
 
 #[derive(Debug, Error)]

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -217,6 +217,9 @@ pub enum FrontendEvent {
     IncomingDisconnected(SocketAddr),
     /// failed connection attempt (approval for fingerprint required)
     ConnectionAttempt { fingerprint: String },
+    /// pixel threshold for the wall-press auto-release fallback.
+    /// 0 means disabled.
+    ReleaseThreshold(u32),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -255,6 +258,8 @@ pub enum FrontendRequest {
     UpdateEnterHook(u64, Option<String>),
     /// save config file
     SaveConfiguration,
+    /// set the wall-press auto-release pixel threshold (0 = disabled)
+    SetReleaseThreshold(u32),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -226,6 +226,11 @@ pub enum FrontendEvent {
     /// pixel threshold for the wall-press auto-release fallback.
     /// 0 means disabled.
     ReleaseThreshold(u32),
+    /// whether scroll events received from peers should be inverted
+    /// before being injected on this device. Mirrors the user's
+    /// libinput natural-scroll preference for forwarded events,
+    /// since virtual-pointer events bypass libinput entirely.
+    NaturalScroll(bool),
     /// whether mDNS-SD discovery is on. When true, lan-mouse
     /// advertises a `_lan-mouse._udp.local.` Bonjour service whose
     /// TXT record's `primary=` field hints at the OS-preferred
@@ -273,6 +278,10 @@ pub enum FrontendRequest {
     SaveConfiguration,
     /// set the wall-press auto-release pixel threshold (0 = disabled)
     SetReleaseThreshold(u32),
+    /// set whether forwarded scroll events should be inverted on
+    /// injection (matches the libinput natural-scroll concept for
+    /// virtual-pointer-injected events that bypass libinput)
+    SetNaturalScroll(bool),
     /// turn mDNS-SD discovery on or off
     SetMdnsDiscovery(bool),
 }

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -176,6 +176,12 @@ pub struct ClientState {
     pub has_pressed_keys: bool,
     /// dns resolving in progress
     pub resolving: bool,
+    /// Peer's build short commit hash from the [`Hello`] proto
+    /// event. `None` means we haven't received a Hello yet — either
+    /// the connection is fresh, or the peer is on an older build
+    /// that predates the Hello event. The frontend uses this to
+    /// soft-warn on version mismatch.
+    pub peer_commit: Option<[u8; 8]>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -226,6 +226,13 @@ pub enum FrontendEvent {
     /// pixel threshold for the wall-press auto-release fallback.
     /// 0 means disabled.
     ReleaseThreshold(u32),
+    /// whether mDNS-SD discovery is on. When true, lan-mouse
+    /// advertises a `_lan-mouse._udp.local.` Bonjour service whose
+    /// TXT record's `primary=` field hints at the OS-preferred
+    /// interface (Mac service order / Linux default route), so
+    /// peers can bias their connection attempts toward the right
+    /// interface on multi-homed hosts.
+    MdnsDiscovery(bool),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -266,6 +273,8 @@ pub enum FrontendRequest {
     SaveConfiguration,
     /// set the wall-press auto-release pixel threshold (0 = disabled)
     SetReleaseThreshold(u32),
+    /// turn mDNS-SD discovery on or off
+    SetMdnsDiscovery(bool),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -79,6 +79,15 @@ pub enum ProtoEvent {
     /// display bounds and the receiver-supplied [`ProtoEvent::Bounds`]
     /// from a prior Enter.
     MotionAbsolute { x: i32, y: i32 },
+    /// Self-sufficient counterpart to [`ProtoEvent::MotionAbsolute`].
+    /// Carries the host's cursor position normalized to the host's
+    /// own display bounds (0..1 along each axis) plus the entry
+    /// side from the receiver's frame. The receiver scales nx/ny
+    /// against its own bounds and pins the on-axis dimension to
+    /// the entry edge, eliminating the bootstrap problem where
+    /// MotionAbsolute couldn't be sent on the first crossing
+    /// because the host had no cached peer geometry.
+    CursorPos { pos: Position, nx: f32, ny: f32 },
 }
 
 impl Display for ProtoEvent {
@@ -98,6 +107,9 @@ impl Display for ProtoEvent {
             }
             ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
             ProtoEvent::MotionAbsolute { x, y } => write!(f, "MotionAbsolute({x}, {y})"),
+            ProtoEvent::CursorPos { pos, nx, ny } => {
+                write!(f, "CursorPos({pos}, {nx:.4}, {ny:.4})")
+            }
         }
     }
 }
@@ -118,6 +130,7 @@ pub enum EventType {
     Ack,
     Bounds,
     MotionAbsolute,
+    CursorPos,
 }
 
 impl ProtoEvent {
@@ -142,6 +155,7 @@ impl ProtoEvent {
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Bounds { .. } => EventType::Bounds,
             ProtoEvent::MotionAbsolute { .. } => EventType::MotionAbsolute,
+            ProtoEvent::CursorPos { .. } => EventType::CursorPos,
         }
     }
 }
@@ -203,6 +217,11 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::MotionAbsolute => Ok(Self::MotionAbsolute {
                 x: decode_i32(&mut buf)?,
                 y: decode_i32(&mut buf)?,
+            }),
+            EventType::CursorPos => Ok(Self::CursorPos {
+                pos: decode_u8(&mut buf)?.try_into()?,
+                nx: decode_f32(&mut buf)?,
+                ny: decode_f32(&mut buf)?,
             }),
         }
     }
@@ -276,6 +295,11 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                     encode_i32(buf, len, x);
                     encode_i32(buf, len, y);
                 }
+                ProtoEvent::CursorPos { pos, nx, ny } => {
+                    encode_u8(buf, len, pos as u8);
+                    encode_f32(buf, len, nx);
+                    encode_f32(buf, len, ny);
+                }
             }
         }
         (buf, len)
@@ -297,6 +321,7 @@ macro_rules! decode_impl {
 decode_impl!(u8);
 decode_impl!(u32);
 decode_impl!(i32);
+decode_impl!(f32);
 decode_impl!(f64);
 
 macro_rules! encode_impl {
@@ -317,4 +342,5 @@ macro_rules! encode_impl {
 encode_impl!(u8);
 encode_impl!(u32);
 encode_impl!(i32);
+encode_impl!(f32);
 encode_impl!(f64);

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -70,6 +70,15 @@ pub enum ProtoEvent {
     /// height are in pixels of the union of all displays on the
     /// emulating device.
     Bounds { width: u32, height: u32 },
+    /// Absolute cursor warp on the receiving device. Sent by the
+    /// capturing peer after [`ProtoEvent::Enter`] so the guest's
+    /// cursor lands at the position that visually corresponds to
+    /// where the user's physical cursor was at the moment of
+    /// crossing. `x` and `y` are pixel coordinates in the receiver's
+    /// screen space, computed by the capturing peer using its own
+    /// display bounds and the receiver-supplied [`ProtoEvent::Bounds`]
+    /// from a prior Enter.
+    MotionAbsolute { x: i32, y: i32 },
 }
 
 impl Display for ProtoEvent {
@@ -88,6 +97,7 @@ impl Display for ProtoEvent {
                 )
             }
             ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
+            ProtoEvent::MotionAbsolute { x, y } => write!(f, "MotionAbsolute({x}, {y})"),
         }
     }
 }
@@ -107,6 +117,7 @@ pub enum EventType {
     Leave,
     Ack,
     Bounds,
+    MotionAbsolute,
 }
 
 impl ProtoEvent {
@@ -130,6 +141,7 @@ impl ProtoEvent {
             ProtoEvent::Leave(_) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Bounds { .. } => EventType::Bounds,
+            ProtoEvent::MotionAbsolute { .. } => EventType::MotionAbsolute,
         }
     }
 }
@@ -187,6 +199,10 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::Bounds => Ok(Self::Bounds {
                 width: decode_u32(&mut buf)?,
                 height: decode_u32(&mut buf)?,
+            }),
+            EventType::MotionAbsolute => Ok(Self::MotionAbsolute {
+                x: decode_i32(&mut buf)?,
+                y: decode_i32(&mut buf)?,
             }),
         }
     }
@@ -255,6 +271,10 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                 ProtoEvent::Bounds { width, height } => {
                     encode_u32(buf, len, width);
                     encode_u32(buf, len, height);
+                }
+                ProtoEvent::MotionAbsolute { x, y } => {
+                    encode_i32(buf, len, x);
+                    encode_i32(buf, len, y);
                 }
             }
         }

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -63,6 +63,13 @@ pub enum ProtoEvent {
     Ping,
     /// Response to [`ProtoEvent::Ping`], true if emulation is enabled / available
     Pong(bool),
+    /// Display geometry of the receiving device. Sent by the
+    /// emulation side immediately after the [`ProtoEvent::Ack`] of
+    /// an [`ProtoEvent::Enter`] so the capturing peer can model the
+    /// guest cursor's position along the entry axis. Width and
+    /// height are in pixels of the union of all displays on the
+    /// emulating device.
+    Bounds { width: u32, height: u32 },
 }
 
 impl Display for ProtoEvent {
@@ -80,6 +87,7 @@ impl Display for ProtoEvent {
                     if *alive { "alive" } else { "not available" }
                 )
             }
+            ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
         }
     }
 }
@@ -98,6 +106,7 @@ pub enum EventType {
     Enter,
     Leave,
     Ack,
+    Bounds,
 }
 
 impl ProtoEvent {
@@ -120,6 +129,7 @@ impl ProtoEvent {
             ProtoEvent::Enter(_) => EventType::Enter,
             ProtoEvent::Leave(_) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
+            ProtoEvent::Bounds { .. } => EventType::Bounds,
         }
     }
 }
@@ -174,6 +184,10 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::Enter => Ok(Self::Enter(decode_u8(&mut buf)?.try_into()?)),
             EventType::Leave => Ok(Self::Leave(decode_u32(&mut buf)?)),
             EventType::Ack => Ok(Self::Ack(decode_u32(&mut buf)?)),
+            EventType::Bounds => Ok(Self::Bounds {
+                width: decode_u32(&mut buf)?,
+                height: decode_u32(&mut buf)?,
+            }),
         }
     }
 }
@@ -238,6 +252,10 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                 ProtoEvent::Enter(pos) => encode_u8(buf, len, pos as u8),
                 ProtoEvent::Leave(serial) => encode_u32(buf, len, serial),
                 ProtoEvent::Ack(serial) => encode_u32(buf, len, serial),
+                ProtoEvent::Bounds { width, height } => {
+                    encode_u32(buf, len, width);
+                    encode_u32(buf, len, height);
+                }
             }
         }
         (buf, len)

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -88,6 +88,15 @@ pub enum ProtoEvent {
     /// MotionAbsolute couldn't be sent on the first crossing
     /// because the host had no cached peer geometry.
     CursorPos { pos: Position, nx: f32, ny: f32 },
+    /// Build identification for the sending peer. Sent by the
+    /// connect side once after the connection authenticates, and
+    /// echoed back by the listen side in reply, so each end can
+    /// display the peer's build hash and warn (soft) on mismatch.
+    /// `commit` is the 8-byte ASCII short commit hash from
+    /// `shadow_rs`'s `SHORT_COMMIT`. Old peers that don't
+    /// recognize the event type silently skip it per the
+    /// forward-compat handling in the receive loop.
+    Hello { commit: [u8; 8] },
 }
 
 impl Display for ProtoEvent {
@@ -110,6 +119,10 @@ impl Display for ProtoEvent {
             ProtoEvent::CursorPos { pos, nx, ny } => {
                 write!(f, "CursorPos({pos}, {nx:.4}, {ny:.4})")
             }
+            ProtoEvent::Hello { commit } => {
+                let s = std::str::from_utf8(commit).unwrap_or("????????");
+                write!(f, "Hello({s})")
+            }
         }
     }
 }
@@ -131,6 +144,7 @@ pub enum EventType {
     Bounds,
     MotionAbsolute,
     CursorPos,
+    Hello,
 }
 
 impl ProtoEvent {
@@ -156,6 +170,7 @@ impl ProtoEvent {
             ProtoEvent::Bounds { .. } => EventType::Bounds,
             ProtoEvent::MotionAbsolute { .. } => EventType::MotionAbsolute,
             ProtoEvent::CursorPos { .. } => EventType::CursorPos,
+            ProtoEvent::Hello { .. } => EventType::Hello,
         }
     }
 }
@@ -223,6 +238,13 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
                 nx: decode_f32(&mut buf)?,
                 ny: decode_f32(&mut buf)?,
             }),
+            EventType::Hello => {
+                let mut commit = [0u8; 8];
+                for b in commit.iter_mut() {
+                    *b = decode_u8(&mut buf)?;
+                }
+                Ok(Self::Hello { commit })
+            }
         }
     }
 }
@@ -299,6 +321,11 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                     encode_u8(buf, len, pos as u8);
                     encode_f32(buf, len, nx);
                     encode_f32(buf, len, ny);
+                }
+                ProtoEvent::Hello { commit } => {
+                    for b in commit.iter() {
+                        encode_u8(buf, len, *b);
+                    }
                 }
             }
         }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -61,6 +61,8 @@ enum CaptureRequest {
     Reenable,
     /// set release bind
     SetReleaseBind(Vec<scancode::Linux>),
+    /// set the auto-release pixel threshold (macOS only). 0 disables.
+    SetReleaseThreshold(u32),
 }
 
 impl Capture {
@@ -68,6 +70,7 @@ impl Capture {
         backend: Option<input_capture::Backend>,
         conn: LanMouseConnection,
         release_bind: Vec<scancode::Linux>,
+        release_threshold_px: u32,
     ) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
@@ -81,6 +84,7 @@ impl Capture {
             event_tx,
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
+            release_threshold_px: Rc::new(RefCell::new(release_threshold_px)),
             state: Default::default(),
         };
         let task = spawn_local(capture_task.run());
@@ -137,6 +141,12 @@ impl Capture {
     pub(crate) fn set_release_bind(&mut self, bind: Vec<scancode::Linux>) {
         let _ = self.request_tx.send(CaptureRequest::SetReleaseBind(bind));
     }
+
+    pub(crate) fn set_release_threshold(&mut self, threshold: u32) {
+        let _ = self
+            .request_tx
+            .send(CaptureRequest::SetReleaseThreshold(threshold));
+    }
 }
 
 /// debounce a statement `$st`, i.e. the statement is executed only if the
@@ -164,6 +174,7 @@ struct CaptureTask {
     conn: LanMouseConnection,
     event_tx: Sender<ICaptureEvent>,
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
+    release_threshold_px: Rc<RefCell<u32>>,
     request_rx: Receiver<CaptureRequest>,
     state: State,
 }
@@ -214,6 +225,9 @@ impl CaptureTask {
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
+                        CaptureRequest::SetReleaseThreshold(threshold) => {
+                            *self.release_threshold_px.borrow_mut() = threshold;
+                        }
                     },
                     _ = self.cancellation_token.cancelled() => return,
                 }
@@ -240,6 +254,11 @@ impl CaptureTask {
             capture.terminate().await?;
             return Err(e.into());
         }
+
+        // Push the configured auto-release threshold to the freshly
+        // created InputCapture. The wall-press detection is
+        // cross-platform — every backend benefits.
+        capture.set_release_threshold(*self.release_threshold_px.borrow());
 
         let r = self.do_capture_session(&mut capture).await;
 
@@ -307,6 +326,10 @@ impl CaptureTask {
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);
                     }
+                    CaptureRequest::SetReleaseThreshold(threshold) => {
+                        *self.release_threshold_px.borrow_mut() = threshold;
+                        capture.set_release_threshold(threshold);
+                    }
                 },
                 _ = self.cancellation_token.cancelled() => break,
             }
@@ -324,6 +347,15 @@ impl CaptureTask {
 
         if capture.keys_pressed(&self.release_bind.borrow()) {
             log::info!("releasing capture: release-bind pressed");
+            return self.release_capture(capture).await;
+        }
+
+        // Backend self-released (currently only macOS, when sustained
+        // back-toward-host motion crosses the configured threshold).
+        // Drive the same teardown path as the release-bind chord so
+        // the peer gets a Leave + key-up flush.
+        if matches!(event, CaptureEvent::AutoRelease) {
+            log::info!("releasing capture: backend auto-release");
             return self.release_capture(capture).await;
         }
 
@@ -363,6 +395,7 @@ impl CaptureTask {
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
                 State::Sending => ProtoEvent::Input(e),
             },
+            CaptureEvent::AutoRelease => unreachable!("handled in early return above"),
         };
 
         if let Err(e) = self.conn.send(event, handle).await {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -371,7 +371,7 @@ impl CaptureTask {
             return self.release_capture(capture).await;
         }
 
-        if event == CaptureEvent::Begin {
+        if matches!(event, CaptureEvent::Begin { .. }) {
             self.event_tx
                 .send(ICaptureEvent::CaptureBegin(handle))
                 .expect("channel closed");
@@ -390,7 +390,7 @@ impl CaptureTask {
         }
 
         // activated a new client
-        if event == CaptureEvent::Begin && Some(handle) != self.active_client {
+        if matches!(event, CaptureEvent::Begin { .. }) && Some(handle) != self.active_client {
             self.state = State::WaitingForAck;
             self.active_client.replace(handle);
             self.event_tx
@@ -400,8 +400,23 @@ impl CaptureTask {
 
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
-        let event = match event {
-            CaptureEvent::Begin => ProtoEvent::Enter(opposite_pos),
+        // If we're starting a fresh capture and the backend reported a
+        // cursor position at the moment of crossing, compute the
+        // visually-corresponding target on the peer's screen so we can
+        // follow Enter with a MotionAbsolute event. Falls back to the
+        // entry-edge-midpoint warp on the guest when this is None
+        // (host can't report cursor or peer hasn't sent Bounds yet).
+        let warp_target = if let CaptureEvent::Begin {
+            cursor: Some(cursor),
+        } = event
+        {
+            capture.peer_warp_target(self.get_pos(handle), cursor)
+        } else {
+            None
+        };
+
+        let proto_event = match event {
+            CaptureEvent::Begin { .. } => ProtoEvent::Enter(opposite_pos),
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
@@ -410,10 +425,27 @@ impl CaptureTask {
             CaptureEvent::AutoRelease => unreachable!("handled in early return above"),
         };
 
-        if let Err(e) = self.conn.send(event, handle).await {
+        if let Err(e) = self.conn.send(proto_event, handle).await {
             const DUR: Duration = Duration::from_millis(500);
             debounce!(PREV_LOG, DUR, log::warn!("releasing capture: {e}"));
             capture.release().await?;
+            return Ok(());
+        }
+
+        // Send MotionAbsolute right after Enter so the guest can warp
+        // its cursor to the right point on its own screen. Done as a
+        // separate event so peers running an older protocol just
+        // tolerate-and-skip via the forward-compat decode path; new
+        // peers warp to (x, y) and override the entry-edge-midpoint
+        // warp triggered by Enter.
+        if let Some((x, y)) = warp_target {
+            if let Err(e) = self
+                .conn
+                .send(ProtoEvent::MotionAbsolute { x, y }, handle)
+                .await
+            {
+                log::warn!("MotionAbsolute send failed: {e}");
+            }
         }
         Ok(())
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -401,18 +401,34 @@ impl CaptureTask {
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
         // If we're starting a fresh capture and the backend reported a
-        // cursor position at the moment of crossing, compute the
-        // visually-corresponding target on the peer's screen so we can
-        // follow Enter with a MotionAbsolute event. Falls back to the
-        // entry-edge-midpoint warp on the guest when this is None
-        // (host can't report cursor or peer hasn't sent Bounds yet).
-        let warp_target = if let CaptureEvent::Begin {
+        // cursor position at the moment of crossing, compute two
+        // representations to follow Enter with:
+        //
+        //   * `MotionAbsolute` (peer pixel coords): more precise when
+        //     the peer's geometry is already cached, but None on the
+        //     very first crossing because we haven't seen `Bounds`
+        //     from the peer yet.
+        //   * `CursorPos` (host-normalized fraction + entry side):
+        //     self-sufficient — the receiver scales against its own
+        //     bounds. Works on the first crossing.
+        //
+        // Both events are emitted when applicable; the receiver
+        // tolerates either order and the second warp wins. Old peers
+        // that don't recognize `CursorPos` skip it via the proto
+        // forward-compat path.
+        let (warp_target, cursor_pos) = if let CaptureEvent::Begin {
             cursor: Some(cursor),
         } = event
         {
-            capture.peer_warp_target(self.get_pos(handle), cursor)
+            let pos = self.get_pos(handle);
+            let warp = capture.peer_warp_target(pos, cursor);
+            let norm = capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
+                let proto_pos = to_proto_pos(pos.opposite());
+                (proto_pos, nx, ny)
+            });
+            (warp, norm)
         } else {
-            None
+            (None, None)
         };
 
         let proto_event = match event {
@@ -445,6 +461,21 @@ impl CaptureTask {
                 .await
             {
                 log::warn!("MotionAbsolute send failed: {e}");
+            }
+        }
+        // Self-sufficient companion event: doesn't need cached peer
+        // bounds, so the very first crossing also lands the cursor
+        // at the visually-corresponding point. Sent after
+        // MotionAbsolute so a new peer that handles both ends up
+        // with the more recent (and more accurate, since it uses
+        // the peer's *current* display bounds) CursorPos warp.
+        if let Some((pos, nx, ny)) = cursor_pos {
+            if let Err(e) = self
+                .conn
+                .send(ProtoEvent::CursorPos { pos, nx, ny }, handle)
+                .await
+            {
+                log::warn!("CursorPos send failed: {e}");
             }
         }
         Ok(())

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -309,6 +309,13 @@ impl CaptureTask {
                             log::info!("releasing capture: left remote client device region");
                             self.release_capture(capture).await?;
                         },
+                        // Peer reported its display geometry — cache it
+                        // so the wall-press model has a real upper
+                        // clamp on virtual_pos for this position.
+                        ProtoEvent::Bounds { width, height } => {
+                            let pos = self.get_pos(handle);
+                            capture.set_peer_bounds(pos, width, height);
+                        }
                         _ => {}
                     }
                 },
@@ -320,8 +327,13 @@ impl CaptureTask {
                         capture.create(h, p).await?;
                     }
                     CaptureRequest::Destroy(h) => {
+                        let pos = self.get_pos(h);
                         self.remove_capture(h);
                         capture.destroy(h).await?;
+                        // Drop the cached geometry — the next client
+                        // added at this position may report different
+                        // bounds.
+                        capture.clear_peer_bounds(pos);
                     }
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -307,10 +307,20 @@ impl CaptureTask {
                             log::info!("client {handle} acknowledged the connection!");
                             self.state = State::Sending;
                         }
-                        // client disconnected
+                        // Peer sent Leave — either they just released
+                        // their own outbound capture, or they're
+                        // taking over and want us to stop sending to
+                        // them. The "taking over" case is the common
+                        // one (CaptureBegin on the peer triggers a
+                        // send_leave_event to every incoming address)
+                        // and is followed by Enter+CursorPos from the
+                        // peer. Use the handover release so the local
+                        // host warp doesn't race against the peer's
+                        // upcoming proportional CursorPos warp on our
+                        // shared cursor.
                         ProtoEvent::Leave(_) => {
                             log::info!("releasing capture: left remote client device region");
-                            self.release_capture(capture).await?;
+                            self.release_capture_handover(capture).await?;
                         },
                         // Peer reported its display geometry — cache it
                         // so the wall-press model has a real upper

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -400,35 +400,25 @@ impl CaptureTask {
 
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
-        // If we're starting a fresh capture and the backend reported a
-        // cursor position at the moment of crossing, compute two
-        // representations to follow Enter with:
-        //
-        //   * `MotionAbsolute` (peer pixel coords): more precise when
-        //     the peer's geometry is already cached, but None on the
-        //     very first crossing because we haven't seen `Bounds`
-        //     from the peer yet.
-        //   * `CursorPos` (host-normalized fraction + entry side):
-        //     self-sufficient — the receiver scales against its own
-        //     bounds. Works on the first crossing.
-        //
-        // Both events are emitted when applicable; the receiver
-        // tolerates either order and the second warp wins. Old peers
-        // that don't recognize `CursorPos` skip it via the proto
-        // forward-compat path.
-        let (warp_target, cursor_pos) = if let CaptureEvent::Begin {
+        // If we're starting a fresh capture and the backend reported
+        // a cursor position at the moment of crossing, send a
+        // `CursorPos` (host-normalized fraction + entry side from the
+        // peer's frame) right after Enter. The peer scales against
+        // its own live bounds and pins the on-axis dimension to the
+        // matching edge — self-sufficient, no prior `Bounds`
+        // round-trip needed, so the very first crossing also lands
+        // the cursor at the visually-corresponding point.
+        let cursor_pos = if let CaptureEvent::Begin {
             cursor: Some(cursor),
         } = event
         {
             let pos = self.get_pos(handle);
-            let warp = capture.peer_warp_target(pos, cursor);
-            let norm = capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
+            capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
                 let proto_pos = to_proto_pos(pos.opposite());
                 (proto_pos, nx, ny)
-            });
-            (warp, norm)
+            })
         } else {
-            (None, None)
+            None
         };
 
         let proto_event = match event {
@@ -448,27 +438,10 @@ impl CaptureTask {
             return Ok(());
         }
 
-        // Send MotionAbsolute right after Enter so the guest can warp
-        // its cursor to the right point on its own screen. Done as a
-        // separate event so peers running an older protocol just
-        // tolerate-and-skip via the forward-compat decode path; new
-        // peers warp to (x, y) and override the entry-edge-midpoint
-        // warp triggered by Enter.
-        if let Some((x, y)) = warp_target {
-            if let Err(e) = self
-                .conn
-                .send(ProtoEvent::MotionAbsolute { x, y }, handle)
-                .await
-            {
-                log::warn!("MotionAbsolute send failed: {e}");
-            }
-        }
-        // Self-sufficient companion event: doesn't need cached peer
-        // bounds, so the very first crossing also lands the cursor
-        // at the visually-corresponding point. Sent after
-        // MotionAbsolute so a new peer that handles both ends up
-        // with the more recent (and more accurate, since it uses
-        // the peer's *current* display bounds) CursorPos warp.
+        // Send CursorPos right after Enter so the receiver can warp
+        // its cursor to the visually-corresponding point on its own
+        // screen — overrides the entry-edge-midpoint warp the
+        // receiver otherwise applies on Enter.
         if let Some((pos, nx, ny)) = cursor_pos {
             if let Err(e) = self
                 .conn

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -443,6 +443,7 @@ impl CaptureTask {
         // screen — overrides the entry-edge-midpoint warp the
         // receiver otherwise applies on Enter.
         if let Some((pos, nx, ny)) = cursor_pos {
+            log::info!("[cursor-pos] send pos={pos:?} nx={nx:.3} ny={ny:.3}");
             if let Err(e) = self
                 .conn
                 .send(ProtoEvent::CursorPos { pos, nx, ny }, handle)
@@ -450,6 +451,10 @@ impl CaptureTask {
             {
                 log::warn!("CursorPos send failed: {e}");
             }
+        } else if matches!(event, CaptureEvent::Begin { .. }) {
+            log::info!(
+                "[cursor-pos] send skipped — Begin had no cursor or host_normalized_cursor returned None"
+            );
         }
         Ok(())
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -51,8 +51,11 @@ pub(crate) enum CaptureType {
 
 #[derive(Clone, Debug)]
 enum CaptureRequest {
-    /// capture must release the mouse
-    Release,
+    /// release because the remote peer is taking over (they sent
+    /// Enter+CursorPos). Skips the host-side warp so the peer's
+    /// proportional CursorPos warp doesn't get clobbered by a
+    /// racing local warp computed from stale virtual_cursor state.
+    ReleaseForHandover,
     /// add a capture client
     Create(CaptureHandle, Position, CaptureType),
     /// destory a capture client
@@ -128,9 +131,9 @@ impl Capture {
             .expect("channel closed");
     }
 
-    pub(crate) fn release(&self) {
+    pub(crate) fn release_for_handover(&self) {
         self.request_tx
-            .send(CaptureRequest::Release)
+            .send(CaptureRequest::ReleaseForHandover)
             .expect("channel closed");
     }
 
@@ -221,7 +224,7 @@ impl CaptureTask {
                         CaptureRequest::Reenable => break,
                         CaptureRequest::Create(h, p, t) => self.add_capture(h, p, t),
                         CaptureRequest::Destroy(h) => self.remove_capture(h),
-                        CaptureRequest::Release => { /* nothing to do */ }
+                        CaptureRequest::ReleaseForHandover => { /* nothing to do */ }
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
@@ -321,7 +324,7 @@ impl CaptureTask {
                 },
                 e = self.request_rx.recv() => match e.expect("channel closed") {
                     CaptureRequest::Reenable => { /* already active */ },
-                    CaptureRequest::Release => self.release_capture(capture).await?,
+                    CaptureRequest::ReleaseForHandover => self.release_capture_handover(capture).await?,
                     CaptureRequest::Create(h, p, t) => {
                         self.add_capture(h, p, t);
                         capture.create(h, p).await?;
@@ -460,6 +463,24 @@ impl CaptureTask {
     }
 
     async fn release_capture(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
+        self.notify_peer_of_leave(capture).await;
+        capture.release().await
+    }
+
+    /// Release path used when the peer is taking over (they sent
+    /// Enter+CursorPos). Same teardown — synthesize key-ups, reset
+    /// mods, send Leave — but skip the host-side cursor warp so it
+    /// doesn't race against the peer's authoritative CursorPos
+    /// warp on our shared cursor.
+    async fn release_capture_handover(
+        &mut self,
+        capture: &mut InputCapture,
+    ) -> Result<(), CaptureError> {
+        self.notify_peer_of_leave(capture).await;
+        capture.release_no_host_warp().await
+    }
+
+    async fn notify_peer_of_leave(&mut self, capture: &mut InputCapture) {
         // If we have an active client, notify them we're leaving
         if let Some(handle) = self.active_client.take() {
             // Synthesize key-up events for every key still held in the
@@ -502,7 +523,6 @@ impl CaptureTask {
                 log::warn!("failed to send Leave to client {handle}: {e}");
             }
         }
-        capture.release().await
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,6 +282,12 @@ impl ClientManager {
         }
     }
 
+    pub(crate) fn set_peer_commit(&self, handle: ClientHandle, commit: Option<[u8; 8]>) {
+        if let Some((_, s)) = self.clients.borrow_mut().get_mut(handle as usize) {
+            s.peer_commit = commit;
+        }
+    }
+
     pub(crate) fn active_addr(&self, handle: ClientHandle) -> Option<SocketAddr> {
         self.clients
             .borrow()

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,10 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    /// pixel threshold for the wall-press auto-release fallback.
+    /// 0 (or absent) disables it; the cursor only releases on the
+    /// release-bind chord or a peer-side `Leave`.
+    release_threshold_px: Option<u32>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -477,6 +481,25 @@ impl Config {
             .as_ref()
             .and_then(|c| c.release_bind.clone())
             .unwrap_or(Vec::from_iter(DEFAULT_RELEASE_KEYS.iter().cloned()))
+    }
+
+    /// Pixel threshold for the wall-press auto-release fallback.
+    /// 0 disables it.
+    pub fn release_threshold_px(&self) -> u32 {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.release_threshold_px)
+            .unwrap_or(0)
+    }
+
+    pub fn set_release_threshold_px(&mut self, threshold: u32) {
+        if self.config_toml.is_none() {
+            self.config_toml = Some(Default::default());
+        }
+        self.config_toml
+            .as_mut()
+            .expect("config")
+            .release_threshold_px = Some(threshold);
     }
 
     /// set configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,11 @@ struct ConfigToml {
     /// 0 (or absent) disables it; the cursor only releases on the
     /// release-bind chord or a peer-side `Leave`.
     release_threshold_px: Option<u32>,
+    /// invert the sign of scroll events received from peers before
+    /// emulation. Equivalent to the libinput `natural_scroll`
+    /// preference, but applied to forwarded events that bypass
+    /// libinput entirely on Wayland virtual-pointer paths.
+    natural_scroll: Option<bool>,
     /// Advertise (and consume) `_lan-mouse._udp.local.` Bonjour
     /// service records. The TXT record's `primary=` field tells the
     /// dialer which interface IP the OS prefers (macOS service order
@@ -77,11 +82,6 @@ struct ConfigToml {
     /// blindly. Default true; turn off on networks where mDNS
     /// multicast (224.0.0.251) is firewalled.
     mdns_discovery: Option<bool>,
-    /// invert the sign of scroll events received from peers before
-    /// emulation. Equivalent to the libinput `natural_scroll`
-    /// preference, but applied to forwarded events that bypass
-    /// libinput entirely on Wayland virtual-pointer paths.
-    natural_scroll: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -535,22 +535,6 @@ impl Config {
             .release_threshold_px = Some(threshold);
     }
 
-    /// Whether mDNS-SD discovery is enabled. Defaults to true when
-    /// the key is absent.
-    pub fn mdns_discovery(&self) -> bool {
-        self.config_toml
-            .as_ref()
-            .and_then(|c| c.mdns_discovery)
-            .unwrap_or(true)
-    }
-
-    pub fn set_mdns_discovery(&mut self, enabled: bool) {
-        if self.config_toml.is_none() {
-            self.config_toml = Some(Default::default());
-        }
-        self.config_toml.as_mut().expect("config").mdns_discovery = Some(enabled);
-    }
-
     /// Whether forwarded scroll events should be sign-inverted on
     /// injection. Default false.
     pub fn natural_scroll(&self) -> bool {
@@ -565,6 +549,22 @@ impl Config {
             self.config_toml = Some(Default::default());
         }
         self.config_toml.as_mut().expect("config").natural_scroll = Some(natural_scroll);
+    }
+
+    /// Whether mDNS-SD discovery is enabled. Defaults to true when
+    /// the key is absent.
+    pub fn mdns_discovery(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.mdns_discovery)
+            .unwrap_or(true)
+    }
+
+    pub fn set_mdns_discovery(&mut self, enabled: bool) {
+        if self.config_toml.is_none() {
+            self.config_toml = Some(Default::default());
+        }
+        self.config_toml.as_mut().expect("config").mdns_discovery = Some(enabled);
     }
 
     /// set configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,11 @@ struct ConfigToml {
     /// blindly. Default true; turn off on networks where mDNS
     /// multicast (224.0.0.251) is firewalled.
     mdns_discovery: Option<bool>,
+    /// invert the sign of scroll events received from peers before
+    /// emulation. Equivalent to the libinput `natural_scroll`
+    /// preference, but applied to forwarded events that bypass
+    /// libinput entirely on Wayland virtual-pointer paths.
+    natural_scroll: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -544,6 +549,22 @@ impl Config {
             self.config_toml = Some(Default::default());
         }
         self.config_toml.as_mut().expect("config").mdns_discovery = Some(enabled);
+    }
+
+    /// Whether forwarded scroll events should be sign-inverted on
+    /// injection. Default false.
+    pub fn natural_scroll(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.natural_scroll)
+            .unwrap_or(false)
+    }
+
+    pub fn set_natural_scroll(&mut self, natural_scroll: bool) {
+        if self.config_toml.is_none() {
+            self.config_toml = Some(Default::default());
+        }
+        self.config_toml.as_mut().expect("config").natural_scroll = Some(natural_scroll);
     }
 
     /// set configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -538,7 +538,6 @@ impl Config {
         self.config_toml.as_mut().expect("config").mdns_discovery = Some(enabled);
     }
 
-
     /// set configured clients
     pub fn set_clients(&mut self, clients: Vec<ConfigClient>) {
         if clients.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,14 @@ struct ConfigToml {
     /// 0 (or absent) disables it; the cursor only releases on the
     /// release-bind chord or a peer-side `Leave`.
     release_threshold_px: Option<u32>,
+    /// Advertise (and consume) `_lan-mouse._udp.local.` Bonjour
+    /// service records. The TXT record's `primary=` field tells the
+    /// dialer which interface IP the OS prefers (macOS service order
+    /// / Linux default route), so when a peer is multi-homed the
+    /// dialer biases toward the right interface instead of racing
+    /// blindly. Default true; turn off on networks where mDNS
+    /// multicast (224.0.0.251) is firewalled.
+    mdns_discovery: Option<bool>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -513,6 +521,23 @@ impl Config {
             .expect("config")
             .release_threshold_px = Some(threshold);
     }
+
+    /// Whether mDNS-SD discovery is enabled. Defaults to true when
+    /// the key is absent.
+    pub fn mdns_discovery(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.mdns_discovery)
+            .unwrap_or(true)
+    }
+
+    pub fn set_mdns_discovery(&mut self, enabled: bool) {
+        if self.config_toml.is_none() {
+            self.config_toml = Some(Default::default());
+        }
+        self.config_toml.as_mut().expect("config").mdns_discovery = Some(enabled);
+    }
+
 
     /// set configured clients
     pub fn set_clients(&mut self, clients: Vec<ConfigClient>) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,14 @@ pub enum Command {
     Cli(CliArgs),
     /// run in daemon mode
     Daemon,
+    /// macOS-only: probe Accessibility permission in a fresh process
+    /// (which bypasses the cached TCC trust state in already-running
+    /// processes). Exits with status 0 if granted, 1 if not. Used by
+    /// the daemon's TCC.db watcher to detect "remove from list" cases
+    /// where AXIsProcessTrusted in the parent process keeps reporting
+    /// cached-true even after the entry is removed.
+    #[cfg(target_os = "macos")]
+    AxProbe,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,18 @@ use shadow_rs::shadow;
 
 shadow!(build);
 
+/// Local build's 8-byte ASCII short commit hash, suitable for use
+/// in [`lan_mouse_proto::ProtoEvent::Hello`]. Pads with `'?'` if
+/// shadow_rs returns an unexpected length so the field is always
+/// well-formed on the wire.
+pub fn local_commit() -> [u8; 8] {
+    let bytes = build::SHORT_COMMIT.as_bytes();
+    let mut out = [b'?'; 8];
+    let n = bytes.len().min(8);
+    out[..n].copy_from_slice(&bytes[..n]);
+    out
+}
+
 const CONFIG_FILE_NAME: &str = "config.toml";
 const CERT_FILE_NAME: &str = "lan-mouse.pem";
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -255,16 +255,23 @@ async fn receive_loop(
 ) {
     let mut buf = [0u8; MAX_EVENT_SIZE];
     while conn.recv(&mut buf).await.is_ok() {
-        if let Ok(event) = buf.try_into() {
-            log::trace!("{addr} <==<==<== {event}");
-            match event {
-                ProtoEvent::Pong(b) => {
-                    client_manager.set_active_addr(handle, Some(addr));
-                    client_manager.set_alive(handle, b);
-                    ping_response.borrow_mut().insert(addr);
+        match buf.try_into() {
+            Ok(event) => {
+                log::trace!("{addr} <==<==<== {event}");
+                match event {
+                    ProtoEvent::Pong(b) => {
+                        client_manager.set_active_addr(handle, Some(addr));
+                        client_manager.set_alive(handle, b);
+                        ping_response.borrow_mut().insert(addr);
+                    }
+                    event => tx.send((handle, event)).expect("channel closed"),
                 }
-                event => tx.send((handle, event)).expect("channel closed"),
             }
+            // Skip undecodable datagrams without dropping the
+            // connection. Each DTLS recv is one framed message, so
+            // skipping is safe and keeps us forward-compatible with
+            // peers that send event types we don't yet know about.
+            Err(e) => log::debug!("ignoring undecodable event from {addr}: {e}"),
         }
     }
     log::warn!("recv error");

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,6 +1,6 @@
 use crate::client::ClientManager;
 use crate::config::local_commit;
-use crate::discovery::PrimaryCache;
+use crate::discovery::{PrimaryCache, normalize_mdns_name};
 use lan_mouse_ipc::{ClientHandle, DEFAULT_PORT};
 use lan_mouse_proto::{MAX_EVENT_SIZE, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -282,7 +282,7 @@ impl LanMouseConnection {
     fn should_attempt(&self, handle: ClientHandle) -> bool {
         let ips = self.client_manager.get_ips(handle).unwrap_or_default();
         let primary = self.client_manager.get_hostname(handle).and_then(|h| {
-            let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
+            let key = normalize_mdns_name(&h);
             self.primary_hints.borrow().get(&key).copied()
         });
         let sig = signature_of(&ips, primary);
@@ -326,7 +326,7 @@ async fn connect_to_handle(
         // so a healthy primary almost always wins regardless of
         // raw RTT ordering.
         let primary_ip = client_manager.get_hostname(handle).and_then(|h| {
-            let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
+            let key = normalize_mdns_name(&h);
             primary_hints.borrow().get(&key).copied()
         });
         let preferred = primary_ip.map(|ip| SocketAddr::new(ip, port));

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,5 +1,6 @@
 use crate::client::ClientManager;
 use crate::config::local_commit;
+use crate::discovery::PrimaryCache;
 use lan_mouse_ipc::{ClientHandle, DEFAULT_PORT};
 use lan_mouse_proto::{MAX_EVENT_SIZE, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -71,12 +72,43 @@ async fn connect(
     }
 }
 
+/// Time the preferred address gets to handshake alone before the
+/// rest of the candidate list joins the race. Modeled on RFC 8305
+/// "happy eyeballs" v6→v4 fallback delay; long enough that a healthy
+/// preferred address virtually always wins, short enough that a
+/// broken preferred path only slightly delays connect.
+const PREFERRED_ADDR_HEAD_START: Duration = Duration::from_millis(200);
+
 async fn connect_any(
     addrs: &[SocketAddr],
+    preferred: Option<SocketAddr>,
     cert: Certificate,
 ) -> Result<(Arc<dyn Conn + Send + Sync>, SocketAddr), LanMouseConnectionError> {
     let mut joinset = JoinSet::new();
+    if let Some(p) = preferred {
+        // Dial the peer's mDNS-advertised primary first. If it
+        // handshakes within `PREFERRED_ADDR_HEAD_START` we're done
+        // before the others even start — the dialer biases toward
+        // the OS-preferred interface (Mac service order, Linux
+        // default route) without relying on RTT racing alone.
+        joinset.spawn_local(connect(p, cert.clone()));
+        let head_start = tokio::time::sleep(PREFERRED_ADDR_HEAD_START);
+        tokio::pin!(head_start);
+        loop {
+            tokio::select! {
+                _ = &mut head_start => break,
+                Some(r) = joinset.join_next() => match r.expect("join error") {
+                    Ok(conn) => return Ok(conn),
+                    Err((a, e)) => log::warn!("failed to connect to {a}: `{e}`"),
+                },
+            }
+        }
+    }
     for &addr in addrs {
+        if Some(addr) == preferred {
+            // already racing; don't dial the same socket twice
+            continue;
+        }
         joinset.spawn_local(connect(addr, cert.clone()));
     }
     loop {
@@ -100,10 +132,19 @@ pub(crate) struct LanMouseConnection {
     recv_rx: Receiver<(ClientHandle, ProtoEvent)>,
     recv_tx: Sender<(ClientHandle, ProtoEvent)>,
     ping_response: Rc<RefCell<HashSet<SocketAddr>>>,
+    /// Map of `peer_hostname -> primary_ipv4` populated by the
+    /// `Discovery` mDNS browse task. Read on every `connect_to_handle`
+    /// to bias which address gets the handshake head-start. Empty
+    /// when discovery is disabled or no peer hint has arrived yet.
+    primary_hints: PrimaryCache,
 }
 
 impl LanMouseConnection {
-    pub(crate) fn new(cert: Certificate, client_manager: ClientManager) -> Self {
+    pub(crate) fn new(
+        cert: Certificate,
+        client_manager: ClientManager,
+        primary_hints: PrimaryCache,
+    ) -> Self {
         let (recv_tx, recv_rx) = channel();
         Self {
             cert,
@@ -113,6 +154,7 @@ impl LanMouseConnection {
             recv_rx,
             recv_tx,
             ping_response: Default::default(),
+            primary_hints,
         }
     }
 
@@ -161,6 +203,7 @@ impl LanMouseConnection {
                 self.connecting.clone(),
                 self.recv_tx.clone(),
                 self.ping_response.clone(),
+                self.primary_hints.clone(),
             ));
         }
         Err(LanMouseConnectionError::NotConnected)
@@ -175,6 +218,7 @@ async fn connect_to_handle(
     connecting: Rc<Mutex<HashSet<ClientHandle>>>,
     tx: Sender<(ClientHandle, ProtoEvent)>,
     ping_response: Rc<RefCell<HashSet<SocketAddr>>>,
+    primary_hints: PrimaryCache,
 ) -> Result<(), LanMouseConnectionError> {
     log::info!("client {handle} connecting ...");
     // sending did not work, figure out active conn.
@@ -184,8 +228,22 @@ async fn connect_to_handle(
             .into_iter()
             .map(|a| SocketAddr::new(a, port))
             .collect::<Vec<_>>();
-        log::info!("client ({handle}) connecting ... (ips: {addrs:?})");
-        let res = connect_any(&addrs, cert).await;
+        // mDNS-advertised primary IP for this peer, if known. Used
+        // by `connect_any` as a head-start address: the dialer races
+        // it alone for ~200ms before joining the rest of the list,
+        // so a healthy primary almost always wins regardless of
+        // raw RTT ordering.
+        let preferred = client_manager
+            .get_hostname(handle)
+            .and_then(|h| {
+                let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
+                primary_hints.borrow().get(&key).copied()
+            })
+            .map(|ip| SocketAddr::new(ip, port));
+        log::info!(
+            "client ({handle}) connecting ... (ips: {addrs:?}, preferred: {preferred:?})"
+        );
+        let res = connect_any(&addrs, preferred, cert).await;
         let (conn, addr) = match res {
             Ok(c) => c,
             Err(e) => {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -277,6 +277,7 @@ impl LanMouseConnection {
     ///   - the candidate-set signature has changed since the last
     ///     attempt (new IP from DNS, or new mDNS primary), or
     ///   - the recorded backoff has elapsed.
+    ///
     /// Otherwise returns false; the caller treats this as "still in
     /// cooldown, keep returning NotConnected silently."
     fn should_attempt(&self, handle: ClientHandle) -> bool {
@@ -300,6 +301,7 @@ impl LanMouseConnection {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn connect_to_handle(
     client_manager: ClientManager,
     cert: Certificate,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,11 +7,12 @@ use local_channel::mpsc::{Receiver, Sender, channel};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    hash::{DefaultHasher, Hash, Hasher},
     io,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     rc::Rc,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use thiserror::Error;
 use tokio::{
@@ -43,6 +44,58 @@ pub(crate) enum LanMouseConnectionError {
 }
 
 const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Initial backoff between connect attempts that find no usable address
+/// (no static IPs, no DNS-resolved IPs, no mDNS primary hint). Doubles
+/// on each subsequent failure up to [`MAX_RETRY_BACKOFF`]. The backoff
+/// is bypassed entirely when the input set changes (e.g. mDNS browse
+/// resolves a primary, DNS lookup returns IPs) so a peer that comes
+/// back online reconnects on the next mouse event without waiting.
+const INITIAL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Per-handle gate that throttles repeat connect attempts when nothing
+/// new is available to dial. `signature` hashes the candidate set we
+/// last attempted; if the current set differs we skip the gate and
+/// retry immediately. Otherwise `next_attempt_at` enforces exponential
+/// backoff capped at [`MAX_RETRY_BACKOFF`].
+struct RetryState {
+    next_attempt_at: Instant,
+    backoff: Duration,
+    signature: u64,
+}
+
+fn signature_of(ips: &HashSet<IpAddr>, primary: Option<IpAddr>) -> u64 {
+    let mut sorted: Vec<IpAddr> = ips.iter().copied().collect();
+    sorted.sort();
+    let mut hasher = DefaultHasher::new();
+    sorted.hash(&mut hasher);
+    primary.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Update `retry_state[handle]` after a failed connect attempt: doubles
+/// the backoff (capped at [`MAX_RETRY_BACKOFF`]) and stamps the
+/// candidate-set signature so a later signature change can short-
+/// circuit the gate.
+fn record_retry_failure(
+    retry_state: &Rc<RefCell<HashMap<ClientHandle, RetryState>>>,
+    handle: ClientHandle,
+    ips: &HashSet<IpAddr>,
+    primary: Option<IpAddr>,
+) {
+    let sig = signature_of(ips, primary);
+    let mut map = retry_state.borrow_mut();
+    let entry = map.entry(handle).or_insert(RetryState {
+        next_attempt_at: Instant::now(),
+        backoff: INITIAL_RETRY_BACKOFF,
+        signature: sig,
+    });
+    entry.signature = sig;
+    let next = entry.backoff;
+    entry.next_attempt_at = Instant::now() + next;
+    entry.backoff = (next * 2).min(MAX_RETRY_BACKOFF);
+}
 
 async fn connect(
     addr: SocketAddr,
@@ -137,6 +190,13 @@ pub(crate) struct LanMouseConnection {
     /// to bias which address gets the handshake head-start. Empty
     /// when discovery is disabled or no peer hint has arrived yet.
     primary_hints: PrimaryCache,
+    /// Per-handle retry gate. Suppresses connect spawns when the
+    /// previous attempt failed and nothing new is available to dial,
+    /// so an offline peer doesn't trigger a fresh `connect_to_handle`
+    /// (and the associated DNS / mDNS lookup churn) on every mouse
+    /// event. Cleared on successful connect; bypassed automatically
+    /// when the candidate-set signature changes.
+    retry_state: Rc<RefCell<HashMap<ClientHandle, RetryState>>>,
 }
 
 impl LanMouseConnection {
@@ -155,6 +215,7 @@ impl LanMouseConnection {
             recv_tx,
             ping_response: Default::default(),
             primary_hints,
+            retry_state: Default::default(),
         }
     }
 
@@ -192,7 +253,7 @@ impl LanMouseConnection {
 
         // check if we are already trying to connect
         let mut connecting = self.connecting.lock().await;
-        if !connecting.contains(&handle) {
+        if !connecting.contains(&handle) && self.should_attempt(handle) {
             connecting.insert(handle);
             // connect in the background
             spawn_local(connect_to_handle(
@@ -204,9 +265,38 @@ impl LanMouseConnection {
                 self.recv_tx.clone(),
                 self.ping_response.clone(),
                 self.primary_hints.clone(),
+                self.retry_state.clone(),
             ));
         }
         Err(LanMouseConnectionError::NotConnected)
+    }
+
+    /// Decide whether to spawn another `connect_to_handle` for `handle`.
+    /// Returns true (and refreshes the recorded signature) when:
+    ///   - we have no prior attempt for this handle, or
+    ///   - the candidate-set signature has changed since the last
+    ///     attempt (new IP from DNS, or new mDNS primary), or
+    ///   - the recorded backoff has elapsed.
+    /// Otherwise returns false; the caller treats this as "still in
+    /// cooldown, keep returning NotConnected silently."
+    fn should_attempt(&self, handle: ClientHandle) -> bool {
+        let ips = self.client_manager.get_ips(handle).unwrap_or_default();
+        let primary = self.client_manager.get_hostname(handle).and_then(|h| {
+            let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
+            self.primary_hints.borrow().get(&key).copied()
+        });
+        let sig = signature_of(&ips, primary);
+        let mut state = self.retry_state.borrow_mut();
+        match state.get_mut(&handle) {
+            None => true,
+            Some(s) if s.signature != sig => {
+                s.signature = sig;
+                s.next_attempt_at = Instant::now();
+                s.backoff = INITIAL_RETRY_BACKOFF;
+                true
+            }
+            Some(s) => Instant::now() >= s.next_attempt_at,
+        }
     }
 }
 
@@ -219,13 +309,15 @@ async fn connect_to_handle(
     tx: Sender<(ClientHandle, ProtoEvent)>,
     ping_response: Rc<RefCell<HashSet<SocketAddr>>>,
     primary_hints: PrimaryCache,
+    retry_state: Rc<RefCell<HashMap<ClientHandle, RetryState>>>,
 ) -> Result<(), LanMouseConnectionError> {
     log::info!("client {handle} connecting ...");
     // sending did not work, figure out active conn.
-    if let Some(addrs) = client_manager.get_ips(handle) {
+    if let Some(ips_set) = client_manager.get_ips(handle) {
         let port = client_manager.get_port(handle).unwrap_or(DEFAULT_PORT);
-        let addrs = addrs
-            .into_iter()
+        let addrs = ips_set
+            .iter()
+            .copied()
             .map(|a| SocketAddr::new(a, port))
             .collect::<Vec<_>>();
         // mDNS-advertised primary IP for this peer, if known. Used
@@ -233,20 +325,26 @@ async fn connect_to_handle(
         // it alone for ~200ms before joining the rest of the list,
         // so a healthy primary almost always wins regardless of
         // raw RTT ordering.
-        let preferred = client_manager
-            .get_hostname(handle)
-            .and_then(|h| {
-                let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
-                primary_hints.borrow().get(&key).copied()
-            })
-            .map(|ip| SocketAddr::new(ip, port));
-        log::info!(
-            "client ({handle}) connecting ... (ips: {addrs:?}, preferred: {preferred:?})"
-        );
+        let primary_ip = client_manager.get_hostname(handle).and_then(|h| {
+            let key = h.strip_suffix('.').unwrap_or(&h).to_ascii_lowercase();
+            primary_hints.borrow().get(&key).copied()
+        });
+        let preferred = primary_ip.map(|ip| SocketAddr::new(ip, port));
+        log::info!("client ({handle}) connecting ... (ips: {addrs:?}, preferred: {preferred:?})");
+        if addrs.is_empty() && preferred.is_none() {
+            // Nothing to dial. Bump backoff and bail without spawning
+            // DTLS work or spamming logs on every subsequent mouse
+            // event — `should_attempt` will keep gating until either
+            // the backoff elapses or new info arrives.
+            record_retry_failure(&retry_state, handle, &ips_set, primary_ip);
+            connecting.lock().await.remove(&handle);
+            return Err(LanMouseConnectionError::NotConnected);
+        }
         let res = connect_any(&addrs, preferred, cert).await;
         let (conn, addr) = match res {
             Ok(c) => c,
             Err(e) => {
+                record_retry_failure(&retry_state, handle, &ips_set, primary_ip);
                 connecting.lock().await.remove(&handle);
                 return Err(e);
             }
@@ -255,6 +353,7 @@ async fn connect_to_handle(
         client_manager.set_active_addr(handle, Some(addr));
         conns.lock().await.insert(addr, conn.clone());
         connecting.lock().await.remove(&handle);
+        retry_state.borrow_mut().remove(&handle);
 
         // Best-effort version handshake. Send our commit hash once
         // immediately after the DTLS handshake; the listen side

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -203,7 +203,10 @@ async fn connect_to_handle(
         // mirrors a Hello back so the receive loop can populate
         // `peer_commit`. Old peers will silently skip this event
         // per the forward-compat handler in [`receive_loop`].
-        let (buf, len) = ProtoEvent::Hello { commit: local_commit() }.into();
+        let (buf, len) = ProtoEvent::Hello {
+            commit: local_commit(),
+        }
+        .into();
         if let Err(e) = conn.send(&buf[..len]).await {
             log::debug!("hello send to {addr} failed: {e}");
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,4 +1,5 @@
 use crate::client::ClientManager;
+use crate::config::local_commit;
 use lan_mouse_ipc::{ClientHandle, DEFAULT_PORT};
 use lan_mouse_proto::{MAX_EVENT_SIZE, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -197,6 +198,16 @@ async fn connect_to_handle(
         conns.lock().await.insert(addr, conn.clone());
         connecting.lock().await.remove(&handle);
 
+        // Best-effort version handshake. Send our commit hash once
+        // immediately after the DTLS handshake; the listen side
+        // mirrors a Hello back so the receive loop can populate
+        // `peer_commit`. Old peers will silently skip this event
+        // per the forward-compat handler in [`receive_loop`].
+        let (buf, len) = ProtoEvent::Hello { commit: local_commit() }.into();
+        if let Err(e) = conn.send(&buf[..len]).await {
+            log::debug!("hello send to {addr} failed: {e}");
+        }
+
         // poll connection for active
         spawn_local(ping_pong(addr, conn.clone(), ping_response.clone()));
 
@@ -264,6 +275,9 @@ async fn receive_loop(
                         client_manager.set_alive(handle, b);
                         ping_response.borrow_mut().insert(addr);
                     }
+                    ProtoEvent::Hello { commit } => {
+                        client_manager.set_peer_commit(handle, Some(commit));
+                    }
                     event => tx.send((handle, event)).expect("channel closed"),
                 }
             }
@@ -287,6 +301,7 @@ async fn disconnect(
     log::warn!("client ({handle}) @ {addr} connection closed");
     conns.lock().await.remove(&addr);
     client_manager.set_active_addr(handle, None);
+    client_manager.set_peer_commit(handle, None);
     let active: Vec<SocketAddr> = conns.lock().await.keys().copied().collect();
     log::info!("active connections: {active:?}");
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -280,10 +280,8 @@ impl Discovery {
     /// need to take the same Rc reference.
     #[allow(dead_code)]
     pub(crate) fn peer_primary_ip(&self, hostname: &str) -> Option<IpAddr> {
-        if self.daemon.is_none() {
-            return None;
-        }
-        let key = strip_trailing_dot(hostname).to_ascii_lowercase();
+        self.daemon.as_ref()?;
+        let key = normalize_mdns_name(hostname);
         self.primary_cache.borrow().get(&key).copied()
     }
 }
@@ -312,8 +310,7 @@ fn start_browse(
         while let Ok(event) = receiver.recv_async().await {
             match event {
                 ServiceEvent::ServiceResolved(resolved) => {
-                    let Some(primary_str) = resolved.get_property_val_str(TXT_PRIMARY_KEY)
-                    else {
+                    let Some(primary_str) = resolved.get_property_val_str(TXT_PRIMARY_KEY) else {
                         continue;
                     };
                     let Ok(ip) = primary_str.parse::<IpAddr>() else {
@@ -323,8 +320,7 @@ fn start_browse(
                         );
                         continue;
                     };
-                    let instance =
-                        instance_from_fullname(resolved.get_fullname(), SERVICE_TYPE);
+                    let instance = instance_from_fullname(resolved.get_fullname(), SERVICE_TYPE);
                     let key = normalize_mdns_name(instance);
                     let target = strip_trailing_dot(resolved.get_hostname());
                     log::info!(

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -65,6 +65,22 @@ fn strip_trailing_dot(s: &str) -> &str {
     s.strip_suffix('.').unwrap_or(s)
 }
 
+/// Pull the service-instance label off a Bonjour fullname.
+///
+/// `mdns-sd` returns fullnames as `"<instance>.<service-type>"` where
+/// `<service-type>` is e.g. `"_lan-mouse._udp.local."`. The instance
+/// label is the user-visible identifier the announcer chose for itself
+/// — typically the system hostname, and the same string the user puts
+/// in their lan-mouse config's `hostname = "..."`. We key
+/// [`PrimaryCache`] on this instead of the SRV target so the dialer
+/// matches the config hostname even when the announcer's SRV target
+/// has macOS-style suffixes (`Foo.local` vs `Foo-2.local`) or other
+/// drift.
+fn instance_from_fullname<'a>(fullname: &'a str, service_type: &str) -> &'a str {
+    let suffix = format!(".{service_type}");
+    fullname.strip_suffix(&suffix).unwrap_or(fullname)
+}
+
 /// Shared `peer_hostname -> primary_ipv4` map, populated by Discovery
 /// and read by the dialer (`connect_to_handle`). Owned by the dialer
 /// path so its references survive across discovery enable/disable
@@ -291,16 +307,20 @@ fn start_browse(
                     let Ok(ip) = primary_str.parse::<IpAddr>() else {
                         log::debug!(
                             "mdns: peer {} advertised malformed primary={primary_str:?}",
-                            resolved.get_hostname()
+                            resolved.get_fullname()
                         );
                         continue;
                     };
-                    let host = strip_trailing_dot(resolved.get_hostname()).to_ascii_lowercase();
+                    let instance =
+                        instance_from_fullname(resolved.get_fullname(), SERVICE_TYPE);
+                    let key = strip_trailing_dot(instance).to_ascii_lowercase();
+                    let target = strip_trailing_dot(resolved.get_hostname());
                     log::info!(
-                        "mdns: peer {host} announces primary={ip} (port={})",
-                        resolved.get_port()
+                        "mdns: peer instance={key} (target={target}) announces primary={ip} \
+                         (port={port})",
+                        port = resolved.get_port(),
                     );
-                    primary_cache.borrow_mut().insert(host, ip);
+                    primary_cache.borrow_mut().insert(key, ip);
                 }
                 ServiceEvent::ServiceRemoved(_, fullname) => {
                     // Best-effort: the fullname is "<instance>._lan-

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -81,6 +81,18 @@ fn instance_from_fullname<'a>(fullname: &'a str, service_type: &str) -> &'a str 
     fullname.strip_suffix(&suffix).unwrap_or(fullname)
 }
 
+/// Canonicalize a Bonjour/mDNS-SD name for cache lookup. Lower-cases,
+/// drops a trailing FQDN dot, and drops the `.local` link-local
+/// suffix. The `.local` domain is implied for everything mDNS-SD
+/// touches, so callers shouldn't have to remember whether to include
+/// it — config that says `Foo.local`, an announcer's instance label
+/// `Foo`, and an SRV target `foo.local.` all collapse to `foo`.
+pub(crate) fn normalize_mdns_name(s: &str) -> String {
+    let s = strip_trailing_dot(s);
+    let s = s.strip_suffix(".local").unwrap_or(s);
+    s.to_ascii_lowercase()
+}
+
 /// Shared `peer_hostname -> primary_ipv4` map, populated by Discovery
 /// and read by the dialer (`connect_to_handle`). Owned by the dialer
 /// path so its references survive across discovery enable/disable
@@ -313,7 +325,7 @@ fn start_browse(
                     };
                     let instance =
                         instance_from_fullname(resolved.get_fullname(), SERVICE_TYPE);
-                    let key = strip_trailing_dot(instance).to_ascii_lowercase();
+                    let key = normalize_mdns_name(instance);
                     let target = strip_trailing_dot(resolved.get_hostname());
                     log::info!(
                         "mdns: peer instance={key} (target={target}) announces primary={ip} \

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -217,9 +217,10 @@ impl Discovery {
         }
     }
 
-    /// Re-register with the current primary IP. Call from the
-    /// `if-watch` supervisor when interfaces come/go so the TXT
-    /// record stays accurate.
+    /// Re-register with the current primary IP. Called periodically
+    /// by the service's main loop so the TXT record reflects the
+    /// active default-route interface even when interface changes
+    /// don't arrive through if-watch.
     pub(crate) fn refresh(&mut self) {
         if self.daemon.is_some() {
             self.register();
@@ -263,26 +264,6 @@ impl Discovery {
         // Don't clear primary_cache: the dialer may still benefit
         // from the last-known hints, and a re-enable would otherwise
         // lose them until each peer's next announcement.
-    }
-
-    /// Look up a peer's advertised primary IP by configured hostname
-    /// (e.g. "JKMBP-M4-Max.local"). Returns `None` if discovery is
-    /// disabled, the peer isn't advertising, or the peer's
-    /// advertisement hasn't been resolved yet (mDNS browse is
-    /// asynchronous; the cache populates as ServiceResolved events
-    /// arrive). Callers should treat None as "no hint, fall through
-    /// to whatever the dialer would have done anyway."
-    ///
-    /// Currently unused by the in-tree dialer (which reads
-    /// `primary_cache` directly via the shared Rc<RefCell> for
-    /// inline use in `connect_to_handle`); kept as the canonical
-    /// lookup entry point so callers outside `connect.rs` don't
-    /// need to take the same Rc reference.
-    #[allow(dead_code)]
-    pub(crate) fn peer_primary_ip(&self, hostname: &str) -> Option<IpAddr> {
-        self.daemon.as_ref()?;
-        let key = normalize_mdns_name(hostname);
-        self.primary_cache.borrow().get(&key).copied()
     }
 }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,319 @@
+//! Bonjour / mDNS-SD service registration + discovery.
+//!
+//! Why this exists: when a peer machine has multiple interfaces on
+//! the same subnet (Mac with Wi-Fi + Ethernet, Linux laptop with
+//! Wi-Fi + USB-C dock, etc.), plain hostname resolution returns
+//! every interface's IP and the dialer has no way to tell which one
+//! the OS would *prefer* for outbound traffic. The current connect
+//! path races them and uses whichever DTLS handshake completes first,
+//! which is RTT-roughly-correct but not always what the user wanted
+//! — Wi-Fi can win the race even when the user has Ethernet ranked
+//! higher in macOS's service order.
+//!
+//! Each lan-mouse instance registers a `_lan-mouse._udp.local.`
+//! Bonjour service whose TXT record advertises `primary=<ip>`, where
+//! `<ip>` is the IPv4 of the interface that owns the default route
+//! (which on macOS reflects service order). The dialer browses the
+//! same service type, looks up the peer instance by hostname, and
+//! prepends the primary IP to its connection-attempt list. If the
+//! peer is on an old version with no advertised service (or mDNS
+//! is firewalled), nothing breaks — we silently fall through to the
+//! existing `connect_any` race.
+//!
+//! The whole subsystem is gated by the `mdns_discovery` config flag
+//! (default true). Toggling it off shuts down the mDNS daemon and
+//! all browse/registration state — useful on networks where mDNS
+//! multicast (224.0.0.251) is firewalled.
+
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+    rc::Rc,
+};
+
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use tokio::task::{JoinHandle, spawn_local};
+
+const SERVICE_TYPE: &str = "_lan-mouse._udp.local.";
+const TXT_PRIMARY_KEY: &str = "primary";
+
+/// Cross-platform: IP of the interface that owns the default route.
+///
+/// On macOS the default route reflects the user's service-order
+/// ranking — that's exactly the "primary" the user expects when they
+/// say "use Ethernet, not Wi-Fi". On Linux it reflects the lowest-
+/// metric default route. On Windows it's whatever
+/// `GetBestRoute2` selects.
+fn primary_ipv4() -> Option<Ipv4Addr> {
+    let iface = netdev::get_default_interface().ok()?;
+    iface.ipv4.first().map(|net| net.addr())
+}
+
+fn local_hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .unwrap_or_else(|| "lan-mouse".to_string())
+}
+
+/// Strip a single trailing dot if present. Bonjour hostnames are
+/// stored as fully-qualified ("foo.local."); user config typically
+/// writes them without the trailing dot ("foo.local"). Normalize
+/// to compare.
+fn strip_trailing_dot(s: &str) -> &str {
+    s.strip_suffix('.').unwrap_or(s)
+}
+
+/// Shared `peer_hostname -> primary_ipv4` map, populated by Discovery
+/// and read by the dialer (`connect_to_handle`). Owned by the dialer
+/// path so its references survive across discovery enable/disable
+/// cycles — when the user toggles discovery off, the daemon stops
+/// publishing/browsing but cached hints stay queryable. A subsequent
+/// re-enable populates fresh entries into the same map.
+pub(crate) type PrimaryCache = Rc<RefCell<HashMap<String, IpAddr>>>;
+
+pub(crate) struct Discovery {
+    /// The mDNS daemon. `None` when the subsystem is disabled (config
+    /// toggle off, or daemon failed to start). All public methods are
+    /// no-ops when this is None.
+    daemon: Option<ServiceDaemon>,
+    /// Fullname of our registered service, kept so we can unregister
+    /// on shutdown / before re-registering.
+    registered_fullname: Option<String>,
+    /// Shared cache (see [`PrimaryCache`]).
+    primary_cache: PrimaryCache,
+    /// Background task that consumes browse events and updates
+    /// `primary_cache`. Aborted when discovery is disabled or torn
+    /// down.
+    browse_task: Option<JoinHandle<()>>,
+    /// Port the dialer should connect to (advertised in the SRV
+    /// record's port field). Tracked so we can re-register when the
+    /// listen port changes.
+    port: u16,
+}
+
+impl Discovery {
+    /// Construct a Discovery sharing `primary_cache` with the dialer.
+    /// If `enabled` is false, returns an inert instance — calling any
+    /// method on it is a no-op. Same outcome when the mDNS daemon
+    /// fails to start (e.g. multicast group already joined by some
+    /// other process, or the OS lacks the permissions). In both
+    /// cases we log a warning and continue without discovery; the
+    /// dialer falls back to plain hostname resolution.
+    pub(crate) fn new(port: u16, enabled: bool, primary_cache: PrimaryCache) -> Self {
+        if !enabled {
+            log::info!("mdns discovery disabled by config");
+            return Self::inert(port, primary_cache);
+        }
+        match ServiceDaemon::new() {
+            Ok(daemon) => {
+                let browse_task = start_browse(&daemon, primary_cache.clone());
+                let mut this = Self {
+                    daemon: Some(daemon),
+                    registered_fullname: None,
+                    primary_cache,
+                    browse_task,
+                    port,
+                };
+                this.register();
+                this
+            }
+            Err(e) => {
+                log::warn!("mdns ServiceDaemon::new failed: {e}; discovery disabled");
+                Self::inert(port, primary_cache)
+            }
+        }
+    }
+
+    fn inert(port: u16, primary_cache: PrimaryCache) -> Self {
+        Self {
+            daemon: None,
+            registered_fullname: None,
+            primary_cache,
+            browse_task: None,
+            port,
+        }
+    }
+
+    /// Register `_lan-mouse._udp.local.` with our hostname + primary
+    /// IP. Called on construction and again whenever the primary IP
+    /// or port may have changed.
+    fn register(&mut self) {
+        let Some(daemon) = self.daemon.as_ref() else {
+            return;
+        };
+        // Drop the old registration first so we don't leave stale
+        // TXT records floating on the network.
+        if let Some(old) = self.registered_fullname.take() {
+            let _ = daemon.unregister(&old);
+        }
+        let host = local_hostname();
+        let host_record = format!("{host}.local.");
+        let primary = match primary_ipv4() {
+            Some(ip) => ip,
+            None => {
+                log::warn!(
+                    "mdns: no default-route interface; skipping registration (will retry on \
+                     interface change)"
+                );
+                return;
+            }
+        };
+        let mut props = HashMap::new();
+        props.insert(TXT_PRIMARY_KEY.to_string(), primary.to_string());
+        let info = match ServiceInfo::new(
+            SERVICE_TYPE,
+            &host,
+            &host_record,
+            IpAddr::V4(primary),
+            self.port,
+            Some(props),
+        ) {
+            Ok(i) => i,
+            Err(e) => {
+                log::warn!("mdns ServiceInfo::new failed: {e}; skipping registration");
+                return;
+            }
+        };
+        let fullname = info.get_fullname().to_string();
+        match daemon.register(info) {
+            Ok(()) => {
+                log::info!(
+                    "mdns: registered {fullname} on {primary}:{port} (primary interface)",
+                    port = self.port,
+                );
+                self.registered_fullname = Some(fullname);
+            }
+            Err(e) => log::warn!("mdns register failed: {e}"),
+        }
+    }
+
+    /// Re-register with the current primary IP. Call from the
+    /// `if-watch` supervisor when interfaces come/go so the TXT
+    /// record stays accurate.
+    pub(crate) fn refresh(&mut self) {
+        if self.daemon.is_some() {
+            self.register();
+        }
+    }
+
+    /// Re-register with a new port (config changed).
+    pub(crate) fn set_port(&mut self, port: u16) {
+        if self.port == port {
+            return;
+        }
+        self.port = port;
+        self.refresh();
+    }
+
+    /// Toggle the subsystem on/off. Off → unregister, abort browse,
+    /// drop daemon. On → spin up afresh, reusing the same shared
+    /// cache so any prior hints stay queryable until overwritten.
+    pub(crate) fn set_enabled(&mut self, enabled: bool) {
+        let currently = self.daemon.is_some();
+        if currently == enabled {
+            return;
+        }
+        if enabled {
+            *self = Self::new(self.port, true, self.primary_cache.clone());
+        } else {
+            self.shutdown();
+        }
+    }
+
+    fn shutdown(&mut self) {
+        if let Some(daemon) = self.daemon.take() {
+            if let Some(name) = self.registered_fullname.take() {
+                let _ = daemon.unregister(&name);
+            }
+            let _ = daemon.shutdown();
+        }
+        if let Some(task) = self.browse_task.take() {
+            task.abort();
+        }
+        // Don't clear primary_cache: the dialer may still benefit
+        // from the last-known hints, and a re-enable would otherwise
+        // lose them until each peer's next announcement.
+    }
+
+    /// Look up a peer's advertised primary IP by configured hostname
+    /// (e.g. "JKMBP-M4-Max.local"). Returns `None` if discovery is
+    /// disabled, the peer isn't advertising, or the peer's
+    /// advertisement hasn't been resolved yet (mDNS browse is
+    /// asynchronous; the cache populates as ServiceResolved events
+    /// arrive). Callers should treat None as "no hint, fall through
+    /// to whatever the dialer would have done anyway."
+    ///
+    /// Currently unused by the in-tree dialer (which reads
+    /// `primary_cache` directly via the shared Rc<RefCell> for
+    /// inline use in `connect_to_handle`); kept as the canonical
+    /// lookup entry point so callers outside `connect.rs` don't
+    /// need to take the same Rc reference.
+    #[allow(dead_code)]
+    pub(crate) fn peer_primary_ip(&self, hostname: &str) -> Option<IpAddr> {
+        if self.daemon.is_none() {
+            return None;
+        }
+        let key = strip_trailing_dot(hostname).to_ascii_lowercase();
+        self.primary_cache.borrow().get(&key).copied()
+    }
+}
+
+impl Drop for Discovery {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Spawn a background task that browses `_lan-mouse._udp.local.` and
+/// keeps `primary_cache` updated as ServiceResolved / ServiceRemoved
+/// events arrive.
+fn start_browse(
+    daemon: &ServiceDaemon,
+    primary_cache: Rc<RefCell<HashMap<String, IpAddr>>>,
+) -> Option<JoinHandle<()>> {
+    let receiver = match daemon.browse(SERVICE_TYPE) {
+        Ok(rx) => rx,
+        Err(e) => {
+            log::warn!("mdns browse failed: {e}");
+            return None;
+        }
+    };
+    Some(spawn_local(async move {
+        while let Ok(event) = receiver.recv_async().await {
+            match event {
+                ServiceEvent::ServiceResolved(resolved) => {
+                    let Some(primary_str) = resolved.get_property_val_str(TXT_PRIMARY_KEY)
+                    else {
+                        continue;
+                    };
+                    let Ok(ip) = primary_str.parse::<IpAddr>() else {
+                        log::debug!(
+                            "mdns: peer {} advertised malformed primary={primary_str:?}",
+                            resolved.get_hostname()
+                        );
+                        continue;
+                    };
+                    let host = strip_trailing_dot(resolved.get_hostname()).to_ascii_lowercase();
+                    log::info!(
+                        "mdns: peer {host} announces primary={ip} (port={})",
+                        resolved.get_port()
+                    );
+                    primary_cache.borrow_mut().insert(host, ip);
+                }
+                ServiceEvent::ServiceRemoved(_, fullname) => {
+                    // Best-effort: the fullname is "<instance>._lan-
+                    // mouse._udp.local." — we don't have the host
+                    // record handy here, so drop on next browse-
+                    // resolved instead of trying to map back. Keeps
+                    // the cache slightly stale on goodbye but never
+                    // wrong: if the peer comes back with a different
+                    // primary, the next ServiceResolved overwrites.
+                    log::debug!("mdns: service removed {fullname}");
+                }
+                _ => {}
+            }
+        }
+    }))
+}

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::HashMap, io, net::IpAddr};
 
 use local_channel::mpsc::{Receiver, Sender, channel};
+use tokio::net::lookup_host;
 use tokio::task::{JoinHandle, spawn_local};
 
-use hickory_resolver::{ResolveError, TokioResolver};
 use tokio_util::sync::CancellationToken;
 
 use lan_mouse_ipc::ClientHandle;
@@ -22,11 +22,10 @@ struct DnsRequest {
 
 pub(crate) enum DnsEvent {
     Resolving(ClientHandle),
-    Resolved(ClientHandle, String, Result<Vec<IpAddr>, ResolveError>),
+    Resolved(ClientHandle, String, io::Result<Vec<IpAddr>>),
 }
 
 struct DnsTask {
-    resolver: TokioResolver,
     request_rx: Receiver<DnsRequest>,
     event_tx: Sender<DnsEvent>,
     cancellation_token: CancellationToken,
@@ -34,14 +33,12 @@ struct DnsTask {
 }
 
 impl DnsResolver {
-    pub(crate) fn new() -> Result<Self, ResolveError> {
-        let resolver = TokioResolver::builder_tokio()?.build();
+    pub(crate) fn new() -> io::Result<Self> {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let cancellation_token = CancellationToken::new();
         let dns_task = DnsTask {
             active_tasks: Default::default(),
-            resolver,
             request_rx,
             event_tx,
             cancellation_token: cancellation_token.clone(),
@@ -97,15 +94,13 @@ impl DnsTask {
 
             /* spawn task for dns request */
             let event_tx = self.event_tx.clone();
-            let resolver = self.resolver.clone();
             let cancellation_token = self.cancellation_token.clone();
 
             let task = tokio::task::spawn_local(async move {
                 tokio::select! {
-                    ips = resolver.lookup_ip(&hostname) => {
-                       let ips = ips.map(|ips| ips.iter().collect::<Vec<_>>());
+                    result = resolve_hostname(&hostname) => {
                        event_tx
-                           .send(DnsEvent::Resolved(handle, hostname, ips))
+                           .send(DnsEvent::Resolved(handle, hostname, result))
                            .expect("channel closed");
                     }
                     _ = cancellation_token.cancelled() => {},
@@ -114,4 +109,19 @@ impl DnsTask {
             self.active_tasks.insert(handle, task);
         }
     }
+}
+
+/// Resolve `hostname` via the operating system's full name-resolution
+/// stack (`getaddrinfo` on Unix, GetAddrInfoEx on Windows). This walks
+/// `/etc/nsswitch.conf` on Linux — picking up mDNS via Avahi, /etc/hosts,
+/// and DNS — and uses Bonjour for `.local` names on macOS. Pure-DNS
+/// resolvers like hickory miss all of those, which is why a Bonjour
+/// hostname (e.g. `JKMBP-M4-Max.local`) wouldn't resolve before.
+///
+/// Port `0` is a placeholder — `lookup_host` requires `host:port` but we
+/// only care about the IPs at this stage; the actual port is appended at
+/// connection time.
+async fn resolve_hostname(hostname: &str) -> io::Result<Vec<IpAddr>> {
+    let addrs = lookup_host((hostname, 0)).await?;
+    Ok(addrs.map(|sa| sa.ip()).collect())
 }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -141,6 +141,24 @@ impl ListenTask {
                                     log::info!("releasing capture: {addr} entered this device");
                                     self.event_tx.send(EmulationEvent::ReleaseNotify).expect("channel closed");
                                     self.listener.reply(addr, ProtoEvent::Ack(0)).await;
+                                    // Send the receiving device's display
+                                    // geometry so the capturing peer can
+                                    // model the guest cursor's position
+                                    // accurately. Old peers that don't
+                                    // recognize this event will skip it
+                                    // per the forward-compat fix.
+                                    if let Some((width, height)) = self.emulation_proxy.display_bounds() {
+                                        self.listener.reply(addr, ProtoEvent::Bounds { width, height }).await;
+                                        // Seat the local cursor at the
+                                        // entry edge so the host's
+                                        // virtual_pos = 0 corresponds to
+                                        // the guest's actual column 0
+                                        // (or width-1, etc.) instead of
+                                        // wherever the previous capture
+                                        // session left it.
+                                        let (x, y) = entry_edge_for(pos, width, height);
+                                        self.emulation_proxy.warp_cursor(x, y);
+                                    }
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
                                 }
                             }
@@ -206,6 +224,11 @@ pub(crate) struct EmulationProxy {
     request_tx: Sender<ProxyRequest>,
     event_rx: Receiver<EmulationEvent>,
     task: JoinHandle<()>,
+    /// Cached display bounds. Refreshed each time the underlying
+    /// InputEmulation is (re)created. `None` until the first
+    /// successful query, or if the active backend doesn't report
+    /// geometry.
+    display_bounds: Rc<Cell<Option<(u32, u32)>>>,
 }
 
 enum ProxyRequest {
@@ -213,6 +236,10 @@ enum ProxyRequest {
     Remove(SocketAddr),
     Terminate,
     Reenable,
+    /// Warp the local cursor to an absolute position. Used on
+    /// `Enter` to seat the cursor at the entry edge so the
+    /// capturing peer's wall-press model is synchronized.
+    Warp(i32, i32),
 }
 
 impl EmulationProxy {
@@ -221,9 +248,11 @@ impl EmulationProxy {
         let (event_tx, event_rx) = channel();
         let emulation_active = Rc::new(Cell::new(false));
         let exit_requested = Rc::new(Cell::new(false));
+        let display_bounds = Rc::new(Cell::new(None));
         let emulation_task = EmulationTask {
             backend,
             exit_requested: exit_requested.clone(),
+            display_bounds: display_bounds.clone(),
             request_rx,
             event_tx,
             handles: Default::default(),
@@ -236,7 +265,24 @@ impl EmulationProxy {
             request_tx,
             task,
             event_rx,
+            display_bounds,
         }
+    }
+
+    /// Display geometry of this device (cached). Refreshed each
+    /// time the input emulation backend is (re)created.
+    pub(crate) fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.display_bounds.get()
+    }
+
+    /// Fire-and-forget cursor warp. Drops silently if emulation
+    /// isn't currently active (no live backend to receive the
+    /// request).
+    pub(crate) fn warp_cursor(&self, x: i32, y: i32) {
+        if !self.emulation_active.get() {
+            return;
+        }
+        let _ = self.request_tx.send(ProxyRequest::Warp(x, y));
     }
 
     async fn event(&mut self) -> EmulationEvent {
@@ -283,6 +329,9 @@ impl EmulationProxy {
 struct EmulationTask {
     backend: Option<input_emulation::Backend>,
     exit_requested: Rc<Cell<bool>>,
+    /// Shared cache; refreshed each time we (re)create the inner
+    /// InputEmulation. Read by `EmulationProxy::display_bounds`.
+    display_bounds: Rc<Cell<Option<(u32, u32)>>>,
     request_rx: Receiver<ProxyRequest>,
     event_tx: Sender<EmulationEvent>,
     handles: HashMap<SocketAddr, EmulationHandle>,
@@ -305,6 +354,7 @@ impl EmulationTask {
                     ProxyRequest::Terminate => return,
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::Warp(..) => { /* emulation inactive => ignore */ }
                 }
             }
         }
@@ -317,6 +367,11 @@ impl EmulationTask {
             // allow termination event while requesting input emulation
             _ = wait_for_termination(&mut self.request_rx) => return Ok(()),
         };
+
+        // Refresh the shared display-bounds cache. Goes through
+        // EmulationProxy::display_bounds() so the daemon can include
+        // it in the ProtoEvent::Bounds reply on Enter.
+        self.display_bounds.set(emulation.display_bounds());
 
         // used to send enabled and disabled events
         let _emulation_guard = DropGuard::new(
@@ -375,6 +430,11 @@ impl EmulationTask {
                             emulation.destroy(handle).await;
                         }
                     }
+                    ProxyRequest::Warp(x, y) => {
+                        if let Err(e) = emulation.warp_cursor(x, y).await {
+                            log::warn!("warp_cursor failed: {e}");
+                        }
+                    }
                     ProxyRequest::Terminate => break Ok(()),
                     ProxyRequest::Reenable => continue,
                 },
@@ -392,12 +452,31 @@ fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
     }
 }
 
+/// Where to seat the local cursor when this device is entered.
+/// `pos` is the protocol-level position in *this device's* frame
+/// (already inverted from the host's perspective by the capture
+/// side). For example, `Position::Left` means "the host is to my
+/// left, the cursor entered from my left edge", so the cursor
+/// should land at x=0. Y is centered along the entry edge for
+/// Left/Right; X is centered for Top/Bottom.
+fn entry_edge_for(pos: Position, width: u32, height: u32) -> (i32, i32) {
+    let w = width as i32;
+    let h = height as i32;
+    match pos {
+        Position::Left => (0, h / 2),
+        Position::Right => (w.saturating_sub(1), h / 2),
+        Position::Top => (w / 2, 0),
+        Position::Bottom => (w / 2, h.saturating_sub(1)),
+    }
+}
+
 async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
     loop {
         match rx.recv().await.expect("channel closed") {
             ProxyRequest::Terminate => return,
             ProxyRequest::Input(_, _) => continue,
             ProxyRequest::Remove(_) => continue,
+            ProxyRequest::Warp(_, _) => continue,
             ProxyRequest::Reenable => continue,
         }
     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -53,6 +53,17 @@ pub(crate) enum EmulationEvent {
     EmulationEnabled,
     /// capture should be released
     ReleaseNotify,
+    /// peer sent us a Hello with its build commit hash. Used to
+    /// populate `client_manager.peer_commit` from the listen side
+    /// too — without this, peer-version visibility silently fails
+    /// whenever the outgoing connection in the *other* direction is
+    /// broken (one-way setups, asymmetric NAT, peer's TCP listener
+    /// down). The connect-side path stays as the primary source;
+    /// this is the defensive fallback.
+    PeerHello {
+        addr: SocketAddr,
+        commit: [u8; 8],
+    },
 }
 
 enum EmulationRequest {
@@ -180,16 +191,21 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
-                            // Mirror the peer's version handshake. The
-                            // outgoing connect side initiated this with
-                            // its own Hello; we echo ours back so the
-                            // peer's connect-side receive_loop can
-                            // populate `peer_commit`. We don't store
-                            // the peer's commit on the listen side —
-                            // the user-visible state lives on outgoing
-                            // connections, where the same peer is also
-                            // configured as a `[[clients]]` entry.
-                            ProtoEvent::Hello { .. } => self.listener.reply(addr, ProtoEvent::Hello { commit: local_commit() }).await,
+                            // Peer's version handshake. Echo our own
+                            // commit back so the peer's connect-side
+                            // receive_loop populates its `peer_commit`,
+                            // AND publish a PeerHello upward so our
+                            // service can populate ours from the listen
+                            // side too — the connect side is the primary
+                            // path, but if the outbound direction is
+                            // broken (one-way setup, NAT, peer's TCP
+                            // listener down) the version display would
+                            // otherwise silently say "unknown" while
+                            // the peer is in fact happily talking to us.
+                            ProtoEvent::Hello { commit } => {
+                                self.listener.reply(addr, ProtoEvent::Hello { commit: local_commit() }).await;
+                                self.event_tx.send(EmulationEvent::PeerHello { addr, commit }).expect("channel closed");
+                            }
                             // Capturing peer told us where on its own
                             // screen the user's cursor was, as a
                             // normalized fraction (nx, ny) ∈ [0, 1]

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -177,6 +177,37 @@ impl ListenTask {
                             ProtoEvent::MotionAbsolute { x, y } => {
                                 self.emulation_proxy.warp_cursor(x, y);
                             }
+                            // Self-sufficient counterpart to
+                            // MotionAbsolute. Carries the host's
+                            // cursor as a fraction of the host's own
+                            // screen plus the entry side. Scale by
+                            // our display bounds, pin the on-axis
+                            // dimension to the matching edge, and
+                            // warp. Works without a prior Bounds
+                            // round-trip — the bug MotionAbsolute hit
+                            // on the very first crossing, where the
+                            // host had no peer geometry to compute
+                            // pixel coords from.
+                            ProtoEvent::CursorPos { pos, nx, ny } => {
+                                if let Some((w, h)) = self.emulation_proxy.display_bounds() {
+                                    let pw = w as f32;
+                                    let ph = h as f32;
+                                    let pwi = w as i32;
+                                    let phi = h as i32;
+                                    let (tx, ty) = match pos {
+                                        // host on our left → cursor enters our left edge
+                                        Position::Left => (0, (ny * ph) as i32),
+                                        Position::Right => {
+                                            (pwi.saturating_sub(1), (ny * ph) as i32)
+                                        }
+                                        Position::Top => ((nx * pw) as i32, 0),
+                                        Position::Bottom => {
+                                            ((nx * pw) as i32, phi.saturating_sub(1))
+                                        }
+                                    };
+                                    self.emulation_proxy.warp_cursor(tx, ty);
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -149,16 +149,27 @@ impl ListenTask {
                                     // per the forward-compat fix.
                                     if let Some((width, height)) = self.emulation_proxy.display_bounds() {
                                         self.listener.reply(addr, ProtoEvent::Bounds { width, height }).await;
-                                        // Seat the local cursor at the
-                                        // entry edge so the host's
-                                        // virtual_pos = 0 corresponds to
-                                        // the guest's actual column 0
-                                        // (or width-1, etc.) instead of
-                                        // wherever the previous capture
-                                        // session left it.
-                                        let (x, y) = entry_edge_for(pos, width, height);
-                                        self.emulation_proxy.warp_cursor(x, y);
                                     }
+                                    // No entry-edge midpoint warp here:
+                                    // the host's CursorPos (sent right
+                                    // after Enter) carries the
+                                    // proportional landing point and
+                                    // pins the on-axis dimension to the
+                                    // matching edge. Warping to the
+                                    // midpoint first would briefly
+                                    // place the cursor at center-edge
+                                    // — and a quick re-cross by the
+                                    // user would have the local
+                                    // CGEventTap (or equivalent) snap
+                                    // its `cursor=` field from the
+                                    // midpoint, masquerading as a
+                                    // mid-screen crossing on the next
+                                    // CursorPos sent back the other
+                                    // way. Trusts the host: if it
+                                    // can't compute a proportional
+                                    // point the cursor stays where it
+                                    // was, which is preferable to a
+                                    // forced midpoint.
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
                                 }
                             }
@@ -496,17 +507,6 @@ fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
 /// left, the cursor entered from my left edge", so the cursor
 /// should land at x=0. Y is centered along the entry edge for
 /// Left/Right; X is centered for Top/Bottom.
-fn entry_edge_for(pos: Position, width: u32, height: u32) -> (i32, i32) {
-    let w = width as i32;
-    let h = height as i32;
-    match pos {
-        Position::Left => (0, h / 2),
-        Position::Right => (w.saturating_sub(1), h / 2),
-        Position::Top => (w / 2, 0),
-        Position::Bottom => (w / 2, h.saturating_sub(1)),
-    }
-}
-
 async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
     loop {
         match rx.recv().await.expect("channel closed") {

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -1,3 +1,4 @@
+use crate::config::local_commit;
 use crate::listen::{LanMouseListener, ListenEvent, ListenerCreationError};
 use futures::StreamExt;
 use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError};
@@ -179,6 +180,16 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
+                            // Mirror the peer's version handshake. The
+                            // outgoing connect side initiated this with
+                            // its own Hello; we echo ours back so the
+                            // peer's connect-side receive_loop can
+                            // populate `peer_commit`. We don't store
+                            // the peer's commit on the listen side —
+                            // the user-visible state lives on outgoing
+                            // connections, where the same peer is also
+                            // configured as a `[[clients]]` entry.
+                            ProtoEvent::Hello { .. } => self.listener.reply(addr, ProtoEvent::Hello { commit: local_commit() }).await,
                             // Capturing peer told us where on its own
                             // screen the user's cursor was, as a
                             // normalized fraction (nx, ny) ∈ [0, 1]

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -168,42 +168,32 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
-                            // Capturing peer told us where on our
-                            // screen the user's cursor was at the
-                            // moment of crossing — warp directly there
-                            // and override the entry-edge-midpoint
-                            // warp from the prior Enter so the
-                            // transition is visually continuous.
-                            ProtoEvent::MotionAbsolute { x, y } => {
-                                self.emulation_proxy.warp_cursor(x, y);
-                            }
-                            // Self-sufficient counterpart to
-                            // MotionAbsolute. Carries the host's
-                            // cursor as a fraction of the host's own
-                            // screen plus the entry side. Scale by
-                            // our display bounds, pin the on-axis
-                            // dimension to the matching edge, and
-                            // warp. Works without a prior Bounds
-                            // round-trip — the bug MotionAbsolute hit
-                            // on the very first crossing, where the
-                            // host had no peer geometry to compute
-                            // pixel coords from.
+                            // Capturing peer told us where on its own
+                            // screen the user's cursor was, as a
+                            // normalized fraction (nx, ny) ∈ [0, 1]
+                            // plus the entry side (from our frame).
+                            // Scale against our live display bounds
+                            // and pin the on-axis dimension to the
+                            // matching edge so the cursor lands at
+                            // the visually-corresponding point.
+                            // Works without a prior Bounds round-trip,
+                            // so the very first crossing of a session
+                            // also lands at the visually-corresponding
+                            // point. The cross-axis multiply is
+                            // clamped to dim - 1 so a host edge
+                            // (nx == 1.0 or ny == 1.0) doesn't compute
+                            // one pixel past the addressable column.
                             ProtoEvent::CursorPos { pos, nx, ny } => {
                                 if let Some((w, h)) = self.emulation_proxy.display_bounds() {
-                                    let pw = w as f32;
-                                    let ph = h as f32;
                                     let pwi = w as i32;
                                     let phi = h as i32;
+                                    let cx = ((nx * w as f32) as i32).clamp(0, pwi.saturating_sub(1));
+                                    let cy = ((ny * h as f32) as i32).clamp(0, phi.saturating_sub(1));
                                     let (tx, ty) = match pos {
-                                        // host on our left → cursor enters our left edge
-                                        Position::Left => (0, (ny * ph) as i32),
-                                        Position::Right => {
-                                            (pwi.saturating_sub(1), (ny * ph) as i32)
-                                        }
-                                        Position::Top => ((nx * pw) as i32, 0),
-                                        Position::Bottom => {
-                                            ((nx * pw) as i32, phi.saturating_sub(1))
-                                        }
+                                        Position::Left => (0, cy),
+                                        Position::Right => (pwi.saturating_sub(1), cy),
+                                        Position::Top => (cx, 0),
+                                        Position::Bottom => (cx, phi.saturating_sub(1)),
                                     };
                                     self.emulation_proxy.warp_cursor(tx, ty);
                                 }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -70,6 +70,7 @@ enum EmulationRequest {
     Reenable,
     Release(SocketAddr),
     ChangePort(u16),
+    SetNaturalScroll(bool),
     Terminate,
 }
 
@@ -110,6 +111,15 @@ impl Emulation {
     pub(crate) fn request_port_change(&self, port: u16) {
         self.request_tx
             .send(EmulationRequest::ChangePort(port))
+            .expect("channel closed")
+    }
+
+    /// Configure whether the active emulation backend should
+    /// sign-invert scroll deltas before injection. Persists across
+    /// backend respawns via the EmulationTask cache.
+    pub(crate) fn set_natural_scroll(&self, natural_scroll: bool) {
+        self.request_tx
+            .send(EmulationRequest::SetNaturalScroll(natural_scroll))
             .expect("channel closed")
     }
 
@@ -270,6 +280,9 @@ impl ListenTask {
                         let result = self.listener.port_changed().await;
                         self.event_tx.send(EmulationEvent::PortChanged(result)).expect("channel closed");
                     }
+                    EmulationRequest::SetNaturalScroll(natural_scroll) => {
+                        self.emulation_proxy.set_natural_scroll(natural_scroll);
+                    }
                     EmulationRequest::Terminate => break,
                 },
                 _ = interval.tick() => {
@@ -315,6 +328,10 @@ enum ProxyRequest {
     /// `Enter` to seat the cursor at the entry edge so the
     /// capturing peer's wall-press model is synchronized.
     Warp(i32, i32),
+    /// Configure whether incoming scroll events should be sign-
+    /// inverted before injection. Mirrors the libinput
+    /// natural-scroll concept for forwarded events.
+    SetNaturalScroll(bool),
 }
 
 impl EmulationProxy {
@@ -328,6 +345,7 @@ impl EmulationProxy {
             backend,
             exit_requested: exit_requested.clone(),
             display_bounds: display_bounds.clone(),
+            natural_scroll: false,
             request_rx,
             event_tx,
             handles: Default::default(),
@@ -358,6 +376,15 @@ impl EmulationProxy {
             return;
         }
         let _ = self.request_tx.send(ProxyRequest::Warp(x, y));
+    }
+
+    /// Fire-and-forget natural-scroll preference update. Persists in
+    /// the EmulationTask so a freshly-created emulation backend
+    /// inherits the last-set value.
+    pub(crate) fn set_natural_scroll(&self, natural_scroll: bool) {
+        let _ = self
+            .request_tx
+            .send(ProxyRequest::SetNaturalScroll(natural_scroll));
     }
 
     async fn event(&mut self) -> EmulationEvent {
@@ -407,6 +434,11 @@ struct EmulationTask {
     /// Shared cache; refreshed each time we (re)create the inner
     /// InputEmulation. Read by `EmulationProxy::display_bounds`.
     display_bounds: Rc<Cell<Option<(u32, u32)>>>,
+    /// Cached natural-scroll preference. Re-applied to every newly
+    /// created InputEmulation so a backend respawn (e.g. after
+    /// CGEventTap timeout / portal session restart) doesn't drop
+    /// the user's setting.
+    natural_scroll: bool,
     request_rx: Receiver<ProxyRequest>,
     event_tx: Sender<EmulationEvent>,
     handles: HashMap<SocketAddr, EmulationHandle>,
@@ -430,6 +462,11 @@ impl EmulationTask {
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Warp(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::SetNaturalScroll(natural_scroll) => {
+                        // No live backend yet, but cache the value so
+                        // the next created backend picks it up.
+                        self.natural_scroll = natural_scroll;
+                    }
                 }
             }
         }
@@ -447,6 +484,10 @@ impl EmulationTask {
         // EmulationProxy::display_bounds() so the daemon can include
         // it in the ProtoEvent::Bounds reply on Enter.
         self.display_bounds.set(emulation.display_bounds());
+
+        // Re-apply the natural-scroll preference so a freshly-spawned
+        // backend inherits the user's setting.
+        emulation.set_natural_scroll(self.natural_scroll);
 
         // used to send enabled and disabled events
         let _emulation_guard = DropGuard::new(
@@ -510,6 +551,10 @@ impl EmulationTask {
                             log::warn!("warp_cursor failed: {e}");
                         }
                     }
+                    ProxyRequest::SetNaturalScroll(natural_scroll) => {
+                        self.natural_scroll = natural_scroll;
+                        emulation.set_natural_scroll(natural_scroll);
+                    }
                     ProxyRequest::Terminate => break Ok(()),
                     ProxyRequest::Reenable => continue,
                 },
@@ -541,6 +586,7 @@ async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
             ProxyRequest::Input(_, _) => continue,
             ProxyRequest::Remove(_) => continue,
             ProxyRequest::Warp(_, _) => continue,
+            ProxyRequest::SetNaturalScroll(_) => continue,
             ProxyRequest::Reenable => continue,
         }
     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -168,6 +168,15 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
+                            // Capturing peer told us where on our
+                            // screen the user's cursor was at the
+                            // moment of crossing — warp directly there
+                            // and override the entry-edge-midpoint
+                            // warp from the prior Enter so the
+                            // transition is visually continuous.
+                            ProtoEvent::MotionAbsolute { x, y } => {
+                                self.emulation_proxy.warp_cursor(x, y);
+                            }
                             _ => {}
                         }
                     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -195,7 +195,14 @@ impl ListenTask {
                                         Position::Top => (cx, 0),
                                         Position::Bottom => (cx, phi.saturating_sub(1)),
                                     };
+                                    log::info!(
+                                        "[cursor-pos] recv pos={pos:?} nx={nx:.3} ny={ny:.3} display_bounds=({w},{h}) → warp=({tx},{ty})"
+                                    );
                                     self.emulation_proxy.warp_cursor(tx, ty);
+                                } else {
+                                    log::info!(
+                                        "[cursor-pos] recv pos={pos:?} nx={nx:.3} ny={ny:.3} but display_bounds=None — skipping warp"
+                                    );
                                 }
                             }
                             _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,8 @@ mod dns;
 mod emulation;
 pub mod emulation_test;
 mod listen;
+#[cfg(target_os = "macos")]
+pub mod macos_tcc_probe;
+#[cfg(target_os = "macos")]
+pub mod macos_tcc_watch;
 pub mod service;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod client;
 pub mod config;
 mod connect;
 mod crypto;
+mod discovery;
 mod dns;
 mod emulation;
 pub mod emulation_test;

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -259,8 +259,16 @@ async fn read_loop(
                 .send(ListenEvent::Msg { event, addr })
                 .expect("channel closed"),
             Err(e) => {
-                log::warn!("error receiving event: {e}");
-                break;
+                // Skip the malformed/unknown datagram and keep
+                // listening. Each DTLS recv returns one full
+                // datagram, so a parse error here can't desync a
+                // stream; the next call gets a fresh, framed
+                // message. This makes the protocol forward-
+                // compatible: a peer running a newer Lan Mouse
+                // version can introduce additional event types
+                // and old peers will simply ignore them rather
+                // than dropping the connection.
+                log::debug!("ignoring undecodable event from {addr}: {e}");
             }
         }
     }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -4,7 +4,7 @@ use local_channel::mpsc::{Receiver, Sender, channel};
 use rustls::pki_types::CertificateDer;
 use std::{
     collections::{HashMap, VecDeque},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     rc::Rc,
     sync::{Arc, Mutex, RwLock},
     time::Duration,
@@ -30,9 +30,12 @@ pub enum ListenerCreationError {
     WebrtcUtil(#[from] webrtc_util::Error),
     #[error(transparent)]
     WebrtcDtls(#[from] webrtc_dtls::Error),
+    #[error("no listener could be bound on any local address")]
+    NoBoundListener,
 }
 
 type ArcConn = Arc<dyn Conn + Send + Sync>;
+type DynListener = Box<dyn Listener + Send + Sync>;
 
 pub(crate) enum ListenEvent {
     Msg {
@@ -63,6 +66,23 @@ type VerifyPeerCertificateFn = Arc<
         + Sync,
 >;
 
+/// One bound DTLS listener and the task that accepts on it. Stored
+/// in a `HashMap<IpAddr, ListenerSlot>` keyed by the local IPv4
+/// address it's bound to so the supervisor can plug/unplug
+/// listeners as interfaces appear/disappear.
+struct ListenerSlot {
+    /// Background task that calls `listener.accept()` in a loop and
+    /// forwards events into the shared `listen_tx` / `conns`.
+    /// Aborted on `Drop` so dropping the supervisor cleans up.
+    accept_task: JoinHandle<()>,
+}
+
+impl Drop for ListenerSlot {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
 impl LanMouseListener {
     pub(crate) async fn new(
         port: u16,
@@ -70,7 +90,7 @@ impl LanMouseListener {
         authorized_keys: Arc<RwLock<HashMap<String, String>>>,
     ) -> Result<Self, ListenerCreationError> {
         let (listen_tx, listen_rx) = channel();
-        let (request_port_change, mut request_port_change_rx) = channel();
+        let (request_port_change, request_port_change_rx) = channel();
         let (port_changed_tx, port_changed) = channel();
         let connection_attempts: Arc<Mutex<VecDeque<String>>> = Default::default();
 
@@ -109,72 +129,72 @@ impl LanMouseListener {
             ..Default::default()
         };
 
-        let listen_addr = SocketAddr::new("0.0.0.0".parse().expect("invalid ip"), port);
-        let mut listener = listen(listen_addr, cfg.clone()).await?;
-
         let conns: Rc<AsyncMutex<Vec<(SocketAddr, ArcConn)>>> =
             Rc::new(AsyncMutex::new(Vec::new()));
 
-        let conns_clone = conns.clone();
-        let listen_task: JoinHandle<()> = {
-            let listen_tx = listen_tx.clone();
-            let connection_attempts = connection_attempts.clone();
-            spawn_local(async move {
-                loop {
-                    let sleep = tokio::time::sleep(Duration::from_secs(2));
-                    tokio::select! {
-                        /* workaround for https://github.com/webrtc-rs/webrtc/issues/614 */
-                        _ = sleep => continue,
-                        c = listener.accept() => match c {
-                            Ok((conn, addr)) => {
-                                log::info!("dtls client connected, ip: {addr}");
-                                let mut conns = conns_clone.lock().await;
-                                conns.push((addr, conn.clone()));
-                                let dtls_conn: &DTLSConn = conn.as_any().downcast_ref().expect("dtls conn");
-                                let certs = dtls_conn.connection_state().await.peer_certificates;
-                                let cert = certs.first().expect("cert");
-                                let fingerprint = crypto::generate_fingerprint(cert);
-                                listen_tx.send(ListenEvent::Accept { addr, fingerprint }).expect("channel closed");
-                                spawn_local(read_loop(conns_clone.clone(), addr, conn, listen_tx.clone()));
-                            },
-                            Err(e) => {
-                                if let Error::Std(ref e) = e {
-                                    if let Some(e) = e.0.downcast_ref::<webrtc_dtls::Error>() {
-                                        match e {
-                                            webrtc_dtls::Error::ErrVerifyDataMismatch => {
-                                                if let Some(fingerprint) = connection_attempts.lock().expect("lock").pop_front() {
-                                                    listen_tx.send(ListenEvent::Rejected { fingerprint }).expect("channel closed");
-                                                }
-                                            }
-                                            _ => log::warn!("accept: {e}"),
-                                        }
-                                    } else {
-                                        log::warn!("accept: {e:?}");
-                                    }
-                                } else {
-                                    log::warn!("accept: {e:?}");
-                                }
-                            }
-                        },
-                        port = request_port_change_rx.recv() => {
-                            let port = port.expect("channel closed");
-                            let listen_addr = SocketAddr::new("0.0.0.0".parse().expect("invalid ip"), port);
-                            match listen(listen_addr, cfg.clone()).await {
-                                Ok(new_listener) => {
-                                    let _ = listener.close().await;
-                                    listener = new_listener;
-                                    port_changed_tx.send(Ok(port)).expect("channel closed");
-                                }
-                                Err(e) => {
-                                    log::warn!("unable to change port: {e}");
-                                    port_changed_tx.send(Err(e.into())).expect("channel closed");
-                                }
-                            };
-                        },
-                    };
+        // Bind one listener per local IPv4 address (skip loopback +
+        // link-local) instead of a single 0.0.0.0:port listener. With
+        // a single 0.0.0.0 bind on a multi-homed host, replies use
+        // the kernel's preferred outbound interface as source IP —
+        // which may not match the IP the peer dialed, breaking QUIC
+        // 4-tuple matching. Per-IP binds make replies symmetric
+        // automatically: each listener's reply socket is bound to a
+        // specific IP, so the kernel uses *that* IP as source.
+        let initial_addrs = enumerate_listenable_ipv4();
+        if initial_addrs.is_empty() {
+            // Fall back to 0.0.0.0 so we at least listen somewhere if
+            // interface enumeration fails (very unusual).
+            log::warn!("no listenable IPv4 addresses found; falling back to 0.0.0.0");
+        }
+        let mut listeners: HashMap<IpAddr, ListenerSlot> = HashMap::new();
+        let mut bound_count = 0usize;
+        for ip in &initial_addrs {
+            match try_bind_listener(*ip, port, &cfg).await {
+                Ok(listener) => {
+                    let task = spawn_accept_task(
+                        listener,
+                        listen_tx.clone(),
+                        conns.clone(),
+                        connection_attempts.clone(),
+                    );
+                    listeners.insert(*ip, ListenerSlot { accept_task: task });
+                    bound_count += 1;
+                    log::info!("listening for DTLS on {ip}:{port}");
                 }
-            })
-        };
+                Err(e) => log::warn!("failed to bind listener on {ip}:{port}: {e}"),
+            }
+        }
+        if bound_count == 0 {
+            // Either enumeration returned no addrs, or every bind
+            // failed. Try `0.0.0.0:port` as a last resort.
+            let fallback = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+            match try_bind_listener(fallback, port, &cfg).await {
+                Ok(listener) => {
+                    let task = spawn_accept_task(
+                        listener,
+                        listen_tx.clone(),
+                        conns.clone(),
+                        connection_attempts.clone(),
+                    );
+                    listeners.insert(fallback, ListenerSlot { accept_task: task });
+                    log::info!(
+                        "listening for DTLS on {fallback}:{port} (fallback — symmetric replies not guaranteed)"
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let listen_task = spawn_supervisor_task(
+            port,
+            cfg,
+            listeners,
+            listen_tx.clone(),
+            conns.clone(),
+            connection_attempts,
+            request_port_change_rx,
+            port_changed_tx,
+        );
 
         Ok(Self {
             conns,
@@ -243,6 +263,206 @@ impl Stream for LanMouseListener {
     ) -> std::task::Poll<Option<Self::Item>> {
         self.listen_rx.poll_next_unpin(cx)
     }
+}
+
+/// Enumerate local IPv4 addresses suitable for binding a public
+/// listener: skip loopback (127.0.0.0/8) and link-local
+/// (169.254.0.0/16) since neither is reachable from a peer. IPv6
+/// is intentionally omitted — lan-mouse is IPv4-only on the wire
+/// today.
+fn enumerate_listenable_ipv4() -> Vec<IpAddr> {
+    let ifaces = match if_addrs::get_if_addrs() {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("get_if_addrs failed: {e}");
+            return Vec::new();
+        }
+    };
+    ifaces
+        .into_iter()
+        .filter_map(|iface| match iface.addr {
+            if_addrs::IfAddr::V4(v4) => Some(v4.ip),
+            if_addrs::IfAddr::V6(_) => None,
+        })
+        .filter(|ip| !ip.is_loopback() && !ip.is_link_local())
+        .map(IpAddr::V4)
+        .collect()
+}
+
+async fn try_bind_listener(
+    ip: IpAddr,
+    port: u16,
+    cfg: &Config,
+) -> Result<DynListener, ListenerCreationError> {
+    let addr = SocketAddr::new(ip, port);
+    let listener = listen(addr, cfg.clone()).await?;
+    Ok(Box::new(listener))
+}
+
+/// Spawn an accept loop for one bound listener. Each accepted
+/// `(conn, addr)` is registered in the shared `conns` vec and an
+/// `Accept` event is published. Verify-peer-certificate failures are
+/// re-published as `Rejected` so the UI can surface unauthorized
+/// fingerprints. The accept loop exits when the listener errors
+/// out or its task is aborted (interface went down, port changed).
+fn spawn_accept_task(
+    listener: DynListener,
+    listen_tx: Sender<ListenEvent>,
+    conns: Rc<AsyncMutex<Vec<(SocketAddr, ArcConn)>>>,
+    connection_attempts: Arc<Mutex<VecDeque<String>>>,
+) -> JoinHandle<()> {
+    spawn_local(async move {
+        loop {
+            // workaround for https://github.com/webrtc-rs/webrtc/issues/614
+            let sleep = tokio::time::sleep(Duration::from_secs(2));
+            tokio::select! {
+                _ = sleep => continue,
+                c = listener.accept() => match c {
+                    Ok((conn, addr)) => {
+                        log::info!("dtls client connected, ip: {addr}");
+                        {
+                            let mut conns_guard = conns.lock().await;
+                            conns_guard.push((addr, conn.clone()));
+                        }
+                        let dtls_conn: &DTLSConn = conn.as_any().downcast_ref().expect("dtls conn");
+                        let certs = dtls_conn.connection_state().await.peer_certificates;
+                        let cert = certs.first().expect("cert");
+                        let fingerprint = crypto::generate_fingerprint(cert);
+                        listen_tx
+                            .send(ListenEvent::Accept { addr, fingerprint })
+                            .expect("channel closed");
+                        spawn_local(read_loop(conns.clone(), addr, conn, listen_tx.clone()));
+                    }
+                    Err(e) => {
+                        if let Error::Std(ref se) = e {
+                            if let Some(de) = se.0.downcast_ref::<webrtc_dtls::Error>() {
+                                match de {
+                                    webrtc_dtls::Error::ErrVerifyDataMismatch => {
+                                        if let Some(fingerprint) =
+                                            connection_attempts.lock().expect("lock").pop_front()
+                                        {
+                                            listen_tx
+                                                .send(ListenEvent::Rejected { fingerprint })
+                                                .expect("channel closed");
+                                        }
+                                    }
+                                    _ => log::warn!("accept: {de}"),
+                                }
+                            } else {
+                                log::warn!("accept: {se:?}");
+                            }
+                        } else {
+                            log::warn!("accept: {e:?}");
+                        }
+                    }
+                },
+            };
+        }
+    })
+}
+
+/// Supervisor task: owns the set of active listeners, watches for
+/// interface up/down events via `if_watch`, and rebuilds listeners
+/// on port change. Each listener slot is keyed by its local IPv4
+/// address; on `IfEvent::Up` we add a slot, on `IfEvent::Down` we
+/// drop one (which aborts its accept task).
+#[allow(clippy::too_many_arguments)]
+fn spawn_supervisor_task(
+    initial_port: u16,
+    cfg: Config,
+    initial_listeners: HashMap<IpAddr, ListenerSlot>,
+    listen_tx: Sender<ListenEvent>,
+    conns: Rc<AsyncMutex<Vec<(SocketAddr, ArcConn)>>>,
+    connection_attempts: Arc<Mutex<VecDeque<String>>>,
+    mut request_port_change_rx: Receiver<u16>,
+    port_changed_tx: Sender<Result<u16, ListenerCreationError>>,
+) -> JoinHandle<()> {
+    spawn_local(async move {
+        let mut port = initial_port;
+        let mut listeners = initial_listeners;
+        let mut watcher = match if_watch::tokio::IfWatcher::new() {
+            Ok(w) => Some(w),
+            Err(e) => {
+                log::warn!(
+                    "if_watch::IfWatcher::new failed: {e}; interface plug/unplug \
+                     will not be detected (restart lan-mouse to pick up new addrs)"
+                );
+                None
+            }
+        };
+        loop {
+            tokio::select! {
+                ev = async {
+                    match watcher.as_mut() {
+                        Some(w) => w.select_next_some().await,
+                        None => std::future::pending().await,
+                    }
+                } => match ev {
+                    Ok(if_watch::IfEvent::Up(net)) => {
+                        let ip = net.addr();
+                        let usable = if let IpAddr::V4(v4) = ip {
+                            !v4.is_loopback() && !v4.is_link_local()
+                        } else {
+                            false
+                        };
+                        if usable && !listeners.contains_key(&ip) {
+                            match try_bind_listener(ip, port, &cfg).await {
+                                Ok(l) => {
+                                    let task = spawn_accept_task(
+                                        l,
+                                        listen_tx.clone(),
+                                        conns.clone(),
+                                        connection_attempts.clone(),
+                                    );
+                                    listeners.insert(ip, ListenerSlot { accept_task: task });
+                                    log::info!("interface up: now listening on {ip}:{port}");
+                                }
+                                Err(e) => log::warn!("failed to bind on {ip}:{port}: {e}"),
+                            }
+                        }
+                    }
+                    Ok(if_watch::IfEvent::Down(net)) => {
+                        let ip = net.addr();
+                        if listeners.remove(&ip).is_some() {
+                            log::info!("interface down: stopped listening on {ip}:{port}");
+                        }
+                    }
+                    Err(e) => log::debug!("if_watch error: {e}"),
+                },
+                p = request_port_change_rx.recv() => {
+                    let new_port = p.expect("channel closed");
+                    listeners.clear(); // Drop aborts each accept task
+                    let mut bound = 0usize;
+                    let addrs = enumerate_listenable_ipv4();
+                    for ip in &addrs {
+                        match try_bind_listener(*ip, new_port, &cfg).await {
+                            Ok(l) => {
+                                let task = spawn_accept_task(
+                                    l,
+                                    listen_tx.clone(),
+                                    conns.clone(),
+                                    connection_attempts.clone(),
+                                );
+                                listeners.insert(*ip, ListenerSlot { accept_task: task });
+                                bound += 1;
+                            }
+                            Err(e) => log::warn!("port change: failed to bind {ip}:{new_port}: {e}"),
+                        }
+                    }
+                    if bound == 0 {
+                        port_changed_tx
+                            .send(Err(ListenerCreationError::NoBoundListener))
+                            .expect("channel closed");
+                    } else {
+                        port = new_port;
+                        port_changed_tx
+                            .send(Ok(port))
+                            .expect("channel closed");
+                    }
+                }
+            }
+        }
+    })
 }
 
 async fn read_loop(

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -3,7 +3,7 @@ use lan_mouse_proto::{MAX_EVENT_SIZE, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
 use rustls::pki_types::CertificateDer;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     net::{IpAddr, SocketAddr},
     rc::Rc,
     sync::{Arc, Mutex, RwLock},
@@ -390,8 +390,58 @@ fn spawn_supervisor_task(
                 None
             }
         };
+        // Periodic reconciliation: enumerate live IPs and diff against
+        // `listeners`. Network.framework on macOS doesn't reliably fire
+        // `IfEvent::Down` when an interface is administratively
+        // disabled (e.g. user toggles Wi-Fi off in System Settings),
+        // leaving stale slots bound to vanished IPs that no traffic
+        // can reach. Polling every 30s catches whatever if-watch
+        // misses — both adds (covers missed Up events too) and drops.
+        let mut reconcile_tick = tokio::time::interval(Duration::from_secs(30));
+        // Skip the immediate-first tick — we just enumerated at startup
+        // and don't want to thrash listeners on the first iteration.
+        reconcile_tick.tick().await;
         loop {
             tokio::select! {
+                _ = reconcile_tick.tick() => {
+                    let current_ips: HashSet<IpAddr> =
+                        enumerate_listenable_ipv4().into_iter().collect();
+                    let to_drop: Vec<IpAddr> = listeners
+                        .keys()
+                        .filter(|ip| !current_ips.contains(*ip))
+                        .copied()
+                        .collect();
+                    for ip in to_drop {
+                        if listeners.remove(&ip).is_some() {
+                            log::info!(
+                                "reconcile: dropping stale listener on {ip}:{port} \
+                                 (IP no longer present on any interface)"
+                            );
+                        }
+                    }
+                    for ip in current_ips {
+                        if !listeners.contains_key(&ip) {
+                            match try_bind_listener(ip, port, &cfg).await {
+                                Ok(l) => {
+                                    let task = spawn_accept_task(
+                                        l,
+                                        listen_tx.clone(),
+                                        conns.clone(),
+                                        connection_attempts.clone(),
+                                    );
+                                    listeners.insert(ip, ListenerSlot { accept_task: task });
+                                    log::info!(
+                                        "reconcile: now listening on {ip}:{port} \
+                                         (IP appeared without an Up event)"
+                                    );
+                                }
+                                Err(e) => log::warn!(
+                                    "reconcile: failed to bind on {ip}:{port}: {e}"
+                                ),
+                            }
+                        }
+                    }
+                }
                 ev = async {
                     match watcher.as_mut() {
                         Some(w) => w.select_next_some().await,

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 use thiserror::Error;
+use tokio::time::MissedTickBehavior;
 use tokio::{
     sync::Mutex as AsyncMutex,
     task::{JoinHandle, spawn_local},
@@ -397,7 +398,10 @@ fn spawn_supervisor_task(
         // leaving stale slots bound to vanished IPs that no traffic
         // can reach. Polling every 30s catches whatever if-watch
         // misses — both adds (covers missed Up events too) and drops.
+        // `Skip` so a long suspend (laptop closed for hours) doesn't
+        // burst-fire backlog ticks at resume.
         let mut reconcile_tick = tokio::time::interval(Duration::from_secs(30));
+        reconcile_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
         // Skip the immediate-first tick — we just enumerated at startup
         // and don't want to thrash listeners on the first iteration.
         reconcile_tick.tick().await;
@@ -412,12 +416,14 @@ fn spawn_supervisor_task(
                         .copied()
                         .collect();
                     for ip in to_drop {
-                        if listeners.remove(&ip).is_some() {
-                            log::info!(
-                                "reconcile: dropping stale listener on {ip}:{port} \
-                                 (IP no longer present on any interface)"
-                            );
-                        }
+                        // `to_drop` was just collected from
+                        // `listeners.keys()` and we run single-
+                        // threaded, so the remove always returns Some.
+                        listeners.remove(&ip);
+                        log::info!(
+                            "reconcile: dropping stale listener on {ip}:{port} \
+                             (IP no longer present on any interface)"
+                        );
                     }
                     // `try_bind_listener` is async and may fail, so
                     // `entry().or_insert_with(...)` doesn't fit — we

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -419,8 +419,16 @@ fn spawn_supervisor_task(
                             );
                         }
                     }
+                    // `try_bind_listener` is async and may fail, so
+                    // `entry().or_insert_with(...)` doesn't fit — we
+                    // only want to insert on bind success. Match the
+                    // `Entry::Vacant` slot up front so the same hash
+                    // lookup covers both the existence check and the
+                    // later insert, satisfying clippy::map_entry.
                     for ip in current_ips {
-                        if !listeners.contains_key(&ip) {
+                        if let std::collections::hash_map::Entry::Vacant(slot) =
+                            listeners.entry(ip)
+                        {
                             match try_bind_listener(ip, port, &cfg).await {
                                 Ok(l) => {
                                     let task = spawn_accept_task(
@@ -429,7 +437,7 @@ fn spawn_supervisor_task(
                                         conns.clone(),
                                         connection_attempts.clone(),
                                     );
-                                    listeners.insert(ip, ListenerSlot { accept_task: task });
+                                    slot.insert(ListenerSlot { accept_task: task });
                                     log::info!(
                                         "reconcile: now listening on {ip}:{port} \
                                          (IP appeared without an Up event)"

--- a/src/macos_tcc_probe.rs
+++ b/src/macos_tcc_probe.rs
@@ -1,0 +1,19 @@
+//! Fresh-process probe of TCC Accessibility permission.
+//!
+//! `AXIsProcessTrusted()` in already-running processes can return
+//! cached-true for an unbounded window after the user *removes* the
+//! app's entry from System Settings → Privacy & Security →
+//! Accessibility (vs *toggling* it off, which flips the cache
+//! promptly). To detect the "remove" case, the daemon spawns a fresh
+//! subprocess of the same binary that runs this probe — a fresh
+//! process consults the current TCC state without inheriting the
+//! parent's cached trust. See `macos_tcc_watch` for the watcher loop.
+
+#[link(name = "ApplicationServices", kind = "framework")]
+unsafe extern "C" {
+    fn AXIsProcessTrusted() -> bool;
+}
+
+pub fn is_accessibility_granted() -> bool {
+    unsafe { AXIsProcessTrusted() }
+}

--- a/src/macos_tcc_watch.rs
+++ b/src/macos_tcc_watch.rs
@@ -1,0 +1,90 @@
+//! TCC.db mtime watcher → fresh-subprocess probe → daemon exit.
+//!
+//! Detects "user removed the app from System Settings → Privacy &
+//! Security → Accessibility" — the case where `AXIsProcessTrusted()`
+//! in already-running processes keeps reporting cached-true for an
+//! unbounded window, even though the OS has effectively revoked
+//! permission and a fresh process would see false.
+//!
+//! Strategy: poll the TCC database file's mtime every 2 seconds. The
+//! stat is essentially free (kernel-cached inode metadata, ~µs per
+//! call). When the mtime ticks, spawn a fresh subprocess of our own
+//! binary that runs `lan-mouse ax-probe` — a fresh process bypasses
+//! the parent's cached trust and consults the current TCC state. If
+//! the probe exits non-zero (AX revoked), we exit the daemon with
+//! `process::exit(0)`. The GUI's IPC-drop watcher then propagates
+//! the exit (see `lan_mouse_gtk::lib::receiver.recv` Err branch).
+//!
+//! Cost is negligible: one stat per 2s, plus one subprocess spawn
+//! per actual TCC change (rare — only fires when the user opens
+//! System Settings and modifies the list).
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+use std::time::{Duration, SystemTime};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// System-level TCC database — holds Accessibility, Input Monitoring,
+/// Screen Recording, etc. for application bundles. This is the file
+/// that ticks when the user adds/removes/toggles entries in System
+/// Settings → Privacy & Security → Accessibility. The per-user
+/// `~/Library/Application Support/com.apple.TCC/TCC.db` does NOT
+/// track Accessibility — confirmed empirically; an earlier version
+/// of this watcher polled both and only the system path moved on
+/// the AX revoke path that this module exists to fix.
+const TCC_DB_PATH: &str = "/Library/Application Support/com.apple.TCC/TCC.db";
+
+fn read_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+fn probe_ax_in_fresh_subprocess() -> Option<bool> {
+    // Spawn a fresh copy of our binary with `ax-probe`. A fresh
+    // process consults the current TCC state without inheriting the
+    // parent's cached trust. Exit 0 = granted, 1 = revoked.
+    let exe = env::current_exe().ok()?;
+    let status = Command::new(exe).arg("ax-probe").status().ok()?;
+    Some(status.success())
+}
+
+/// Spawn the watcher on the current tokio runtime. Must be called
+/// from inside a tokio runtime; runs forever until the daemon exits.
+pub fn spawn() {
+    tokio::spawn(async move {
+        let path = PathBuf::from(TCC_DB_PATH);
+        let mut last_mtime = read_mtime(&path);
+        log::info!(
+            "tcc_watch: watching {} (initial mtime: {:?})",
+            path.display(),
+            last_mtime
+        );
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            let current_mtime = read_mtime(&path);
+            if current_mtime == last_mtime {
+                continue;
+            }
+            log::info!(
+                "tcc_watch: TCC.db mtime changed ({last_mtime:?} -> {current_mtime:?}) — confirming AX via fresh subprocess"
+            );
+            last_mtime = current_mtime;
+            match probe_ax_in_fresh_subprocess() {
+                Some(true) => {
+                    log::debug!("tcc_watch: probe confirms AX still granted");
+                }
+                Some(false) => {
+                    log::error!(
+                        "tcc_watch: AX revoked (TCC.db changed and fresh probe returned false) — daemon exiting"
+                    );
+                    process::exit(0);
+                }
+                None => {
+                    log::warn!("tcc_watch: probe subprocess failed to spawn or run");
+                }
+            }
+        }
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use lan_mouse::{
 use lan_mouse_cli::CliError;
 #[cfg(feature = "gtk")]
 use lan_mouse_gtk::GtkError;
-use lan_mouse_ipc::{IpcError, IpcListenerCreationError};
+use lan_mouse_ipc::{GuiLock, IpcError, IpcListenerCreationError};
 use std::{
     future::Future,
     io,
@@ -84,8 +84,31 @@ fn run() -> Result<(), LanMouseError> {
             //  run a frontend
             #[cfg(feature = "gtk")]
             {
+                // Cross-platform GUI singleton: only one Lan Mouse
+                // window per user session. If another GUI is already
+                // listening we send it a "show yourself" byte and
+                // exit; otherwise we hold the lock for the GUI's
+                // lifetime. Decoupled from the daemon socket so a
+                // headless `lan-mouse daemon` doesn't block a later
+                // GUI launch.
+                let gui_lock = match GuiLock::acquire_or_signal() {
+                    Ok(Some(lock)) => Some(lock),
+                    Ok(None) => {
+                        log::info!(
+                            "lan-mouse GUI is already running; brought it to the foreground"
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        // Don't fail the whole launch over the lock —
+                        // log and proceed without singleton coverage.
+                        log::warn!("could not acquire GUI singleton lock: {e}");
+                        None
+                    }
+                };
+
                 let mut service = start_service()?;
-                let res = lan_mouse_gtk::run(config::local_commit());
+                let res = lan_mouse_gtk::run(gui_lock, config::local_commit());
 
                 // Bound the daemon-child cleanup so a wedged daemon
                 // (CGEventTap stuck on macOS, hung syscall, etc.)

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,16 +75,42 @@ fn run() -> Result<(), LanMouseError> {
             {
                 let mut service = start_service()?;
                 let res = lan_mouse_gtk::run(config::local_commit());
+
+                // Bound the daemon-child cleanup so a wedged daemon
+                // (CGEventTap stuck on macOS, hung syscall, etc.)
+                // can't freeze the GUI on quit. SIGINT first, give it
+                // a few seconds to exit cleanly, then SIGKILL.
                 #[cfg(unix)]
                 {
-                    // on unix we give the service a chance to terminate gracefully
                     let pid = service.id() as libc::pid_t;
                     unsafe {
                         libc::kill(pid, libc::SIGINT);
                     }
-                    service.wait()?;
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+                    loop {
+                        match service.try_wait() {
+                            Ok(Some(_)) => break,
+                            Ok(None) if std::time::Instant::now() >= deadline => {
+                                log::warn!(
+                                    "daemon child did not exit on SIGINT in 3s — sending SIGKILL"
+                                );
+                                let _ = service.kill();
+                                let _ = service.wait();
+                                break;
+                            }
+                            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
+                            Err(e) => {
+                                log::error!("waiting for daemon child: {e}");
+                                break;
+                            }
+                        }
+                    }
                 }
-                service.kill()?;
+                #[cfg(not(unix))]
+                {
+                    let _ = service.kill();
+                    let _ = service.wait();
+                }
                 res?;
             }
             #[cfg(not(feature = "gtk"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,17 @@ fn run() -> Result<(), LanMouseError> {
                     r => r?,
                 }
             }
+            #[cfg(target_os = "macos")]
+            Command::AxProbe => {
+                // Fresh-process probe of TCC Accessibility state. Spawned
+                // by the daemon's TCC.db watcher (see lan_mouse::tcc_watch
+                // on macOS) to bypass cached-trust state in already-running
+                // processes — particularly important for the "remove from
+                // list" case where AXIsProcessTrusted in the parent keeps
+                // reporting cached-true. Exit 0 = granted, 1 = revoked.
+                let granted = lan_mouse::macos_tcc_probe::is_accessibility_granted();
+                process::exit(if granted { 0 } else { 1 });
+            }
         },
         None => {
             //  otherwise start the service as a child process and
@@ -158,6 +169,15 @@ async fn run_service(config: Config) -> Result<(), ServiceError> {
     let mut service = Service::new(config).await?;
     log::info!("using config: {config_path:?}");
     log::info!("Press {release_bind:?} to release the mouse");
+
+    // macOS-only: detect AX-permission "remove from list" by polling
+    // TCC.db's mtime and confirming via a fresh subprocess. The
+    // existing in-process AXIsProcessTrusted polling in the GUI only
+    // catches the toggle-off case; the remove case leaves the cached
+    // trust state stuck at true forever. See `macos_tcc_watch`.
+    #[cfg(target_os = "macos")]
+    lan_mouse::macos_tcc_watch::spawn();
+
     service.run().await?;
     log::info!("service exited!");
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn run() -> Result<(), LanMouseError> {
             #[cfg(feature = "gtk")]
             {
                 let mut service = start_service()?;
-                let res = lan_mouse_gtk::run();
+                let res = lan_mouse_gtk::run(config::local_commit());
                 #[cfg(unix)]
                 {
                     // on unix we give the service a chance to terminate gracefully

--- a/src/service.rs
+++ b/src/service.rs
@@ -101,7 +101,12 @@ impl Service {
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
-        let capture = Capture::new(capture_backend, conn, config.release_bind());
+        let capture = Capture::new(
+            capture_backend,
+            conn,
+            config.release_bind(),
+            config.release_threshold_px(),
+        );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
 
@@ -218,6 +223,12 @@ impl Service {
                 self.update_enter_hook(handle, enter_hook)
             }
             FrontendRequest::SaveConfiguration => self.save_config(),
+            FrontendRequest::SetReleaseThreshold(threshold) => {
+                self.config.set_release_threshold_px(threshold);
+                self.capture.set_release_threshold(threshold);
+                self.notify_frontend(FrontendEvent::ReleaseThreshold(threshold));
+                self.save_config();
+            }
         }
     }
 
@@ -258,6 +269,9 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
+        let release_threshold = self.config.release_threshold_px();
+        self.capture.set_release_threshold(release_threshold);
+        self.notify_frontend(FrontendEvent::ReleaseThreshold(release_threshold));
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()
@@ -378,6 +392,9 @@ impl Service {
         self.notify_frontend(FrontendEvent::PortChanged(self.port, None));
         self.notify_frontend(FrontendEvent::PublicKeyFingerprint(
             self.public_key_fingerprint.clone(),
+        ));
+        self.notify_frontend(FrontendEvent::ReleaseThreshold(
+            self.config.release_threshold_px(),
         ));
         let keys = self.authorized_keys.read().expect("lock").clone();
         self.notify_frontend(FrontendEvent::AuthorizedUpdated(keys));

--- a/src/service.rs
+++ b/src/service.rs
@@ -333,6 +333,17 @@ impl Service {
             EmulationEvent::Connected { addr, fingerprint } => {
                 self.notify_frontend(FrontendEvent::DeviceConnected { addr, fingerprint });
             }
+            EmulationEvent::PeerHello { addr, commit } => {
+                // Map the peer's source addr back to its client handle
+                // and stamp the commit. Skip if we don't have an
+                // outgoing client configured for this peer (incoming-
+                // only setup) — there's nowhere to display the version
+                // in that case anyway.
+                if let Some(handle) = self.client_manager.get_client(addr) {
+                    self.client_manager.set_peer_commit(handle, Some(commit));
+                    self.broadcast_client(handle);
+                }
+            }
         }
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -329,7 +329,7 @@ impl Service {
                 self.emulation_status = Status::Enabled;
                 self.notify_frontend(FrontendEvent::EmulationStatus(self.emulation_status));
             }
-            EmulationEvent::ReleaseNotify => self.capture.release(),
+            EmulationEvent::ReleaseNotify => self.capture.release_for_handover(),
             EmulationEvent::Connected { addr, fingerprint } => {
                 self.notify_frontend(FrontendEvent::DeviceConnected { addr, fingerprint });
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -9,7 +9,6 @@ use crate::{
     listen::{LanMouseListener, ListenerCreationError},
 };
 use futures::StreamExt;
-use hickory_resolver::ResolveError;
 use lan_mouse_ipc::{
     AsyncFrontendListener, ClientHandle, FrontendEvent, FrontendRequest, IpcError,
     IpcListenerCreationError, Position, Status,
@@ -26,8 +25,6 @@ use tokio::{process::Command, signal, sync::Notify};
 
 #[derive(Debug, Error)]
 pub enum ServiceError {
-    #[error(transparent)]
-    Dns(#[from] ResolveError),
     #[error(transparent)]
     IpcListen(#[from] IpcListenerCreationError),
     #[error(transparent)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -164,8 +164,10 @@ impl Service {
         // interface (default route) changes — e.g. user switches
         // off Wi-Fi and Mac falls back to Ethernet. Cheap: at most
         // one re-publish every 30s, and a no-op when the primary
-        // hasn't moved.
+        // hasn't moved. `Skip` so a long suspend doesn't backlog-
+        // burst on resume.
         let mut discovery_refresh_tick = tokio::time::interval(Duration::from_secs(30));
+        discovery_refresh_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // skip the immediate-fire of the first tick — Discovery
         // already published once at startup
         discovery_refresh_tick.tick().await;

--- a/src/service.rs
+++ b/src/service.rs
@@ -105,11 +105,8 @@ impl Service {
         let listener =
             LanMouseListener::new(config.port(), cert.clone(), authorized_keys.clone()).await?;
         let primary_cache: PrimaryCache = Default::default();
-        let conn = LanMouseConnection::new(
-            cert.clone(),
-            client_manager.clone(),
-            primary_cache.clone(),
-        );
+        let conn =
+            LanMouseConnection::new(cert.clone(), client_manager.clone(), primary_cache.clone());
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
@@ -168,8 +165,7 @@ impl Service {
         // off Wi-Fi and Mac falls back to Ethernet. Cheap: at most
         // one re-publish every 30s, and a no-op when the primary
         // hasn't moved.
-        let mut discovery_refresh_tick =
-            tokio::time::interval(Duration::from_secs(30));
+        let mut discovery_refresh_tick = tokio::time::interval(Duration::from_secs(30));
         // skip the immediate-fire of the first tick — Discovery
         // already published once at startup
         discovery_refresh_tick.tick().await;

--- a/src/service.rs
+++ b/src/service.rs
@@ -118,6 +118,9 @@ impl Service {
         );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
+        // Apply persisted natural-scroll preference at startup so
+        // the freshly-spawned emulation backend picks it up.
+        emulation.set_natural_scroll(config.natural_scroll());
 
         // create dns resolver
         let resolver = DnsResolver::new()?;
@@ -254,6 +257,12 @@ impl Service {
                 self.notify_frontend(FrontendEvent::ReleaseThreshold(threshold));
                 self.save_config();
             }
+            FrontendRequest::SetNaturalScroll(natural_scroll) => {
+                self.config.set_natural_scroll(natural_scroll);
+                self.emulation.set_natural_scroll(natural_scroll);
+                self.notify_frontend(FrontendEvent::NaturalScroll(natural_scroll));
+                self.save_config();
+            }
             FrontendRequest::SetMdnsDiscovery(enabled) => {
                 self.config.set_mdns_discovery(enabled);
                 self.discovery.set_enabled(enabled);
@@ -303,6 +312,9 @@ impl Service {
         let release_threshold = self.config.release_threshold_px();
         self.capture.set_release_threshold(release_threshold);
         self.notify_frontend(FrontendEvent::ReleaseThreshold(release_threshold));
+        let natural_scroll = self.config.natural_scroll();
+        self.emulation.set_natural_scroll(natural_scroll);
+        self.notify_frontend(FrontendEvent::NaturalScroll(natural_scroll));
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()
@@ -439,6 +451,7 @@ impl Service {
         self.notify_frontend(FrontendEvent::ReleaseThreshold(
             self.config.release_threshold_px(),
         ));
+        self.notify_frontend(FrontendEvent::NaturalScroll(self.config.natural_scroll()));
         self.notify_frontend(FrontendEvent::MdnsDiscovery(self.config.mdns_discovery()));
         let keys = self.authorized_keys.read().expect("lock").clone();
         self.notify_frontend(FrontendEvent::AuthorizedUpdated(keys));

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,6 +4,7 @@ use crate::{
     config::{Config, ConfigClient},
     connect::LanMouseConnection,
     crypto,
+    discovery::{Discovery, PrimaryCache},
     dns::{DnsEvent, DnsResolver},
     emulation::{Emulation, EmulationEvent},
     listen::{LanMouseListener, ListenerCreationError},
@@ -19,6 +20,7 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     sync::{Arc, RwLock},
+    time::Duration,
 };
 use thiserror::Error;
 use tokio::{process::Command, signal, sync::Notify};
@@ -67,6 +69,11 @@ pub struct Service {
     /// map from capture handle to connection info
     incoming_conn_info: HashMap<ClientHandle, Incoming>,
     next_trigger_handle: u64,
+    /// mDNS-SD service registration + browse. Advertises our primary
+    /// interface IP for peer dialers to bias toward; populates
+    /// shared `PrimaryCache` (read by `LanMouseConnection`) from
+    /// peer announcements.
+    discovery: Discovery,
 }
 
 #[derive(Debug)]
@@ -91,10 +98,18 @@ impl Service {
         let frontend_listener = AsyncFrontendListener::new().await?;
 
         let authorized_keys = Arc::new(RwLock::new(config.authorized_fingerprints()));
-        // listener + connection
+        // listener + connection. The primary-IP cache is owned by
+        // the dialer side so its references survive Discovery
+        // toggles; Discovery writes peer hints into it as browse
+        // events arrive.
         let listener =
             LanMouseListener::new(config.port(), cert.clone(), authorized_keys.clone()).await?;
-        let conn = LanMouseConnection::new(cert.clone(), client_manager.clone());
+        let primary_cache: PrimaryCache = Default::default();
+        let conn = LanMouseConnection::new(
+            cert.clone(),
+            client_manager.clone(),
+            primary_cache.clone(),
+        );
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
@@ -111,6 +126,7 @@ impl Service {
         let resolver = DnsResolver::new()?;
 
         let port = config.port();
+        let discovery = Discovery::new(port, config.mdns_discovery(), primary_cache);
         let service = Self {
             config,
             capture,
@@ -128,6 +144,7 @@ impl Service {
             incoming_conn_info: Default::default(),
             incoming_conns: Default::default(),
             next_trigger_handle: 0,
+            discovery,
         };
         Ok(service)
     }
@@ -145,6 +162,18 @@ impl Service {
             self.activate_client(handle);
         }
 
+        // Periodic refresh of the Discovery service registration so
+        // its TXT record stays accurate when the OS-preferred
+        // interface (default route) changes — e.g. user switches
+        // off Wi-Fi and Mac falls back to Ethernet. Cheap: at most
+        // one re-publish every 30s, and a no-op when the primary
+        // hasn't moved.
+        let mut discovery_refresh_tick =
+            tokio::time::interval(Duration::from_secs(30));
+        // skip the immediate-fire of the first tick — Discovery
+        // already published once at startup
+        discovery_refresh_tick.tick().await;
+
         loop {
             tokio::select! {
                 request = self.frontend_listener.next() => self.handle_frontend_request(request),
@@ -153,6 +182,7 @@ impl Service {
                 event = self.capture.event() => self.handle_capture_event(event),
                 event = self.resolver.event() => self.handle_resolver_event(event),
                 _ = self.config.changed() => self.handle_config_change(),
+                _ = discovery_refresh_tick.tick() => self.discovery.refresh(),
                 r = signal::ctrl_c() => break r.expect("failed to wait for CTRL+C"),
             }
         }
@@ -224,6 +254,12 @@ impl Service {
                 self.config.set_release_threshold_px(threshold);
                 self.capture.set_release_threshold(threshold);
                 self.notify_frontend(FrontendEvent::ReleaseThreshold(threshold));
+                self.save_config();
+            }
+            FrontendRequest::SetMdnsDiscovery(enabled) => {
+                self.config.set_mdns_discovery(enabled);
+                self.discovery.set_enabled(enabled);
+                self.notify_frontend(FrontendEvent::MdnsDiscovery(enabled));
                 self.save_config();
             }
         }
@@ -313,6 +349,7 @@ impl Service {
             EmulationEvent::PortChanged(port) => match port {
                 Ok(port) => {
                     self.port = port;
+                    self.discovery.set_port(port);
                     self.notify_frontend(FrontendEvent::PortChanged(port, None));
                 }
                 Err(e) => self
@@ -404,6 +441,7 @@ impl Service {
         self.notify_frontend(FrontendEvent::ReleaseThreshold(
             self.config.release_threshold_px(),
         ));
+        self.notify_frontend(FrontendEvent::MdnsDiscovery(self.config.mdns_discovery()));
         let keys = self.authorized_keys.read().expect("lock").clone();
         self.notify_frontend(FrontendEvent::AuthorizedUpdated(keys));
     }


### PR DESCRIPTION
**Review-only focused diff** (just this PR's commits, vs. `split/06-scroll`): https://github.com/jondkinney/lan-mouse/compare/split/06-scroll...split/07-singleton

## Summary

Cross-platform GUI singleton — `lan-mouse` launched twice no longer opens a second window.

Dedicated `lan-mouse-gui.sock` (Unix) / `127.0.0.1:5253` (Windows), separate from the daemon socket. First GUI binds; later launches connect, send a byte, and exit. Primary forwards into the GTK main loop and calls `window.present()`.

Decoupled from the daemon socket on purpose: `lan-mouse daemon` headless workflow is unchanged. Stale-socket recovery if the primary crashed without cleanup. Defense-in-depth via `app.windows().first()` for the in-process activation path. Unit test covers acquire → signal → re-acquire.

## Test plan

- [x] First GUI invocation binds the singleton socket; window opens
- [x] Second invocation while the first is running: the second exits cleanly and the first's window is brought forward
- [x] Primary crashed without cleanup → next GUI invocation reclaims the stale socket and starts fresh
- [x] Headless `lan-mouse daemon` workflow unchanged (singleton lock only exists while a GUI is running)
- [x] In-process activation (DBus single-instance on Linux, `kAEReopenApplication` on macOS) reuses the existing window via `app.windows().first()`

---

Split out from #418, the umbrella PR collecting ~10 independent feature areas. This PR is the GUI singleton subset. See #418 for the full picture.

## Stack overview

These PRs are split out from #418 and stack in this order:

1. #420 — cursor sync + wall-press + host-lock + slider/UI
2. #421 — peer version exchange
3. #422 — hostname resolver + multi-homed DTLS listener
4. #423 — mDNS-SD service-order discovery
5. #424 — macOS QoL + UI polish
6. #425 — scroll forwarding
7. #426 — GUI singleton

Each PR's branch builds on the previous one, so until earlier PRs are merged the cumulative diff against `main` includes all preceding work. Reviewing in order is easiest.