### PR TITLE
feat(cursor-sync): CursorPos protocol + cursor warps without prior Bounds

### DIFF
--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -42,7 +42,7 @@ impl Capture for DummyInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         Ok(())
     }
 

--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -62,7 +62,7 @@ impl Stream for DummyInputCapture {
         let event = match self.start {
             None => {
                 self.start.replace(current);
-                CaptureEvent::Begin
+                CaptureEvent::Begin { cursor: None }
             }
             Some(start) => {
                 let elapsed = start.elapsed();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -654,7 +654,7 @@ impl Capture for LayerShellInputCapture {
         Ok(inner.flush_events()?)
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         log::debug!("releasing pointer");
         let inner = self.0.get_mut();
         inner.state.ungrab();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -753,7 +753,8 @@ impl Dispatch<WlPointer, ()> for State {
                     .find(|w| w.surface == surface)
                     .map(|w| w.pos)
                     .unwrap();
-                app.pending_events.push_back((pos, CaptureEvent::Begin));
+                app.pending_events
+                    .push_back((pos, CaptureEvent::Begin { cursor: None }));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -149,6 +149,13 @@ struct Window {
     surface: WlSurface,
     layer_surface: ZwlrLayerSurfaceV1,
     pos: Position,
+    /// Output's top-left corner in compositor coordinate space —
+    /// used together with `wl_pointer::Enter`'s surface-local coords
+    /// to recover the host screen-space cursor position at the moment
+    /// of crossing, so we can populate `CaptureEvent::Begin { cursor }`
+    /// for cross-axis preservation.
+    output_pos: (i32, i32),
+    output_size: (i32, i32),
 }
 
 impl Window {
@@ -157,6 +164,7 @@ impl Window {
         qh: &QueueHandle<State>,
         output: &WlOutput,
         pos: Position,
+        output_pos: (i32, i32),
         size: (i32, i32),
     ) -> Window {
         log::debug!("creating window output: {output:?}, size: {size:?}");
@@ -208,6 +216,8 @@ impl Window {
             buffer,
             surface,
             layer_surface,
+            output_pos,
+            output_size: size,
         }
     }
 }
@@ -218,6 +228,22 @@ impl Drop for Window {
         self.layer_surface.destroy();
         self.surface.destroy();
         self.buffer.destroy();
+    }
+}
+
+/// Translate `wl_pointer.enter` surface-local coords into the host's
+/// compositor coordinate space, using the layer-surface's anchor edge
+/// and the output it's attached to. Layer surfaces here are 1 px on
+/// the on-axis dimension and span the cross-axis, so the surface-local
+/// cross-axis coord is the screen offset directly.
+fn surface_to_screen(window: &Window, surface_x: f64, surface_y: f64) -> (i32, i32) {
+    let (ox, oy) = window.output_pos;
+    let (ow, oh) = window.output_size;
+    match window.pos {
+        Position::Left => (ox, oy + surface_y as i32),
+        Position::Right => (ox + ow.saturating_sub(1), oy + surface_y as i32),
+        Position::Top => (ox + surface_x as i32, oy),
+        Position::Bottom => (ox + surface_x as i32, oy + oh.saturating_sub(1)),
     }
 }
 
@@ -525,7 +551,7 @@ impl State {
         );
         outputs.iter().for_each(|o| {
             if let Some(info) = o.info.as_ref() {
-                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.size);
+                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
                 let window = Arc::new(window);
                 self.active_windows.push(window);
             }
@@ -638,6 +664,28 @@ impl Capture for LayerShellInputCapture {
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Union of every active output's rectangle in compositor
+        // coords. Mirrors the macOS impl so MotionAbsolute scaling
+        // stays consistent: cursor coords reported in this same
+        // space normalize cleanly against the returned dimensions.
+        let outputs = &self.0.get_ref().state.outputs;
+        let mut xmin = i32::MAX;
+        let mut ymin = i32::MAX;
+        let mut xmax = i32::MIN;
+        let mut ymax = i32::MIN;
+        for info in outputs.iter().filter_map(|o| o.info.as_ref()) {
+            xmin = xmin.min(info.position.0);
+            ymin = ymin.min(info.position.1);
+            xmax = xmax.max(info.position.0 + info.size.0);
+            ymax = ymax.max(info.position.1 + info.size.1);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
+    }
 }
 
 impl Stream for LayerShellInputCapture {
@@ -735,26 +783,26 @@ impl Dispatch<WlPointer, ()> for State {
             wl_pointer::Event::Enter {
                 serial,
                 surface,
-                surface_x: _,
-                surface_y: _,
+                surface_x,
+                surface_y,
             } => {
-                // get client corresponding to the focused surface
-                {
-                    if let Some(window) = app.active_windows.iter().find(|w| w.surface == surface) {
-                        app.focused = Some(window.clone());
-                        app.grab(&surface, pointer, serial, qh);
-                    } else {
-                        return;
-                    }
-                }
-                let pos = app
+                let Some(window) = app
                     .active_windows
                     .iter()
                     .find(|w| w.surface == surface)
-                    .map(|w| w.pos)
-                    .unwrap();
-                app.pending_events
-                    .push_back((pos, CaptureEvent::Begin { cursor: None }));
+                    .cloned()
+                else {
+                    return;
+                };
+                app.focused = Some(window.clone());
+                app.grab(&surface, pointer, serial, qh);
+                let cursor = surface_to_screen(&window, surface_x, surface_y);
+                app.pending_events.push_back((
+                    window.pos,
+                    CaptureEvent::Begin {
+                        cursor: Some(cursor),
+                    },
+                ));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -551,7 +551,8 @@ impl State {
         );
         outputs.iter().for_each(|o| {
             if let Some(info) = o.info.as_ref() {
-                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
+                let window =
+                    Window::new(self, &self.qh, &o.wl_output, pos, info.position, info.size);
                 let window = Arc::new(window);
                 self.active_windows.push(window);
             }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures_core::Stream;
 
-use input_event::{Event, KeyboardEvent, scancode};
+use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
 
 pub use error::{CaptureCreationError, CaptureError, InputCaptureError};
 
@@ -41,6 +41,11 @@ pub enum CaptureEvent {
     Begin,
     /// input event coming from capture handle
     Input(Event),
+    /// the capture wrapper detected sustained back-toward-host motion
+    /// past the configured threshold (the user has pinned the cursor
+    /// at the host-adjacent edge of the guest and kept pushing). The
+    /// capture loop should treat this like a release-bind chord.
+    AutoRelease,
 }
 
 impl Display for CaptureEvent {
@@ -48,6 +53,7 @@ impl Display for CaptureEvent {
         match self {
             CaptureEvent::Begin => write!(f, "begin capture"),
             CaptureEvent::Input(e) => write!(f, "{e}"),
+            CaptureEvent::AutoRelease => write!(f, "auto-release"),
         }
     }
 }
@@ -127,6 +133,37 @@ pub struct InputCapture {
     id_map: HashMap<CaptureHandle, Position>,
     /// pending events
     pending: VecDeque<(CaptureHandle, CaptureEvent)>,
+    /// pixel threshold for the cross-platform auto-release-on-wall-
+    /// press fallback. 0 disables. See `track_wall_press`.
+    release_threshold_px: u32,
+    /// position the cursor is currently captured into, if any. Tracks
+    /// `Begin`/release transitions so the wall-press accumulator
+    /// resets correctly across capture sessions.
+    capture_pos: Option<Position>,
+    /// Modeled cursor position on the guest along the entry axis,
+    /// relative to the host-adjacent edge. 0 = at the entry edge,
+    /// growing values = further into the guest. Clamped at 0 from
+    /// below; *not* clamped from above (the wrapper can't know the
+    /// guest's far-edge extent without a protocol-level Bounds event,
+    /// and any proxy is wrong for some user's setup).
+    virtual_pos: f64,
+    /// Pixels of back-toward-host motion that the modeled cursor
+    /// could not absorb (proposed virtual_pos < 0). Resets whenever
+    /// the cursor is back in the interior or moving deeper.
+    wall_pressure: f64,
+}
+
+/// Project a motion delta onto the entry axis. Positive return =
+/// "into guest", so virtual_pos increases as the user pushes deeper.
+fn entry_axis_delta(position: Position, dx: f64, dy: f64) -> f64 {
+    match position {
+        // Position::Left = guest is to the LEFT of host. User entered
+        // by moving left (-dx). Convention: positive = into guest.
+        Position::Left => -dx,
+        Position::Right => dx,
+        Position::Top => -dy,
+        Position::Bottom => dy,
+    }
 }
 
 impl InputCapture {
@@ -168,7 +205,80 @@ impl InputCapture {
     /// release mouse
     pub async fn release(&mut self) -> Result<(), CaptureError> {
         self.pressed_keys.clear();
+        self.reset_wall_press_state();
         self.capture.release().await
+    }
+
+    /// Configure the wall-press auto-release pixel threshold.
+    /// 0 disables. Effective immediately for the next motion event;
+    /// no need to recreate the backend.
+    pub fn set_release_threshold(&mut self, threshold: u32) {
+        self.release_threshold_px = threshold;
+    }
+
+    fn reset_wall_press_state(&mut self) {
+        self.capture_pos = None;
+        self.virtual_pos = 0.0;
+        self.wall_pressure = 0.0;
+    }
+
+    /// Update the wall-press accumulator from one event coming up
+    /// from the backend. Returns true if the threshold was reached
+    /// and an `AutoRelease` should be synthesized for the active
+    /// capture position.
+    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
+        match event {
+            CaptureEvent::Begin => {
+                self.capture_pos = Some(pos);
+                self.virtual_pos = 0.0;
+                self.wall_pressure = 0.0;
+                false
+            }
+            CaptureEvent::AutoRelease => {
+                self.reset_wall_press_state();
+                false
+            }
+            CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
+                if self.release_threshold_px == 0 {
+                    return false;
+                }
+                let Some(active_pos) = self.capture_pos else {
+                    return false;
+                };
+                if active_pos != pos {
+                    return false;
+                }
+
+                let delta = entry_axis_delta(active_pos, *dx, *dy);
+                let proposed = self.virtual_pos + delta;
+                self.virtual_pos = proposed.max(0.0);
+
+                if proposed < 0.0 {
+                    // Motion overshot the host-adjacent edge —
+                    // accumulate the unabsorbed amount as wall
+                    // pressure.
+                    self.wall_pressure += -proposed;
+                } else {
+                    // Cursor moved into the interior or further in;
+                    // reset so a brief bump against the wall followed
+                    // by motion deeper into the guest doesn't combine
+                    // with a later wall-press to fire spuriously.
+                    self.wall_pressure = 0.0;
+                }
+
+                if self.wall_pressure >= f64::from(self.release_threshold_px) {
+                    log::info!(
+                        "auto-release: {:.0}px wall-press past entry edge ({}px threshold)",
+                        self.wall_pressure,
+                        self.release_threshold_px
+                    );
+                    self.reset_wall_press_state();
+                    return true;
+                }
+                false
+            }
+            _ => false,
+        }
     }
 
     /// Drain and return every key the capture has forwarded as
@@ -198,6 +308,10 @@ impl InputCapture {
             pending: Default::default(),
             position_map: Default::default(),
             pressed_keys: HashSet::new(),
+            release_threshold_px: 0,
+            capture_pos: None,
+            virtual_pos: 0.0,
+            wall_pressure: 0.0,
         })
     }
 
@@ -248,6 +362,11 @@ impl Stream for InputCapture {
             self.update_pressed_keys(key, state);
         }
 
+        // wall-press auto-release tracking. Runs against every event
+        // before routing so a single global accumulator stays consistent
+        // regardless of how many handles exist at this position.
+        let auto_release = self.track_wall_press(pos, &event);
+
         let len = self
             .position_map
             .get(&pos)
@@ -256,16 +375,25 @@ impl Stream for InputCapture {
 
         match len {
             0 => Poll::Pending,
-            1 => Poll::Ready(Some(Ok((
-                self.position_map.get(&pos).expect("no id")[0],
-                event,
-            )))),
+            1 => {
+                let id = self.position_map.get(&pos).expect("no id")[0];
+                if auto_release {
+                    // Deliver the original motion first; queue the
+                    // synthesized AutoRelease so the next poll picks
+                    // it up.
+                    self.pending.push_back((id, CaptureEvent::AutoRelease));
+                }
+                Poll::Ready(Some(Ok((id, event))))
+            }
             _ => {
                 let mut position_map = HashMap::new();
                 swap(&mut self.position_map, &mut position_map);
                 {
                     for &id in position_map.get(&pos).expect("position") {
                         self.pending.push_back((id, event));
+                        if auto_release {
+                            self.pending.push_back((id, CaptureEvent::AutoRelease));
+                        }
                     }
                 }
                 swap(&mut self.position_map, &mut position_map);

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -37,8 +37,15 @@ pub type CaptureHandle = u64;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CaptureEvent {
-    /// capture on this capture handle is now active
-    Begin,
+    /// Capture on this handle is now active. `cursor`, when present,
+    /// is the host's screen-space cursor position (in pixels) at the
+    /// instant of the edge crossing — the capture loop forwards it to
+    /// the peer as a [`ProtoEvent::MotionAbsolute`] so the guest's
+    /// cursor lands at the visually-corresponding point on its own
+    /// screen rather than snapping to the entry-edge midpoint.
+    /// Backends that can't report cursor position emit `None` and
+    /// the peer falls back to the entry-edge-midpoint warp.
+    Begin { cursor: Option<(i32, i32)> },
     /// input event coming from capture handle
     Input(Event),
     /// the capture wrapper detected sustained back-toward-host motion
@@ -51,7 +58,10 @@ pub enum CaptureEvent {
 impl Display for CaptureEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CaptureEvent::Begin => write!(f, "begin capture"),
+            CaptureEvent::Begin { cursor: None } => write!(f, "begin capture"),
+            CaptureEvent::Begin {
+                cursor: Some((x, y)),
+            } => write!(f, "begin capture @ ({x}, {y})"),
             CaptureEvent::Input(e) => write!(f, "{e}"),
             CaptureEvent::AutoRelease => write!(f, "auto-release"),
         }
@@ -237,6 +247,49 @@ impl InputCapture {
         self.peer_bounds.remove(&pos);
     }
 
+    /// Host's own display geometry — width and height in pixels of
+    /// the union of all displays. Returns `None` when the active
+    /// backend can't query its own bounds (e.g. xdg-desktop-portal,
+    /// dummy). Used together with `peer_bounds` to compute a
+    /// [`ProtoEvent::MotionAbsolute`] target so the guest cursor
+    /// lands at the visually-corresponding point on Enter.
+    pub fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.capture.display_bounds()
+    }
+
+    /// Cursor warp target on the peer for a transition at `pos`,
+    /// given the host's screen-space cursor position at the moment
+    /// of crossing. Returns `None` when either the host's own
+    /// `display_bounds` or the cached peer geometry is unavailable —
+    /// in that case the capture loop just doesn't send MotionAbsolute
+    /// and the guest falls back to its entry-edge-midpoint warp.
+    ///
+    /// Coordinates returned are pixels in the peer's screen space:
+    /// the cross-axis is preserved as a normalized fraction of the
+    /// host screen (so a host_y near the top maps to a peer_y near
+    /// the top regardless of resolution mismatch), the on-axis is
+    /// pinned to the peer's far edge for the entering side.
+    pub fn peer_warp_target(&self, pos: Position, cursor: (i32, i32)) -> Option<(i32, i32)> {
+        let (host_w, host_h) = self.display_bounds()?;
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (cx, cy) = cursor;
+        let nx = (cx as f64 / host_w as f64).clamp(0.0, 1.0);
+        let ny = (cy as f64 / host_h as f64).clamp(0.0, 1.0);
+        let peer_w_i = peer_w as i32;
+        let peer_h_i = peer_h as i32;
+        let target = match pos {
+            // Peer to our Left → cursor exits on left, enters peer on right
+            Position::Left => (peer_w_i.saturating_sub(1), (ny * peer_h as f64) as i32),
+            // Peer to our Right → cursor enters peer on left
+            Position::Right => (0, (ny * peer_h as f64) as i32),
+            // Peer above → cursor enters peer on bottom
+            Position::Top => ((nx * peer_w as f64) as i32, peer_h_i.saturating_sub(1)),
+            // Peer below → cursor enters peer on top
+            Position::Bottom => ((nx * peer_w as f64) as i32, 0),
+        };
+        Some(target)
+    }
+
     /// Returns the upper-clamp value (along the entry axis) for the
     /// given position, or `f64::INFINITY` if the peer hasn't reported
     /// bounds yet.
@@ -262,7 +315,7 @@ impl InputCapture {
     /// capture position.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
         match event {
-            CaptureEvent::Begin => {
+            CaptureEvent::Begin { .. } => {
                 self.capture_pos = Some(pos);
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
@@ -462,6 +515,13 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;
+
+    /// Host's own display geometry. Default implementation returns
+    /// `None`; backends that can query their own dimensions override
+    /// (currently macOS via CGDisplay; others may add this later).
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        None
+    }
 }
 
 async fn create_backend(

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -143,14 +143,19 @@ pub struct InputCapture {
     /// Modeled cursor position on the guest along the entry axis,
     /// relative to the host-adjacent edge. 0 = at the entry edge,
     /// growing values = further into the guest. Clamped at 0 from
-    /// below; *not* clamped from above (the wrapper can't know the
-    /// guest's far-edge extent without a protocol-level Bounds event,
-    /// and any proxy is wrong for some user's setup).
+    /// below; clamped at the cached peer extent from above when
+    /// available, otherwise unbounded (degraded fallback).
     virtual_pos: f64,
     /// Pixels of back-toward-host motion that the modeled cursor
     /// could not absorb (proposed virtual_pos < 0). Resets whenever
     /// the cursor is back in the interior or moving deeper.
     wall_pressure: f64,
+    /// Per-position cache of peer display geometry. Populated when
+    /// the peer responds with a `ProtoEvent::Bounds` event after
+    /// Ack. Used as the upper clamp for `virtual_pos` so that
+    /// pushing past the guest's actual far edge doesn't make the
+    /// model run away. Only the entry-axis dimension is consulted.
+    peer_bounds: HashMap<Position, (u32, u32)>,
 }
 
 /// Project a motion delta onto the entry axis. Positive return =
@@ -216,6 +221,35 @@ impl InputCapture {
         self.release_threshold_px = threshold;
     }
 
+    /// Cache the peer's display geometry for a position. Used by
+    /// the wall-press tracker as the upper bound for `virtual_pos`
+    /// so the model can't run away when the user pushes past the
+    /// peer's actual far edge.
+    pub fn set_peer_bounds(&mut self, pos: Position, width: u32, height: u32) {
+        log::debug!("peer at {pos} reports bounds {width}x{height}");
+        self.peer_bounds.insert(pos, (width, height));
+    }
+
+    /// Forget the cached peer geometry for a position. Called when
+    /// the corresponding capture is destroyed so re-adding the same
+    /// peer later (potentially with new geometry) starts fresh.
+    pub fn clear_peer_bounds(&mut self, pos: Position) {
+        self.peer_bounds.remove(&pos);
+    }
+
+    /// Returns the upper-clamp value (along the entry axis) for the
+    /// given position, or `f64::INFINITY` if the peer hasn't reported
+    /// bounds yet.
+    fn peer_extent(&self, pos: Position) -> f64 {
+        let Some(&(w, h)) = self.peer_bounds.get(&pos) else {
+            return f64::INFINITY;
+        };
+        match pos {
+            Position::Left | Position::Right => f64::from(w),
+            Position::Top | Position::Bottom => f64::from(h),
+        }
+    }
+
     fn reset_wall_press_state(&mut self) {
         self.capture_pos = None;
         self.virtual_pos = 0.0;
@@ -251,7 +285,17 @@ impl InputCapture {
 
                 let delta = entry_axis_delta(active_pos, *dx, *dy);
                 let proposed = self.virtual_pos + delta;
-                self.virtual_pos = proposed.max(0.0);
+                let upper = self.peer_extent(active_pos);
+                // Clamp at 0 from below (host-adjacent edge — wall
+                // pressure accumulates here) and at the peer's
+                // entry-axis extent from above when known. The upper
+                // clamp prevents the model from running away if the
+                // user obliviously pushes their physical mouse past
+                // the guest's actual far edge. When the peer hasn't
+                // reported bounds yet (older peer, or pre-Ack
+                // window), `upper` is INFINITY and we fall back to
+                // the heuristic behavior.
+                self.virtual_pos = proposed.clamp(0.0, upper);
 
                 if proposed < 0.0 {
                     // Motion overshot the host-adjacent edge —
@@ -312,6 +356,7 @@ impl InputCapture {
             capture_pos: None,
             virtual_pos: 0.0,
             wall_pressure: 0.0,
+            peer_bounds: HashMap::new(),
         })
     }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -281,6 +281,27 @@ impl InputCapture {
         self.capture.display_bounds()
     }
 
+    /// Host's screen-space cursor position normalized to the host's
+    /// own display bounds (each axis in 0..1, clamped). Returns
+    /// `None` when the active backend can't report its own bounds.
+    /// Used for the self-sufficient `ProtoEvent::CursorPos` event
+    /// (the receiver scales the normalized fraction against its
+    /// own bounds and pins the entry axis to the matching edge), so
+    /// the first crossing isn't blocked by the bootstrap problem
+    /// `peer_warp_target` has — that variant requires a prior
+    /// `Bounds` round-trip from the peer, which can't have happened
+    /// yet on the very first Enter.
+    pub fn host_normalized_cursor(&self, cursor: (i32, i32)) -> Option<(f32, f32)> {
+        let (host_w, host_h) = self.display_bounds()?;
+        if host_w == 0 || host_h == 0 {
+            return None;
+        }
+        let (cx, cy) = cursor;
+        let nx = (cx as f32 / host_w as f32).clamp(0.0, 1.0);
+        let ny = (cy as f32 / host_h as f32).clamp(0.0, 1.0);
+        Some((nx, ny))
+    }
+
     /// Cursor warp target on the peer for a transition at `pos`,
     /// given the host's screen-space cursor position at the moment
     /// of crossing. Returns `None` when either the host's own

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -171,6 +171,21 @@ pub struct InputCapture {
     /// the matching point on the host's screen instead of jumping
     /// back to where capture started.
     virtual_cursor: Option<(f64, f64)>,
+    /// Host-coord cursor at the moment of `Begin`, retained until
+    /// `peer_bounds` arrives so we can retroactively seed
+    /// `virtual_cursor` once the round-trip completes. Without this,
+    /// a `Begin` that fires before the peer's `Bounds` reply leaves
+    /// `virtual_cursor` stuck at `None` for the rest of the session
+    /// — the wall-press accumulator skips updates and the
+    /// release-time warp falls back to the original crossing
+    /// y-value instead of where the cursor visually was on the peer.
+    pending_begin_cursor: Option<(i32, i32)>,
+    /// Motion deltas that arrived while `virtual_cursor` was still
+    /// `None` (between `Begin` and the late-arriving
+    /// `set_peer_bounds`). Drained into the freshly-seeded
+    /// `virtual_cursor` when the bootstrap completes so deltas
+    /// during the round-trip aren't lost.
+    pending_motion: (f64, f64),
     /// Per-position cache of peer display geometry. Populated when
     /// the peer responds with a `ProtoEvent::Bounds` event after
     /// Ack. Used as the upper clamp for `virtual_pos` so that
@@ -261,9 +276,39 @@ impl InputCapture {
     /// the wall-press tracker as the upper bound for `virtual_pos`
     /// so the model can't run away when the user pushes past the
     /// peer's actual far edge.
+    ///
+    /// If `Begin` fired before this arrived (the round-trip
+    /// bootstrap case — `Bounds` is sent in response to `Enter`,
+    /// which is sent by the host AFTER `Begin` fires), seed
+    /// `virtual_cursor` retroactively so the wall-press / release
+    /// machinery has a baseline to track from. Drains any motion
+    /// that piled up in `pending_motion` so deltas during the
+    /// round-trip aren't lost.
     pub fn set_peer_bounds(&mut self, pos: Position, width: u32, height: u32) {
         log::debug!("peer at {pos} reports bounds {width}x{height}");
         self.peer_bounds.insert(pos, (width, height));
+
+        if self.virtual_cursor.is_none()
+            && self.capture_pos == Some(pos)
+            && self.pending_begin_cursor.is_some()
+        {
+            let begin_cursor = self.pending_begin_cursor;
+            let seeded = self.initial_virtual_cursor(pos, begin_cursor);
+            if let Some((sx, sy)) = seeded {
+                let (mx, my) = self.pending_motion;
+                let peer_w = width as f64;
+                let peer_h = height as f64;
+                self.virtual_cursor = Some((
+                    (sx + mx).clamp(0.0, peer_w),
+                    (sy + my).clamp(0.0, peer_h),
+                ));
+                self.pending_motion = (0.0, 0.0);
+                log::info!(
+                    "[bootstrap] seeded virtual_cursor={:?} after late peer_bounds at {pos} (drained pending_motion=({mx:.1}, {my:.1}))",
+                    self.virtual_cursor
+                );
+            }
+        }
     }
 
     /// Forget the cached peer geometry for a position. Called when
@@ -372,6 +417,8 @@ impl InputCapture {
         self.virtual_pos = 0.0;
         self.wall_pressure = 0.0;
         self.virtual_cursor = None;
+        self.pending_begin_cursor = None;
+        self.pending_motion = (0.0, 0.0);
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -442,6 +489,16 @@ impl InputCapture {
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
                 self.virtual_cursor = self.initial_virtual_cursor(pos, *cursor);
+                // Stash the host-coord cursor so set_peer_bounds can
+                // retroactively seed virtual_cursor if peer_bounds
+                // arrives after Begin.
+                self.pending_begin_cursor = *cursor;
+                self.pending_motion = (0.0, 0.0);
+                log::info!(
+                    "[wp-begin] pos={pos} cursor={cursor:?} peer_bounds={:?} virtual_cursor={:?}",
+                    self.peer_bounds.get(&pos).copied(),
+                    self.virtual_cursor,
+                );
                 false
             }
             CaptureEvent::AutoRelease => {
@@ -462,12 +519,31 @@ impl InputCapture {
                 // back to the host. Clamped to the peer's bounds so
                 // the model doesn't drift past the guest's screen
                 // when the user pushes obliviously.
-                if let (Some(vc), Some(&(peer_w, peer_h))) = (
+                match (
                     self.virtual_cursor.as_mut(),
                     self.peer_bounds.get(&active_pos),
                 ) {
-                    vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
-                    vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                    (Some(vc), Some(&(peer_w, peer_h))) => {
+                        vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
+                        vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                    }
+                    // virtual_cursor not yet seeded (peer_bounds was
+                    // None at Begin time and the round-trip hasn't
+                    // completed yet). Buffer the deltas so they can
+                    // be applied retroactively in set_peer_bounds
+                    // once the bootstrap finishes — otherwise the
+                    // motion that happened during the round-trip is
+                    // silently lost and the release-time warp picks
+                    // the wrong y.
+                    (None, _) => {
+                        self.pending_motion.0 += *dx;
+                        self.pending_motion.1 += *dy;
+                        log::debug!(
+                            "[wp-motion] deferred dx={dx:.1} dy={dy:.1} (peer_bounds for {active_pos}: {:?})",
+                            self.peer_bounds.get(&active_pos).copied(),
+                        );
+                    }
+                    _ => {}
                 }
 
                 if self.release_threshold_px == 0 {
@@ -548,6 +624,8 @@ impl InputCapture {
             virtual_pos: 0.0,
             wall_pressure: 0.0,
             virtual_cursor: None,
+            pending_begin_cursor: None,
+            pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
         })
     }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -160,6 +160,15 @@ pub struct InputCapture {
     /// could not absorb (proposed virtual_pos < 0). Resets whenever
     /// the cursor is back in the interior or moving deeper.
     wall_pressure: f64,
+    /// Modeled guest cursor position in the guest's screen space,
+    /// updated by accumulating Motion deltas while captured. Seeded
+    /// on `Begin` from the cross-axis warp target (if peer bounds
+    /// are known) or the entry-edge midpoint otherwise — i.e. wherever
+    /// the guest's cursor visually lands at Enter. Read on release
+    /// to compute a host-side warp so the local cursor reappears at
+    /// the matching point on the host's screen instead of jumping
+    /// back to where capture started.
+    virtual_cursor: Option<(f64, f64)>,
     /// Per-position cache of peer display geometry. Populated when
     /// the peer responds with a `ProtoEvent::Bounds` event after
     /// Ack. Used as the upper clamp for `virtual_pos` so that
@@ -219,9 +228,24 @@ impl InputCapture {
 
     /// release mouse
     pub async fn release(&mut self) -> Result<(), CaptureError> {
+        // Compute the host-side warp target before resetting the
+        // wall-press / virtual_cursor state — once those are cleared
+        // we lose the data needed to figure out where the guest's
+        // cursor visually was.
+        let warp_target = self
+            .capture_pos
+            .and_then(|pos| self.host_warp_target_on_release(pos));
+        log::info!(
+            "[release-warp] capture_pos={:?} virtual_cursor={:?} peer_bounds={:?} display_bounds={:?} → warp_target={warp_target:?}",
+            self.capture_pos,
+            self.virtual_cursor,
+            self.capture_pos
+                .and_then(|p| self.peer_bounds.get(&p).copied()),
+            self.capture.display_bounds(),
+        );
         self.pressed_keys.clear();
         self.reset_wall_press_state();
-        self.capture.release().await
+        self.capture.release(warp_target).await
     }
 
     /// Configure the wall-press auto-release pixel threshold.
@@ -307,6 +331,64 @@ impl InputCapture {
         self.capture_pos = None;
         self.virtual_pos = 0.0;
         self.wall_pressure = 0.0;
+        self.virtual_cursor = None;
+    }
+
+    /// Initial guest-space cursor position for a freshly-started
+    /// capture. Mirrors what the guest's emulation will visibly do on
+    /// the corresponding `Enter`: a `MotionAbsolute` warp target if
+    /// the host can compute one (peer bounds known + capture backend
+    /// reports cursor), otherwise the entry-edge midpoint that
+    /// `entry_edge_for` produces on the guest side.
+    fn initial_virtual_cursor(
+        &self,
+        pos: Position,
+        host_cursor: Option<(i32, i32)>,
+    ) -> Option<(f64, f64)> {
+        if let Some(host_cursor) = host_cursor {
+            if let Some((x, y)) = self.peer_warp_target(pos, host_cursor) {
+                return Some((x as f64, y as f64));
+            }
+        }
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let pw = peer_w as f64;
+        let ph = peer_h as f64;
+        Some(match pos {
+            Position::Left => (0.0, ph / 2.0),
+            Position::Right => ((pw - 1.0).max(0.0), ph / 2.0),
+            Position::Top => (pw / 2.0, 0.0),
+            Position::Bottom => (pw / 2.0, (ph - 1.0).max(0.0)),
+        })
+    }
+
+    /// Where on the host's own screen the cursor should land when
+    /// capture is released, given the modeled guest cursor position
+    /// at the moment of release. Symmetric inverse of
+    /// `peer_warp_target`: cross-axis is preserved as a normalized
+    /// fraction of the peer's screen, on-axis is pinned to the
+    /// host's far edge for the side the guest is on so the cursor
+    /// reappears at the boundary it just crossed back through.
+    fn host_warp_target_on_release(&self, pos: Position) -> Option<(i32, i32)> {
+        let (gx, gy) = self.virtual_cursor?;
+        let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (host_w, host_h) = self.capture.display_bounds()?;
+        if peer_w == 0 || peer_h == 0 || host_w == 0 || host_h == 0 {
+            return None;
+        }
+        let nx = (gx / peer_w as f64).clamp(0.0, 1.0);
+        let ny = (gy / peer_h as f64).clamp(0.0, 1.0);
+        let host_w_i = host_w as i32;
+        let host_h_i = host_h as i32;
+        Some(match pos {
+            // Peer to our Left → cursor returns through host's left edge
+            Position::Left => (0, (ny * host_h as f64) as i32),
+            // Peer to our Right → cursor returns through host's right edge
+            Position::Right => (host_w_i.saturating_sub(1), (ny * host_h as f64) as i32),
+            // Peer above → cursor returns through host's top edge
+            Position::Top => ((nx * host_w as f64) as i32, 0),
+            // Peer below → cursor returns through host's bottom edge
+            Position::Bottom => ((nx * host_w as f64) as i32, host_h_i.saturating_sub(1)),
+        })
     }
 
     /// Update the wall-press accumulator from one event coming up
@@ -315,24 +397,39 @@ impl InputCapture {
     /// capture position.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
         match event {
-            CaptureEvent::Begin { .. } => {
+            CaptureEvent::Begin { cursor } => {
                 self.capture_pos = Some(pos);
                 self.virtual_pos = 0.0;
                 self.wall_pressure = 0.0;
+                self.virtual_cursor = self.initial_virtual_cursor(pos, *cursor);
                 false
             }
             CaptureEvent::AutoRelease => {
-                self.reset_wall_press_state();
+                // Don't reset virtual_cursor here — release() needs it
+                // to compute the host-side warp target. The wrapper's
+                // release() resets state after consuming it.
                 false
             }
             CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
-                if self.release_threshold_px == 0 {
-                    return false;
-                }
                 let Some(active_pos) = self.capture_pos else {
                     return false;
                 };
                 if active_pos != pos {
+                    return false;
+                }
+
+                // Track guest-space cursor for the on-release warp
+                // back to the host. Clamped to the peer's bounds so
+                // the model doesn't drift past the guest's screen
+                // when the user pushes obliviously.
+                if let (Some(vc), Some(&(peer_w, peer_h))) =
+                    (self.virtual_cursor.as_mut(), self.peer_bounds.get(&active_pos))
+                {
+                    vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
+                    vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
+                }
+
+                if self.release_threshold_px == 0 {
                     return false;
                 }
 
@@ -409,6 +506,7 @@ impl InputCapture {
             capture_pos: None,
             virtual_pos: 0.0,
             wall_pressure: 0.0,
+            virtual_cursor: None,
             peer_bounds: HashMap::new(),
         })
     }
@@ -510,8 +608,14 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
     /// destroy the client with the given id, if it exists
     async fn destroy(&mut self, pos: Position) -> Result<(), CaptureError>;
 
-    /// release mouse
-    async fn release(&mut self) -> Result<(), CaptureError>;
+    /// release mouse. `warp_target`, when present, is a screen-space
+    /// pixel point on the host's own display where the local cursor
+    /// should be placed before becoming visible again — used to
+    /// preserve cross-axis continuity when capture ends so the cursor
+    /// reappears next to where it visually was on the guest, not at
+    /// the spot where capture started. Backends that don't hide the
+    /// system cursor or can't warp it can ignore the parameter.
+    async fn release(&mut self, warp_target: Option<(i32, i32)>) -> Result<(), CaptureError>;
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -281,6 +281,13 @@ impl InputCapture {
         self.capture.display_bounds()
     }
 
+    /// Top-left corner of the host's display union in pointer-event
+    /// coordinate space. See `Capture::display_origin` for why this
+    /// matters on multi-monitor macOS hosts.
+    fn display_origin(&self) -> (i32, i32) {
+        self.capture.display_origin()
+    }
+
     /// Host's screen-space cursor position normalized to the host's
     /// own display bounds (each axis in 0..1, clamped). Returns
     /// `None` when the active backend can't report its own bounds.
@@ -296,9 +303,15 @@ impl InputCapture {
         if host_w == 0 || host_h == 0 {
             return None;
         }
+        let (origin_x, origin_y) = self.display_origin();
         let (cx, cy) = cursor;
-        let nx = (cx as f32 / host_w as f32).clamp(0.0, 1.0);
-        let ny = (cy as f32 / host_h as f32).clamp(0.0, 1.0);
+        // Subtract the union origin before normalizing so that
+        // points on a non-origin display (e.g. a macOS external
+        // monitor positioned to the left of the primary, where
+        // cursor x is negative) map correctly. Without this, the
+        // clamp masks every off-primary point as the screen edge.
+        let nx = ((cx - origin_x) as f32 / host_w as f32).clamp(0.0, 1.0);
+        let ny = ((cy - origin_y) as f32 / host_h as f32).clamp(0.0, 1.0);
         Some((nx, ny))
     }
 
@@ -317,9 +330,12 @@ impl InputCapture {
     pub fn peer_warp_target(&self, pos: Position, cursor: (i32, i32)) -> Option<(i32, i32)> {
         let (host_w, host_h) = self.display_bounds()?;
         let &(peer_w, peer_h) = self.peer_bounds.get(&pos)?;
+        let (origin_x, origin_y) = self.display_origin();
         let (cx, cy) = cursor;
-        let nx = (cx as f64 / host_w as f64).clamp(0.0, 1.0);
-        let ny = (cy as f64 / host_h as f64).clamp(0.0, 1.0);
+        // Subtract the union origin before normalizing — same
+        // rationale as in host_normalized_cursor.
+        let nx = ((cx - origin_x) as f64 / host_w as f64).clamp(0.0, 1.0);
+        let ny = ((cy - origin_y) as f64 / host_h as f64).clamp(0.0, 1.0);
         let peer_w_i = peer_w as i32;
         let peer_h_i = peer_h as i32;
         let target = match pos {
@@ -647,6 +663,21 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
     /// (currently macOS via CGDisplay; others may add this later).
     fn display_bounds(&self) -> Option<(u32, u32)> {
         None
+    }
+
+    /// Top-left corner of the union of all displays in the host's
+    /// global pointer-coordinate system. Defaults to (0, 0) — fine
+    /// for any backend whose primary display is the origin (Windows,
+    /// most X11/Wayland setups). Returns the actual `(xmin, ymin)`
+    /// on macOS, where the global coordinate system is anchored at
+    /// the primary's top-left and a left-attached external display
+    /// occupies negative x. Used by `host_normalized_cursor` and
+    /// `peer_warp_target` to correctly normalize cursor positions
+    /// outside the primary display — without this, the
+    /// `clamp(0.0, 1.0)` in those helpers silently maps every point
+    /// on a non-origin display to the screen edge.
+    fn display_origin(&self) -> (i32, i32) {
+        (0, 0)
     }
 }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -298,10 +298,8 @@ impl InputCapture {
                 let (mx, my) = self.pending_motion;
                 let peer_w = width as f64;
                 let peer_h = height as f64;
-                self.virtual_cursor = Some((
-                    (sx + mx).clamp(0.0, peer_w),
-                    (sy + my).clamp(0.0, peer_h),
-                ));
+                self.virtual_cursor =
+                    Some(((sx + mx).clamp(0.0, peer_w), (sy + my).clamp(0.0, peer_h)));
                 self.pending_motion = (0.0, 0.0);
                 log::info!(
                     "[bootstrap] seeded virtual_cursor={:?} after late peer_bounds at {pos} (drained pending_motion=({mx:.1}, {my:.1}))",

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     mem::swap,
     pin::Pin,
     task::{Poll, ready},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -196,16 +196,17 @@ pub struct InputCapture {
     /// pushing past the guest's actual far edge doesn't make the
     /// model run away. Only the entry-axis dimension is consulted.
     peer_bounds: HashMap<Position, (u32, u32)>,
-    /// Set when wall_pressure first crosses `release_threshold_px`,
-    /// cleared when the peer's handover Leave arrives (which routes
-    /// through `release_no_host_warp` → `reset_wall_press_state`) or
-    /// when the cursor moves back into the interior. The wall-press
-    /// auto-release fires only after `wall_press_deadline` elapses
-    /// without being cleared — turning the historically race-y
-    /// "wall-press vs peer-Leave" into an explicit fallback that
-    /// only kicks in when the peer can't deliver a Leave (lock
-    /// screen, restricted DE, dead peer).
-    wall_press_pending_at: Option<Instant>,
+    /// True when wall_pressure has crossed `release_threshold_px` and
+    /// `wall_press_timer` has been armed but not yet either elapsed
+    /// or been cancelled. Cleared when the peer's handover Leave
+    /// arrives (which routes through `release_no_host_warp` →
+    /// `reset_wall_press_state`) or when the cursor moves back into
+    /// the interior. The wall-press auto-release fires only after
+    /// `wall_press_deadline` elapses without this being cleared —
+    /// turning the historically race-y "wall-press vs peer-Leave"
+    /// into an explicit fallback that only kicks in when the peer
+    /// can't deliver a Leave (lock screen, restricted DE, dead peer).
+    wall_press_pending: bool,
     /// Window after the threshold is crossed during which a peer
     /// Leave can cancel the deferred AutoRelease. Sized so a
     /// healthy LAN round-trip beats it comfortably.
@@ -460,7 +461,7 @@ impl InputCapture {
         self.pending_motion = (0.0, 0.0);
         // Cancel any deferred AutoRelease — release() / handover have
         // taken responsibility for the transition.
-        self.wall_press_pending_at = None;
+        self.wall_press_pending = false;
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -534,11 +535,10 @@ impl InputCapture {
     }
 
     /// Update the wall-press accumulator from one event coming up
-    /// from the backend. Sets `wall_press_pending_at` (and arms the
+    /// from the backend. Sets `wall_press_pending` (and arms the
     /// timer) when the threshold is first crossed; the actual
     /// `AutoRelease` synthesis happens in `poll_next` once the
-    /// deadline elapses without a peer Leave clearing the pending
-    /// flag.
+    /// deadline elapses without a peer Leave clearing the flag.
     fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) {
         match event {
             CaptureEvent::Begin { cursor } => {
@@ -630,7 +630,7 @@ impl InputCapture {
                     // by motion deeper into the guest doesn't combine
                     // with a later wall-press to fire spuriously.
                     self.wall_pressure = 0.0;
-                    if self.wall_press_pending_at.take().is_some() {
+                    if std::mem::take(&mut self.wall_press_pending) {
                         log::info!(
                             "wall-press deferred AutoRelease cancelled (cursor moved away from entry edge)"
                         );
@@ -638,15 +638,12 @@ impl InputCapture {
                 }
 
                 if self.wall_pressure >= f64::from(self.release_threshold_px)
-                    && self.wall_press_pending_at.is_none()
+                    && !self.wall_press_pending
                 {
-                    let now = Instant::now();
-                    self.wall_press_pending_at = Some(now);
+                    self.wall_press_pending = true;
                     self.wall_press_timer
                         .as_mut()
-                        .reset(tokio::time::Instant::from_std(
-                            now + self.wall_press_deadline,
-                        ));
+                        .reset(tokio::time::Instant::now() + self.wall_press_deadline);
                     log::info!(
                         "wall-press threshold reached ({:.0}px past entry edge, {}px threshold) — \
                          deferring AutoRelease for {}ms pending peer Leave",
@@ -699,7 +696,7 @@ impl InputCapture {
             pending_begin_cursor: None,
             pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
-            wall_press_pending_at: None,
+            wall_press_pending: false,
             wall_press_deadline: Duration::from_millis(150),
             wall_press_timer: Box::pin(tokio::time::sleep(Duration::from_secs(0))),
         })
@@ -734,16 +731,14 @@ impl Stream for InputCapture {
 
         // Deferred wall-press fallback. If the threshold was crossed
         // and the deadline elapsed without a peer Leave clearing
-        // `wall_press_pending_at` (release_no_host_warp →
+        // `wall_press_pending` (release_no_host_warp →
         // reset_wall_press_state), synthesize AutoRelease for every
         // capture handle at the active position. Polled before the
         // backend so a fire still happens when the user pinned the
         // cursor against the wall and stopped moving (no further
         // backend events, but the deadline still has to elapse).
-        if self.wall_press_pending_at.is_some()
-            && self.wall_press_timer.as_mut().poll(cx).is_ready()
-        {
-            self.wall_press_pending_at = None;
+        if self.wall_press_pending && self.wall_press_timer.as_mut().poll(cx).is_ready() {
+            self.wall_press_pending = false;
             log::info!(
                 "wall-press deadline elapsed ({}ms) — firing AutoRelease (no peer Leave; \
                  assuming peer-side capture is unavailable, e.g. lock screen)",

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -462,19 +462,32 @@ impl InputCapture {
         if peer_w == 0 || peer_h == 0 || host_w == 0 || host_h == 0 {
             return None;
         }
+        let (origin_x, origin_y) = self.display_origin();
         let nx = (gx / peer_w as f64).clamp(0.0, 1.0);
         let ny = (gy / peer_h as f64).clamp(0.0, 1.0);
         let host_w_i = host_w as i32;
         let host_h_i = host_h as i32;
+        // Add the union origin back so the result is in pointer-event
+        // coordinate space (which is what `CGDisplay::warp_mouse_cursor_position`
+        // and friends consume), not "0..host_w" of the union rectangle.
+        // Matters on macOS hosts whose primary isn't anchored at (0, 0)
+        // — `display_bounds` returns just the size of the union, so the
+        // origin needs to be reapplied to recover absolute coords.
         Some(match pos {
             // Peer to our Left → cursor returns through host's left edge
-            Position::Left => (0, (ny * host_h as f64) as i32),
+            Position::Left => (origin_x, origin_y + (ny * host_h as f64) as i32),
             // Peer to our Right → cursor returns through host's right edge
-            Position::Right => (host_w_i.saturating_sub(1), (ny * host_h as f64) as i32),
+            Position::Right => (
+                origin_x + host_w_i.saturating_sub(1),
+                origin_y + (ny * host_h as f64) as i32,
+            ),
             // Peer above → cursor returns through host's top edge
-            Position::Top => ((nx * host_w as f64) as i32, 0),
+            Position::Top => (origin_x + (nx * host_w as f64) as i32, origin_y),
             // Peer below → cursor returns through host's bottom edge
-            Position::Bottom => ((nx * host_w as f64) as i32, host_h_i.saturating_sub(1)),
+            Position::Bottom => (
+                origin_x + (nx * host_w as f64) as i32,
+                origin_y + host_h_i.saturating_sub(1),
+            ),
         })
     }
 

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -39,12 +39,14 @@ pub type CaptureHandle = u64;
 pub enum CaptureEvent {
     /// Capture on this handle is now active. `cursor`, when present,
     /// is the host's screen-space cursor position (in pixels) at the
-    /// instant of the edge crossing — the capture loop forwards it to
-    /// the peer as a [`ProtoEvent::MotionAbsolute`] so the guest's
-    /// cursor lands at the visually-corresponding point on its own
-    /// screen rather than snapping to the entry-edge midpoint.
-    /// Backends that can't report cursor position emit `None` and
-    /// the peer falls back to the entry-edge-midpoint warp.
+    /// instant of the edge crossing — the capture loop normalizes it
+    /// against the host's display bounds and forwards it to the peer
+    /// as a [`ProtoEvent::CursorPos`] so the guest's cursor lands at
+    /// the visually-corresponding point on its own screen. Backends
+    /// that can't report cursor position emit `None`; the peer's
+    /// cursor stays where it was on remote-takeover (no forced
+    /// midpoint warp — that masquerades as a mid-screen crossing on
+    /// fast re-crosses).
     Begin { cursor: Option<(i32, i32)> },
     /// input event coming from capture handle
     Input(Event),
@@ -274,9 +276,9 @@ impl InputCapture {
     /// Host's own display geometry — width and height in pixels of
     /// the union of all displays. Returns `None` when the active
     /// backend can't query its own bounds (e.g. xdg-desktop-portal,
-    /// dummy). Used together with `peer_bounds` to compute a
-    /// [`ProtoEvent::MotionAbsolute`] target so the guest cursor
-    /// lands at the visually-corresponding point on Enter.
+    /// dummy). Used by `host_normalized_cursor` to compute the
+    /// [`ProtoEvent::CursorPos`] fraction the guest scales against
+    /// its own bounds on Enter.
     pub fn display_bounds(&self) -> Option<(u32, u32)> {
         self.capture.display_bounds()
     }
@@ -319,8 +321,9 @@ impl InputCapture {
     /// given the host's screen-space cursor position at the moment
     /// of crossing. Returns `None` when either the host's own
     /// `display_bounds` or the cached peer geometry is unavailable —
-    /// in that case the capture loop just doesn't send MotionAbsolute
-    /// and the guest falls back to its entry-edge-midpoint warp.
+    /// in that case there's no warp target to compute and the peer's
+    /// cursor stays wherever the most recent `CursorPos` (or, if none
+    /// arrived this session, where it was) put it.
     ///
     /// Coordinates returned are pixels in the peer's screen space:
     /// the cross-axis is preserved as a normalized fraction of the
@@ -373,10 +376,10 @@ impl InputCapture {
 
     /// Initial guest-space cursor position for a freshly-started
     /// capture. Mirrors what the guest's emulation will visibly do on
-    /// the corresponding `Enter`: a `MotionAbsolute` warp target if
-    /// the host can compute one (peer bounds known + capture backend
-    /// reports cursor), otherwise the entry-edge midpoint that
-    /// `entry_edge_for` produces on the guest side.
+    /// the corresponding `Enter`: the `CursorPos` proportional warp
+    /// target if the host can compute one (capture backend reports
+    /// cursor), otherwise the entry-edge midpoint as a fallback for
+    /// the wall-press model's starting position.
     fn initial_virtual_cursor(
         &self,
         pos: Position,

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -265,6 +265,24 @@ impl InputCapture {
         self.capture.release(warp_target).await
     }
 
+    /// Release without applying a host-side cursor warp. Used when
+    /// the remote peer is taking over (it just sent us Enter +
+    /// CursorPos): the proportional warp from CursorPos is the
+    /// authoritative final position for our shared cursor, and the
+    /// stale `virtual_cursor`-derived warp would race against it
+    /// and frequently win — clobbering the proportional landing
+    /// with whatever position Linux *thought* the peer's cursor was
+    /// at before the user moved it.
+    pub async fn release_no_host_warp(&mut self) -> Result<(), CaptureError> {
+        log::info!(
+            "[release-warp] handover release: capture_pos={:?} — skipping host warp, peer's CursorPos is authoritative",
+            self.capture_pos,
+        );
+        self.pressed_keys.clear();
+        self.reset_wall_press_state();
+        self.capture.release(None).await
+    }
+
     /// Configure the wall-press auto-release pixel threshold.
     /// 0 disables. Effective immediately for the next motion event;
     /// no need to recreate the backend.

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -422,9 +422,10 @@ impl InputCapture {
                 // back to the host. Clamped to the peer's bounds so
                 // the model doesn't drift past the guest's screen
                 // when the user pushes obliviously.
-                if let (Some(vc), Some(&(peer_w, peer_h))) =
-                    (self.virtual_cursor.as_mut(), self.peer_bounds.get(&active_pos))
-                {
+                if let (Some(vc), Some(&(peer_w, peer_h))) = (
+                    self.virtual_cursor.as_mut(),
+                    self.peer_bounds.get(&active_pos),
+                ) {
                     vc.0 = (vc.0 + *dx).clamp(0.0, peer_w as f64);
                     vc.1 = (vc.1 + *dy).clamp(0.0, peer_h as f64);
                 }

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -1,13 +1,17 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Display,
+    future::Future,
     mem::swap,
+    pin::Pin,
     task::{Poll, ready},
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_core::Stream;
+use tokio::time::Sleep;
 
 use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
 
@@ -192,6 +196,25 @@ pub struct InputCapture {
     /// pushing past the guest's actual far edge doesn't make the
     /// model run away. Only the entry-axis dimension is consulted.
     peer_bounds: HashMap<Position, (u32, u32)>,
+    /// Set when wall_pressure first crosses `release_threshold_px`,
+    /// cleared when the peer's handover Leave arrives (which routes
+    /// through `release_no_host_warp` → `reset_wall_press_state`) or
+    /// when the cursor moves back into the interior. The wall-press
+    /// auto-release fires only after `wall_press_deadline` elapses
+    /// without being cleared — turning the historically race-y
+    /// "wall-press vs peer-Leave" into an explicit fallback that
+    /// only kicks in when the peer can't deliver a Leave (lock
+    /// screen, restricted DE, dead peer).
+    wall_press_pending_at: Option<Instant>,
+    /// Window after the threshold is crossed during which a peer
+    /// Leave can cancel the deferred AutoRelease. Sized so a
+    /// healthy LAN round-trip beats it comfortably.
+    wall_press_deadline: Duration,
+    /// Timer driving the deferred fire. Reset to deadline-from-now
+    /// on first threshold crossing; polled in `poll_next` so the
+    /// fire happens even when no further backend events arrive
+    /// (the user pinned the cursor against the wall and stopped).
+    wall_press_timer: Pin<Box<Sleep>>,
 }
 
 /// Project a motion delta onto the entry axis. Positive return =
@@ -435,6 +458,9 @@ impl InputCapture {
         self.virtual_cursor = None;
         self.pending_begin_cursor = None;
         self.pending_motion = (0.0, 0.0);
+        // Cancel any deferred AutoRelease — release() / handover have
+        // taken responsibility for the transition.
+        self.wall_press_pending_at = None;
     }
 
     /// Initial guest-space cursor position for a freshly-started
@@ -508,10 +534,12 @@ impl InputCapture {
     }
 
     /// Update the wall-press accumulator from one event coming up
-    /// from the backend. Returns true if the threshold was reached
-    /// and an `AutoRelease` should be synthesized for the active
-    /// capture position.
-    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) -> bool {
+    /// from the backend. Sets `wall_press_pending_at` (and arms the
+    /// timer) when the threshold is first crossed; the actual
+    /// `AutoRelease` synthesis happens in `poll_next` once the
+    /// deadline elapses without a peer Leave clearing the pending
+    /// flag.
+    fn track_wall_press(&mut self, pos: Position, event: &CaptureEvent) {
         match event {
             CaptureEvent::Begin { cursor } => {
                 self.capture_pos = Some(pos);
@@ -528,20 +556,18 @@ impl InputCapture {
                     self.peer_bounds.get(&pos).copied(),
                     self.virtual_cursor,
                 );
-                false
             }
             CaptureEvent::AutoRelease => {
                 // Don't reset virtual_cursor here — release() needs it
                 // to compute the host-side warp target. The wrapper's
                 // release() resets state after consuming it.
-                false
             }
             CaptureEvent::Input(Event::Pointer(PointerEvent::Motion { dx, dy, .. })) => {
                 let Some(active_pos) = self.capture_pos else {
-                    return false;
+                    return;
                 };
                 if active_pos != pos {
-                    return false;
+                    return;
                 }
 
                 // Track guest-space cursor for the on-release warp
@@ -576,7 +602,7 @@ impl InputCapture {
                 }
 
                 if self.release_threshold_px == 0 {
-                    return false;
+                    return;
                 }
 
                 let delta = entry_axis_delta(active_pos, *dx, *dy);
@@ -604,20 +630,37 @@ impl InputCapture {
                     // by motion deeper into the guest doesn't combine
                     // with a later wall-press to fire spuriously.
                     self.wall_pressure = 0.0;
+                    if self.wall_press_pending_at.take().is_some() {
+                        log::info!(
+                            "wall-press deferred AutoRelease cancelled (cursor moved away from entry edge)"
+                        );
+                    }
                 }
 
-                if self.wall_pressure >= f64::from(self.release_threshold_px) {
+                if self.wall_pressure >= f64::from(self.release_threshold_px)
+                    && self.wall_press_pending_at.is_none()
+                {
+                    let now = Instant::now();
+                    self.wall_press_pending_at = Some(now);
+                    self.wall_press_timer
+                        .as_mut()
+                        .reset(tokio::time::Instant::from_std(
+                            now + self.wall_press_deadline,
+                        ));
                     log::info!(
-                        "auto-release: {:.0}px wall-press past entry edge ({}px threshold)",
+                        "wall-press threshold reached ({:.0}px past entry edge, {}px threshold) — \
+                         deferring AutoRelease for {}ms pending peer Leave",
                         self.wall_pressure,
-                        self.release_threshold_px
+                        self.release_threshold_px,
+                        self.wall_press_deadline.as_millis(),
                     );
-                    self.reset_wall_press_state();
-                    return true;
                 }
-                false
+                // Fire is now driven by the timer in `poll_next`, not
+                // directly from this event — keeps the behavior gated
+                // on "peer didn't claim handover in time" instead of
+                // racing the peer's Leave.
             }
-            _ => false,
+            _ => {}
         }
     }
 
@@ -656,6 +699,9 @@ impl InputCapture {
             pending_begin_cursor: None,
             pending_motion: (0.0, 0.0),
             peer_bounds: HashMap::new(),
+            wall_press_pending_at: None,
+            wall_press_deadline: Duration::from_millis(150),
+            wall_press_timer: Box::pin(tokio::time::sleep(Duration::from_secs(0))),
         })
     }
 
@@ -686,6 +732,35 @@ impl Stream for InputCapture {
             return Poll::Ready(Some(Ok(e)));
         }
 
+        // Deferred wall-press fallback. If the threshold was crossed
+        // and the deadline elapsed without a peer Leave clearing
+        // `wall_press_pending_at` (release_no_host_warp →
+        // reset_wall_press_state), synthesize AutoRelease for every
+        // capture handle at the active position. Polled before the
+        // backend so a fire still happens when the user pinned the
+        // cursor against the wall and stopped moving (no further
+        // backend events, but the deadline still has to elapse).
+        if self.wall_press_pending_at.is_some()
+            && self.wall_press_timer.as_mut().poll(cx).is_ready()
+        {
+            self.wall_press_pending_at = None;
+            log::info!(
+                "wall-press deadline elapsed ({}ms) — firing AutoRelease (no peer Leave; \
+                 assuming peer-side capture is unavailable, e.g. lock screen)",
+                self.wall_press_deadline.as_millis(),
+            );
+            if let Some(pos) = self.capture_pos {
+                if let Some(ids) = self.position_map.get(&pos).cloned() {
+                    for id in ids {
+                        self.pending.push_back((id, CaptureEvent::AutoRelease));
+                    }
+                }
+            }
+            if let Some(e) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(e)));
+            }
+        }
+
         // ready
         let event = ready!(self.capture.poll_next_unpin(cx));
 
@@ -708,8 +783,10 @@ impl Stream for InputCapture {
 
         // wall-press auto-release tracking. Runs against every event
         // before routing so a single global accumulator stays consistent
-        // regardless of how many handles exist at this position.
-        let auto_release = self.track_wall_press(pos, &event);
+        // regardless of how many handles exist at this position. The
+        // fire itself is deferred and driven by `wall_press_timer`
+        // above so the peer's Leave can cancel it.
+        self.track_wall_press(pos, &event);
 
         let len = self
             .position_map
@@ -721,12 +798,6 @@ impl Stream for InputCapture {
             0 => Poll::Pending,
             1 => {
                 let id = self.position_map.get(&pos).expect("no id")[0];
-                if auto_release {
-                    // Deliver the original motion first; queue the
-                    // synthesized AutoRelease so the next poll picks
-                    // it up.
-                    self.pending.push_back((id, CaptureEvent::AutoRelease));
-                }
                 Poll::Ready(Some(Ok((id, event))))
             }
             _ => {
@@ -735,9 +806,6 @@ impl Stream for InputCapture {
                 {
                     for &id in position_map.get(&pos).expect("position") {
                         self.pending.push_back((id, event));
-                        if auto_release {
-                            self.pending.push_back((id, CaptureEvent::AutoRelease));
-                        }
                     }
                 }
                 swap(&mut self.position_map, &mut position_map);

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -417,7 +417,10 @@ async fn do_capture_session(
                     current_pos.replace(Some(pos));
 
                     // client entered => send event
-                    event_tx.send((pos, CaptureEvent::Begin)).await.expect("no channel");
+                    event_tx
+                        .send((pos, CaptureEvent::Begin { cursor: None }))
+                        .await
+                        .expect("no channel");
 
                     tokio::select! {
                         _ = notify_release.notified() => { /* capture release */

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -592,7 +592,7 @@ impl LanMouseInputCapture for LibeiInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         self.notify_release.notify_waiters();
         Ok(())
     }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -840,6 +840,31 @@ impl Capture for MacOSInputCapture {
         }
         Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
     }
+
+    fn display_origin(&self) -> (i32, i32) {
+        // Top-left of the union of all active displays. Matters when
+        // a secondary monitor is positioned LEFT of (or ABOVE) the
+        // primary — the global pointer-coordinate system is anchored
+        // at the primary's top-left, so a left-attached external
+        // gives cursor x ∈ [-w, 0). Without this offset,
+        // host_normalized_cursor / peer_warp_target's clamp(0, 1)
+        // silently maps every point on the external to "left edge"
+        // and the receiver warps to the wrong column.
+        let Ok(displays) = CGDisplay::active_displays() else {
+            return (0, 0);
+        };
+        let mut xmin = f64::INFINITY;
+        let mut ymin = f64::INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            ymin = ymin.min(bounds.origin.y);
+        }
+        if xmin.is_infinite() || ymin.is_infinite() {
+            return (0, 0);
+        }
+        (xmin as i32, ymin as i32)
+    }
 }
 
 impl Stream for MacOSInputCapture {

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -519,10 +519,17 @@ fn create_event_tap<'a>(
             // Did we cross a barrier?
             if let Some(new_pos) = state.crossed(cg_ev) {
                 capture_position = Some(new_pos);
+                // Snapshot the cursor's screen-space position at the
+                // instant of crossing — before start_capture's
+                // reset_cursor() snaps it to the edge. The peer uses
+                // this for the visually-corresponding warp on Enter
+                // so the cursor doesn't jump to the entry-edge midpoint.
+                let cross_loc = cg_ev.location();
+                let cursor = Some((cross_loc.x as i32, cross_loc.y as i32));
                 state
                     .start_capture(cg_ev, new_pos)
                     .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin);
+                res_events.push(CaptureEvent::Begin { cursor });
                 notify_tx
                     .blocking_send(ProducerEvent::Grab(new_pos))
                     .expect("Failed to send notification");
@@ -783,6 +790,29 @@ impl Capture for MacOSInputCapture {
 
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
+    }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Mirror the InputEmulation-side implementation: the union of
+        // every active display's rectangle, in points (which match
+        // the units used by CGEvent.location() so the
+        // MotionAbsolute math stays internally consistent).
+        let displays = CGDisplay::active_displays().ok()?;
+        let mut xmin = f64::INFINITY;
+        let mut xmax = f64::NEG_INFINITY;
+        let mut ymin = f64::INFINITY;
+        let mut ymax = f64::NEG_INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            xmax = xmax.max(bounds.origin.x + bounds.size.width);
+            ymin = ymin.min(bounds.origin.y);
+            ymax = ymax.max(bounds.origin.y + bounds.size.height);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
     }
 }
 

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -9,7 +9,7 @@ use core_foundation::{
     string::{CFStringCreateWithCString, CFStringRef, kCFStringEncodingUTF8},
 };
 use core_graphics::{
-    base::{CGError, kCGErrorSuccess},
+    base::{CGError, CGFloat, kCGErrorSuccess},
     display::{CGDisplay, CGPoint},
     event::{
         CGEvent, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
@@ -809,9 +809,7 @@ impl Capture for MacOSInputCapture {
         let notify_tx = self.notify_tx.clone();
         tokio::task::spawn_local(async move {
             log::debug!("notifying Release");
-            let _ = notify_tx
-                .send(ProducerEvent::Release { warp_target })
-                .await;
+            let _ = notify_tx.send(ProducerEvent::Release { warp_target }).await;
         });
         Ok(())
     }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -62,7 +62,14 @@ struct InputCaptureState {
 
 #[derive(Debug)]
 enum ProducerEvent {
-    Release,
+    /// `warp_target`, when present, is a screen-space (Quartz) point
+    /// at which to warp the local cursor before showing it. Used to
+    /// preserve cross-axis continuity on release: the visible cursor
+    /// reappears at the host point matching where it visually was on
+    /// the guest, instead of snapping back to the capture-start edge.
+    Release {
+        warp_target: Option<(i32, i32)>,
+    },
     Create(Position),
     Destroy(Position),
     Grab(Position),
@@ -153,8 +160,26 @@ impl InputCaptureState {
     ) -> Result<(), CaptureError> {
         log::debug!("handling event: {producer_event:?}");
         match producer_event {
-            ProducerEvent::Release => {
+            ProducerEvent::Release { warp_target } => {
+                log::info!(
+                    "[release-warp] handle_producer_event Release: current_pos={:?} warp_target={warp_target:?}",
+                    self.current_pos
+                );
                 if self.current_pos.is_some() {
+                    // Warp BEFORE clearing current_pos so the
+                    // event-tap callback can't see Some(pos) and
+                    // re-snap the cursor to the entry edge before we
+                    // make it visible again. Then show_cursor() reveals
+                    // it at the warped point.
+                    if let Some((x, y)) = warp_target {
+                        log::info!("[release-warp] warping local cursor to ({x}, {y})");
+                        if let Err(e) = CGDisplay::warp_mouse_cursor_position(CGPoint {
+                            x: x as CGFloat,
+                            y: y as CGFloat,
+                        }) {
+                            log::warn!("[release-warp] warp_mouse_cursor_position failed: {e:?}");
+                        }
+                    }
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
@@ -779,11 +804,14 @@ impl Capture for MacOSInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
+        log::info!("[release-warp] macOS backend release(warp_target={warp_target:?})");
         let notify_tx = self.notify_tx.clone();
         tokio::task::spawn_local(async move {
             log::debug!("notifying Release");
-            let _ = notify_tx.send(ProducerEvent::Release).await;
+            let _ = notify_tx
+                .send(ProducerEvent::Release { warp_target })
+                .await;
         });
         Ok(())
     }

--- a/input-capture/src/windows.rs
+++ b/input-capture/src/windows.rs
@@ -29,7 +29,7 @@ impl Capture for WindowsInputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         self.event_thread.release_capture();
         Ok(())
     }

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -221,12 +221,10 @@ fn start_routine(
         .expect("CreateWindowExW");
     }
 
-    /* run message loop */
-    loop {
-        // mouse / keybrd proc do not actually return a message
-        let Some(msg) = get_msg() else {
-            break;
-        };
+    /* run message loop. mouse / keybrd procs don't actually return
+     * a message, so `get_msg() == None` ends the loop; an Exit-typed
+     * thread message breaks out from inside the body. */
+    while let Some(msg) = get_msg() {
         if msg.hwnd.0.is_null() {
             /* messages sent via PostThreadMessage */
             match msg.wParam.0 {

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -300,7 +300,7 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
     let active = ACTIVE_CLIENT.get().expect("active client");
-    blocking_send_event(active, CaptureEvent::Begin);
+    blocking_send_event(active, CaptureEvent::Begin { cursor: None });
 
     ret
 }

--- a/input-capture/src/x11.rs
+++ b/input-capture/src/x11.rs
@@ -23,7 +23,7 @@ impl Capture for X11InputCapture {
         Ok(())
     }
 
-    async fn release(&mut self) -> Result<(), CaptureError> {
+    async fn release(&mut self, _warp_target: Option<(i32, i32)>) -> Result<(), CaptureError> {
         Ok(())
     }
 

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -178,6 +178,19 @@ impl InputEmulation {
         self.emulation.terminate().await
     }
 
+    /// Display geometry of this device (union of all active
+    /// displays), if the backend can report it. See
+    /// `Emulation::display_bounds`.
+    pub fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.emulation.display_bounds()
+    }
+
+    /// Warp the local cursor to the given absolute position. See
+    /// `Emulation::warp_cursor`.
+    pub async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        self.emulation.warp_cursor(x, y).await
+    }
+
     pub async fn release_keys(&mut self, handle: EmulationHandle) -> Result<(), EmulationError> {
         if let Some(keys) = self.pressed_keys.get_mut(&handle) {
             let keys = keys.drain().collect::<Vec<_>>();
@@ -237,4 +250,27 @@ trait Emulation: Send {
     async fn create(&mut self, handle: EmulationHandle);
     async fn destroy(&mut self, handle: EmulationHandle);
     async fn terminate(&mut self);
+
+    /// Geometry (width, height) of the union of this device's
+    /// active displays in pixels. Used by the protocol-level
+    /// `Bounds` event so a capturing peer can model the guest
+    /// cursor's position. Backends that can't report geometry
+    /// should leave the default `None` and the wall-press
+    /// auto-release fallback will degrade to "no upper clamp"
+    /// behavior on the host.
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    /// Warp the cursor to an absolute position on the receiving
+    /// device's primary display, if the backend supports absolute
+    /// positioning. Called when an `Enter` event arrives so the
+    /// guest cursor lands at the entry edge instead of staying
+    /// wherever the previous capture session left it. Backends
+    /// without absolute positioning can leave the default no-op
+    /// — the wall-press auto-release will be inaccurate but the
+    /// connection still works.
+    async fn warp_cursor(&mut self, _x: i32, _y: i32) -> Result<(), EmulationError> {
+        Ok(())
+    }
 }

--- a/input-emulation/src/libei.rs
+++ b/input-emulation/src/libei.rs
@@ -19,8 +19,8 @@ use async_trait::async_trait;
 
 use reis::{
     ei::{
-        self, Button, Keyboard, Pointer, Scroll, button::ButtonState, handshake::ContextType,
-        keyboard::KeyState,
+        self, Button, Keyboard, Pointer, PointerAbsolute, Scroll, button::ButtonState,
+        handshake::ContextType, keyboard::KeyState,
     },
     event::{self, Connection, DeviceCapability, DeviceEvent, EiEvent, SeatEvent},
     tokio::EiConvertEventStream,
@@ -35,6 +35,7 @@ use super::{Emulation, EmulationHandle, error::LibeiEmulationCreationError};
 #[derive(Clone, Default)]
 struct Devices {
     pointer: Arc<RwLock<Option<(ei::Device, ei::Pointer)>>>,
+    pointer_abs: Arc<RwLock<Option<(ei::Device, ei::PointerAbsolute)>>>,
     scroll: Arc<RwLock<Option<(ei::Device, ei::Scroll)>>>,
     button: Arc<RwLock<Option<(ei::Device, ei::Button)>>>,
     keyboard: Arc<RwLock<Option<(ei::Device, ei::Keyboard)>>>,
@@ -261,6 +262,37 @@ impl Emulation for LibeiEmulation {
         let _ = self.session.close().await;
         self.ei_task.abort();
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // TODO: derive from ei::Region events on the
+        // PointerAbsolute device, or query wl_output via a side
+        // wayland-client connection. For now we return None and
+        // the host falls back to the no-upper-clamp heuristic.
+        None
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64;
+        let pointer_abs = self.devices.pointer_abs.read().unwrap();
+        if let Some((device, pointer_abs)) = pointer_abs.as_ref() {
+            pointer_abs.motion_absolute(x as f32, y as f32);
+            device.frame(self.conn.serial(), now);
+            self.context
+                .flush()
+                .map_err(|e| io::Error::new(e.kind(), e))?;
+        } else {
+            // Compositor didn't grant a PointerAbsolute device.
+            // Nothing we can do to warp the cursor; the host's
+            // wall-press model will be off by however far the
+            // user pushed forward in the prior session, but
+            // operation continues.
+            log::debug!("warp_cursor: no PointerAbsolute device available, skipping");
+        }
+        Ok(())
+    }
 }
 
 async fn ei_task(
@@ -322,6 +354,13 @@ async fn ei_event_handler(
                         .write()
                         .unwrap()
                         .replace((device.device().clone(), pointer));
+                }
+                if let Some(pointer_abs) = e.device().interface::<PointerAbsolute>() {
+                    devices
+                        .pointer_abs
+                        .write()
+                        .unwrap()
+                        .replace((device.device().clone(), pointer_abs));
                 }
                 if let Some(keyboard) = e.device().interface::<Keyboard>() {
                     devices

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bitflags::bitflags;
 use core_graphics::base::CGFloat;
 use core_graphics::display::{
-    CGDirectDisplayID, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
+    CGDirectDisplayID, CGDisplay, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
 };
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGKeyCode, CGMouseButton, EventField,
@@ -489,6 +489,39 @@ impl Emulation for MacOSEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Union of every active display's rectangle. Matches the
+        // shape used on the input-capture side so the host's
+        // wall-press model is consistent across both ends.
+        let displays = CGDisplay::active_displays().ok()?;
+        let mut xmin = f64::INFINITY;
+        let mut xmax = f64::NEG_INFINITY;
+        let mut ymin = f64::INFINITY;
+        let mut ymax = f64::NEG_INFINITY;
+        for id in displays {
+            let bounds = CGDisplay::new(id).bounds();
+            xmin = xmin.min(bounds.origin.x);
+            xmax = xmax.max(bounds.origin.x + bounds.size.width);
+            ymin = ymin.min(bounds.origin.y);
+            ymax = ymax.max(bounds.origin.y + bounds.size.height);
+        }
+        if xmax <= xmin || ymax <= ymin {
+            return None;
+        }
+        Some(((xmax - xmin) as u32, (ymax - ymin) as u32))
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let pt = CGPoint {
+            x: x as CGFloat,
+            y: y as CGFloat,
+        };
+        // CGDisplay::warp_mouse_cursor_position is a global Quartz
+        // call; it doesn't matter which CGDisplay receiver we use.
+        let _ = CGDisplay::warp_mouse_cursor_position(pt);
+        Ok(())
+    }
 }
 
 fn update_modifiers(modifiers: &Cell<XMods>, key: u32, state: u8) -> bool {

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -17,7 +17,9 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT_0, KEYEVENTF_EXTENDEDKEY, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, SendInput,
 };
-use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SetCursorPos, XBUTTON1, XBUTTON2,
+};
 
 use super::{Emulation, EmulationHandle};
 
@@ -80,6 +82,27 @@ impl Emulation for WindowsEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        // Virtual-screen metrics cover the union of every monitor
+        // attached to the system, matching the host-side capture
+        // model that uses the union of all displays.
+        unsafe {
+            let w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            let h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            if w <= 0 || h <= 0 {
+                return None;
+            }
+            Some((w as u32, h as u32))
+        }
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        unsafe {
+            let _ = SetCursorPos(x, y);
+        }
+        Ok(())
+    }
 }
 
 impl WindowsEmulation {

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -12,6 +12,7 @@ use wayland_client::WEnum;
 use wayland_client::backend::WaylandError;
 
 use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
+use wayland_client::protocol::wl_output::{self, WlOutput};
 use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
@@ -42,6 +43,25 @@ struct State {
     qh: QueueHandle<Self>,
     vpm: VpManager,
     vkm: VkManager,
+    /// All wl_outputs the compositor advertises, keyed by their
+    /// proxy id. Updated via Geometry/Mode events. We keep the
+    /// `WlOutput` proxy alive in the value so events keep flowing.
+    outputs: HashMap<u32, (WlOutput, OutputInfo)>,
+    /// Dedicated virtual pointer used only for absolute-position
+    /// warps on `Enter`. Separate from per-handle pointers so warp
+    /// works regardless of which client is active.
+    warp_pointer: Vp,
+}
+
+#[derive(Default, Clone, Copy)]
+struct OutputInfo {
+    /// Position in the compositor's global coordinate space, from
+    /// wl_output::Event::Geometry.
+    x: i32,
+    y: i32,
+    /// Pixel dimensions of the active mode, from wl_output::Event::Mode.
+    width: i32,
+    height: i32,
 }
 
 // App State, implements Dispatch event handlers
@@ -68,6 +88,26 @@ impl WlrootsEmulation {
             .bind(&qh, 1..=1, ())
             .map_err(|e| WaylandBindError::new(e, "virtual-keyboard-unstable-v1"))?;
 
+        // Bind every advertised wl_output so we receive Geometry +
+        // Mode events for each one. Used to compute display_bounds.
+        let mut outputs: HashMap<u32, (WlOutput, OutputInfo)> = HashMap::new();
+        for global in globals.contents().clone_list() {
+            if global.interface == "wl_output" {
+                // version 2 is enough for Geometry + Mode events.
+                let output: WlOutput =
+                    globals
+                        .registry()
+                        .bind(global.name, global.version.min(2), &qh, ());
+                let id = output.id().protocol_id();
+                outputs.insert(id, (output, OutputInfo::default()));
+            }
+        }
+
+        // Dedicated warp pointer — used only for motion_absolute on
+        // Enter, so warp works even when no per-handle virtual
+        // pointer is currently active.
+        let warp_pointer: Vp = vpm.create_virtual_pointer(None, &qh, ());
+
         let input_for_client: HashMap<EmulationHandle, VirtualInput> = HashMap::new();
 
         let mut emulate = WlrootsEmulation {
@@ -79,6 +119,8 @@ impl WlrootsEmulation {
                 vpm,
                 vkm,
                 qh,
+                outputs,
+                warp_pointer,
             },
             queue,
         };
@@ -118,6 +160,33 @@ impl State {
             input.pointer.destroy();
             input.keyboard.destroy();
         }
+    }
+
+    /// Bounding rectangle of every active wl_output's logical
+    /// position + active mode. Returns None if no output has
+    /// reported both Geometry and Mode yet.
+    fn union_bounds(&self) -> Option<(u32, u32)> {
+        let mut xmin = i32::MAX;
+        let mut ymin = i32::MAX;
+        let mut xmax = i32::MIN;
+        let mut ymax = i32::MIN;
+        let mut any = false;
+        for (_, o) in self.outputs.values() {
+            if o.width <= 0 || o.height <= 0 {
+                continue;
+            }
+            any = true;
+            xmin = xmin.min(o.x);
+            ymin = ymin.min(o.y);
+            xmax = xmax.max(o.x + o.width);
+            ymax = ymax.max(o.y + o.height);
+        }
+        if !any {
+            return None;
+        }
+        let w = (xmax - xmin) as u32;
+        let h = (ymax - ymin) as u32;
+        Some((w, h))
     }
 }
 
@@ -172,7 +241,31 @@ impl Emulation for WlrootsEmulation {
         }
     }
     async fn terminate(&mut self) {
-        /* nothing to do */
+        self.state.warp_pointer.destroy();
+    }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.state.union_bounds()
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        let Some((width, height)) = self.state.union_bounds() else {
+            return Ok(());
+        };
+        let now: u32 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u32;
+        let cx = x.clamp(0, width as i32) as u32;
+        let cy = y.clamp(0, height as i32) as u32;
+        self.state
+            .warp_pointer
+            .motion_absolute(now, cx, cy, width, height);
+        self.state.warp_pointer.frame();
+        if let Err(e) = self.queue.flush() {
+            log::warn!("warp_cursor flush failed: {e}");
+        }
+        Ok(())
     }
 }
 
@@ -278,6 +371,38 @@ impl Dispatch<WlKeyboard, ()> for State {
     ) {
         if let wl_keyboard::Event::Keymap { format, fd, size } = event {
             state.keymap = Some((u32::from(format), fd, size));
+        }
+    }
+}
+
+impl Dispatch<WlOutput, ()> for State {
+    fn event(
+        state: &mut Self,
+        output: &WlOutput,
+        event: <WlOutput as wayland_client::Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let id = output.id().protocol_id();
+        let Some((_, info)) = state.outputs.get_mut(&id) else {
+            return;
+        };
+        match event {
+            wl_output::Event::Geometry { x, y, .. } => {
+                info.x = x;
+                info.y = y;
+            }
+            wl_output::Event::Mode {
+                flags: WEnum::Value(flags),
+                width,
+                height,
+                ..
+            } if flags.contains(wl_output::Mode::Current) => {
+                info.width = width;
+                info.height = height;
+            }
+            _ => {}
         }
     }
 }

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -26,7 +26,7 @@ use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
 };
 
 use wayland_client::{
-    Connection, Dispatch, EventQueue, QueueHandle, delegate_noop,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
     globals::{GlobalListContents, registry_queue_init},
     protocol::{wl_registry, wl_seat},
 };

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -15,6 +15,10 @@ use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
 use wayland_client::protocol::wl_output::{self, WlOutput};
 use wayland_client::protocol::wl_pointer::{Axis, AxisSource, ButtonState};
 use wayland_client::protocol::wl_seat::WlSeat;
+use wayland_protocols::xdg::xdg_output::zv1::client::{
+    zxdg_output_manager_v1::ZxdgOutputManagerV1,
+    zxdg_output_v1::{self, ZxdgOutputV1},
+};
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
     zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1 as VpManager,
     zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1 as Vp,
@@ -46,7 +50,7 @@ struct State {
     /// All wl_outputs the compositor advertises, keyed by their
     /// proxy id. Updated via Geometry/Mode events. We keep the
     /// `WlOutput` proxy alive in the value so events keep flowing.
-    outputs: HashMap<u32, (WlOutput, OutputInfo)>,
+    outputs: HashMap<u32, (WlOutput, OutputInfo, Option<ZxdgOutputV1>)>,
     /// Dedicated virtual pointer used only for absolute-position
     /// warps on `Enter`. Separate from per-handle pointers so warp
     /// works regardless of which client is active.
@@ -56,12 +60,25 @@ struct State {
 #[derive(Default, Clone, Copy)]
 struct OutputInfo {
     /// Position in the compositor's global coordinate space, from
-    /// wl_output::Event::Geometry.
+    /// wl_output::Event::Geometry. Raw-pixel coordinates.
     x: i32,
     y: i32,
     /// Pixel dimensions of the active mode, from wl_output::Event::Mode.
     width: i32,
     height: i32,
+    /// Logical position in the compositor's coordinate space, from
+    /// zxdg_output_v1::Event::LogicalPosition. Reflects software
+    /// scaling (e.g. fractional or HiDPI). Falls back to (x, y) when
+    /// xdg-output isn't available.
+    logical_x: Option<i32>,
+    logical_y: Option<i32>,
+    /// Logical dimensions, from zxdg_output_v1::Event::LogicalSize.
+    /// This is the coordinate space the compositor uses for cursor
+    /// positions and the same one the capture side uses, so we
+    /// prefer it for `display_bounds()` to keep both sides in sync.
+    /// Falls back to (width, height) when xdg-output isn't available.
+    logical_width: Option<i32>,
+    logical_height: Option<i32>,
 }
 
 // App State, implements Dispatch event handlers
@@ -87,10 +104,20 @@ impl WlrootsEmulation {
         let vkm: VkManager = globals
             .bind(&qh, 1..=1, ())
             .map_err(|e| WaylandBindError::new(e, "virtual-keyboard-unstable-v1"))?;
+        // xdg-output gives us LogicalSize/LogicalPosition — the
+        // coordinate space the compositor actually uses (with
+        // software/fractional scaling applied). The capture side
+        // already reports bounds in this space, so emulation needs
+        // it too or warps land on different proportions than the
+        // sender computed. Optional: if the compositor doesn't
+        // advertise xdg_output_manager we fall back to wl_output's
+        // raw mode dimensions.
+        let xdg_output_manager: Option<ZxdgOutputManagerV1> = globals.bind(&qh, 1..=3, ()).ok();
 
         // Bind every advertised wl_output so we receive Geometry +
         // Mode events for each one. Used to compute display_bounds.
-        let mut outputs: HashMap<u32, (WlOutput, OutputInfo)> = HashMap::new();
+        let mut outputs: HashMap<u32, (WlOutput, OutputInfo, Option<ZxdgOutputV1>)> =
+            HashMap::new();
         for global in globals.contents().clone_list() {
             if global.interface == "wl_output" {
                 // version 2 is enough for Geometry + Mode events.
@@ -99,7 +126,10 @@ impl WlrootsEmulation {
                         .registry()
                         .bind(global.name, global.version.min(2), &qh, ());
                 let id = output.id().protocol_id();
-                outputs.insert(id, (output, OutputInfo::default()));
+                let xdg_output = xdg_output_manager
+                    .as_ref()
+                    .map(|mgr| mgr.get_xdg_output(&output, &qh, id));
+                outputs.insert(id, (output, OutputInfo::default(), xdg_output));
             }
         }
 
@@ -162,24 +192,30 @@ impl State {
         }
     }
 
-    /// Bounding rectangle of every active wl_output's logical
-    /// position + active mode. Returns None if no output has
-    /// reported both Geometry and Mode yet.
+    /// Bounding rectangle of every active wl_output in the
+    /// compositor's logical coordinate space (with software /
+    /// fractional scaling applied). Falls back per-output to raw
+    /// mode dimensions when xdg-output is unavailable. Returns
+    /// None if no output has reported usable size info yet.
     fn union_bounds(&self) -> Option<(u32, u32)> {
         let mut xmin = i32::MAX;
         let mut ymin = i32::MAX;
         let mut xmax = i32::MIN;
         let mut ymax = i32::MIN;
         let mut any = false;
-        for (_, o) in self.outputs.values() {
-            if o.width <= 0 || o.height <= 0 {
+        for (_, o, _) in self.outputs.values() {
+            let w = o.logical_width.unwrap_or(o.width);
+            let h = o.logical_height.unwrap_or(o.height);
+            if w <= 0 || h <= 0 {
                 continue;
             }
+            let ox = o.logical_x.unwrap_or(o.x);
+            let oy = o.logical_y.unwrap_or(o.y);
             any = true;
-            xmin = xmin.min(o.x);
-            ymin = ymin.min(o.y);
-            xmax = xmax.max(o.x + o.width);
-            ymax = ymax.max(o.y + o.height);
+            xmin = xmin.min(ox);
+            ymin = ymin.min(oy);
+            xmax = xmax.max(ox + w);
+            ymax = ymax.max(oy + h);
         }
         if !any {
             return None;
@@ -347,6 +383,33 @@ delegate_noop!(State: Vp);
 delegate_noop!(State: Vk);
 delegate_noop!(State: VpManager);
 delegate_noop!(State: VkManager);
+delegate_noop!(State: ZxdgOutputManagerV1);
+
+impl Dispatch<ZxdgOutputV1, u32> for State {
+    fn event(
+        state: &mut Self,
+        _: &ZxdgOutputV1,
+        event: <ZxdgOutputV1 as wayland_client::Proxy>::Event,
+        id: &u32,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some((_, info, _)) = state.outputs.get_mut(id) else {
+            return;
+        };
+        match event {
+            zxdg_output_v1::Event::LogicalPosition { x, y } => {
+                info.logical_x = Some(x);
+                info.logical_y = Some(y);
+            }
+            zxdg_output_v1::Event::LogicalSize { width, height } => {
+                info.logical_width = Some(width);
+                info.logical_height = Some(height);
+            }
+            _ => {}
+        }
+    }
+}
 
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
     fn event(
@@ -385,7 +448,7 @@ impl Dispatch<WlOutput, ()> for State {
         _: &QueueHandle<Self>,
     ) {
         let id = output.id().protocol_id();
-        let Some((_, info)) = state.outputs.get_mut(&id) else {
+        let Some((_, info, _)) = state.outputs.get_mut(&id) else {
             return;
         };
         match event {

--- a/input-emulation/src/x11.rs
+++ b/input-emulation/src/x11.rs
@@ -151,4 +151,31 @@ impl Emulation for X11Emulation {
     async fn terminate(&mut self) {
         /* nothing to do */
     }
+
+    fn display_bounds(&self) -> Option<(u32, u32)> {
+        unsafe {
+            // DisplayWidth/DisplayHeight on the default screen
+            // returns the union extent of the X server's logical
+            // screen across all monitors (Xinerama / RandR).
+            let screen = xlib::XDefaultScreen(self.display);
+            let w = xlib::XDisplayWidth(self.display, screen);
+            let h = xlib::XDisplayHeight(self.display, screen);
+            if w <= 0 || h <= 0 {
+                return None;
+            }
+            Some((w as u32, h as u32))
+        }
+    }
+
+    async fn warp_cursor(&mut self, x: i32, y: i32) -> Result<(), EmulationError> {
+        unsafe {
+            let root = xlib::XDefaultRootWindow(self.display);
+            // XWarpPointer with src_w = 0 means "no source window",
+            // so the cursor moves to (x, y) relative to dest_w
+            // (the root window) regardless of where it currently is.
+            xlib::XWarpPointer(self.display, 0, root, 0, 0, 0, 0, x, y);
+            xlib::XFlush(self.display);
+        }
+        Ok(())
+    }
 }

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -200,6 +200,58 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
+                        <property name="title" translatable="yes">Auto-release</property>
+                        <property name="description" translatable="yes">Auto-release capture when the cursor reaches the host-adjacent edge of the guest and you keep pushing. 0 disables; rely on the release-bind chord or a peer-side leave event.</property>
+                        <child>
+                          <object class="AdwActionRow" id="release_threshold_row">
+                            <property name="title" translatable="yes">Release threshold</property>
+                            <property name="subtitle" translatable="yes">pixels of wall-press past the entry edge before auto-release fires</property>
+                            <child type="suffix">
+                              <object class="GtkLabel" id="release_threshold_value">
+                                <property name="label">disabled</property>
+                                <property name="valign">center</property>
+                                <property name="width-chars">8</property>
+                                <property name="xalign">1.0</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                  <class name="numeric"/>
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="release_threshold_scale">
+                            <property name="orientation">horizontal</property>
+                            <property name="hexpand">true</property>
+                            <property name="draw-value">false</property>
+                            <property name="round-digits">0</property>
+                            <property name="margin-start">12</property>
+                            <property name="margin-end">12</property>
+                            <property name="margin-top">4</property>
+                            <property name="margin-bottom">8</property>
+                            <property name="adjustment">
+                              <object class="GtkAdjustment" id="release_threshold_adjustment">
+                                <property name="lower">0</property>
+                                <property name="upper">500</property>
+                                <property name="step-increment">10</property>
+                                <property name="page-increment">50</property>
+                                <property name="value">0</property>
+                              </object>
+                            </property>
+                            <marks>
+                              <mark value="0" position="bottom">off</mark>
+                              <mark value="50" position="bottom">50</mark>
+                              <mark value="100" position="bottom">100</mark>
+                              <mark value="200" position="bottom">200</mark>
+                              <mark value="500" position="bottom">500</mark>
+                            </marks>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Connections</property>
                         <property name="header-suffix">
                           <object class="GtkButton">

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -200,8 +200,8 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
-                        <property name="title" translatable="yes">Auto-release</property>
-                        <property name="description" translatable="yes">Auto-release capture when the cursor reaches the host-adjacent edge of the guest and you keep pushing. 0 disables; rely on the release-bind chord or a peer-side leave event.</property>
+                        <property name="title" translatable="yes">Outgoing Auto-Release</property>
+                        <property name="description" translatable="yes">When this machine is capturing input for a peer, releases capture automatically once the cursor pushes past the host-adjacent edge. With the slider off, release still happens via the bind chord or a peer-side leave event. Useful when crossing one or more lock screens between machines.</property>
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release threshold</property>

--- a/lan-mouse-gtk/resources/window.ui
+++ b/lan-mouse-gtk/resources/window.ui
@@ -201,7 +201,7 @@
                     <child>
                       <object class="AdwPreferencesGroup">
                         <property name="title" translatable="yes">Outgoing Auto-Release</property>
-                        <property name="description" translatable="yes">When this machine is capturing input for a peer, releases capture automatically once the cursor pushes past the host-adjacent edge. With the slider off, release still happens via the bind chord or a peer-side leave event. Useful when crossing one or more lock screens between machines.</property>
+                        <property name="description" translatable="yes">Fallback release when the peer can't tell us the cursor reached its edge — typically because the peer's screen is locked. No effect on peers that release themselves; the cursor-release keybind still works either way.</property>
                         <child>
                           <object class="AdwActionRow" id="release_threshold_row">
                             <property name="title" translatable="yes">Release threshold</property>

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -269,6 +269,9 @@ fn build_ui(app: &Application) {
                     FrontendEvent::IncomingDisconnected(addr) => {
                         window.show_toast(format!("{addr} disconnected").as_str());
                     }
+                    FrontendEvent::ReleaseThreshold(threshold) => {
+                        window.set_release_threshold(threshold);
+                    }
                 }
             }
         }

--- a/lan-mouse-gtk/src/window.rs
+++ b/lan-mouse-gtk/src/window.rs
@@ -407,6 +407,10 @@ impl Window {
         self.request(FrontendRequest::Create);
     }
 
+    pub(super) fn request_release_threshold(&self, threshold: u32) {
+        self.request(FrontendRequest::SetReleaseThreshold(threshold));
+    }
+
     fn open_fingerprint_dialog(&self, fp: Option<String>) {
         let window = FingerprintWindow::new(fp);
         window.set_transient_for(Some(self));
@@ -459,6 +463,28 @@ impl Window {
     pub(super) fn set_emulation(&self, active: bool) {
         self.imp().emulation_active.replace(active);
         self.update_capture_emulation_status();
+    }
+
+    pub(super) fn set_release_threshold(&self, threshold: u32) {
+        let imp = self.imp();
+        // Block the value-changed handler so programmatically setting
+        // the slider value (e.g. on Sync from the daemon) doesn't
+        // ricochet back as a SetReleaseThreshold request.
+        let scale = &imp.release_threshold_scale;
+        let handler_id = imp.release_threshold_handler.borrow();
+        if let Some(id) = handler_id.as_ref() {
+            scale.block_signal(id);
+        }
+        scale.set_value(threshold as f64);
+        if let Some(id) = handler_id.as_ref() {
+            scale.unblock_signal(id);
+        }
+        let label = if threshold == 0 {
+            "disabled".to_string()
+        } else {
+            format!("{threshold} px")
+        };
+        imp.release_threshold_value.set_label(&label);
     }
 
     #[cfg(target_os = "macos")]

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -4,7 +4,7 @@ use adw::subclass::prelude::*;
 use adw::{ActionRow, PreferencesGroup, ToastOverlay, prelude::*};
 use glib::subclass::InitializingObject;
 use gtk::glib::clone;
-use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, gdk, gio, glib};
+use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, Scale, gdk, gio, glib};
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
 
@@ -45,6 +45,12 @@ pub struct Window {
     pub input_capture_button: TemplateChild<Button>,
     #[template_child]
     pub authorized_list: TemplateChild<ListBox>,
+    #[template_child]
+    pub release_threshold_row: TemplateChild<ActionRow>,
+    #[template_child]
+    pub release_threshold_scale: TemplateChild<Scale>,
+    #[template_child]
+    pub release_threshold_value: TemplateChild<Label>,
     pub clients: RefCell<Option<gio::ListStore>>,
     pub authorized: RefCell<Option<gio::ListStore>>,
     pub frontend_request_writer: RefCell<Option<FrontendRequestWriter>>,
@@ -52,6 +58,10 @@ pub struct Window {
     pub capture_active: Cell<bool>,
     pub emulation_active: Cell<bool>,
     pub authorization_window: RefCell<Option<AuthorizationWindow>>,
+    /// Connected handler for the auto-release-threshold scale's
+    /// value-changed signal, so we can block it when programmatically
+    /// updating the slider in response to a Sync event.
+    pub release_threshold_handler: RefCell<Option<glib::SignalHandlerId>>,
 }
 
 #[glib::object_subclass]
@@ -200,6 +210,26 @@ impl ObjectImpl for Window {
         obj.setup_icon();
         obj.setup_clients();
         obj.setup_authorized();
+
+        // Connect the auto-release threshold slider. Stash the handler
+        // id so set_release_threshold() can block the signal when the
+        // daemon-driven Sync sets the value programmatically.
+        let scale = self.release_threshold_scale.clone();
+        let handler_id = scale.connect_value_changed(clone!(
+            #[weak(rename_to = window)]
+            obj,
+            move |scale| {
+                let value = scale.value().round() as u32;
+                let label = if value == 0 {
+                    "disabled".to_string()
+                } else {
+                    format!("{value} px")
+                };
+                window.imp().release_threshold_value.set_label(&label);
+                window.request_release_threshold(value);
+            }
+        ));
+        self.release_threshold_handler.replace(Some(handler_id));
     }
 }
 

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -6,7 +6,7 @@ use glib::subclass::InitializingObject;
 use gtk::glib::clone;
 use gtk::{
     Button, CompositeTemplate, Entry, EventControllerScroll, EventControllerScrollFlags, Image,
-    Label, ListBox, PropagationPhase, Scale, gdk, gio, glib,
+    Label, ListBox, PropagationPhase, Scale, ScrolledWindow, gdk, gio, glib,
 };
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
@@ -234,20 +234,48 @@ impl ObjectImpl for Window {
         ));
         self.release_threshold_handler.replace(Some(handler_id));
 
-        // Eat scroll-wheel events on the threshold slider. By default
-        // GtkScale treats vertical scroll as increment / decrement,
-        // which makes the threshold drift any time the user scrolls
-        // the window and the cursor passes over the slider. We
-        // intercept in the capture phase and return Stop so the scale's
-        // own controller never sees the event. Side effect: scrolling
-        // doesn't pass through to the parent ScrolledWindow while the
-        // cursor is on the slider — to scroll, move the cursor off it.
-        let scroll_block = EventControllerScroll::new(
+        // Pass scroll-wheel events on the threshold slider through to
+        // the ancestor ScrolledWindow instead of letting GtkScale's
+        // default handler treat them as increment / decrement (which
+        // would drift the threshold any time the user scrolls past
+        // the slider). Returning `Stop` from a capture-phase handler
+        // suppresses the scale's own scroll-to-adjust handler, but
+        // also stops propagation to the parent — so we additionally
+        // bump the parent ScrolledWindow's vadjustment by hand to
+        // mimic native scroll-passthrough.
+        let scroll_forward = EventControllerScroll::new(
             EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::HORIZONTAL,
         );
-        scroll_block.set_propagation_phase(PropagationPhase::Capture);
-        scroll_block.connect_scroll(|_, _, _| glib::Propagation::Stop);
-        self.release_threshold_scale.add_controller(scroll_block);
+        scroll_forward.set_propagation_phase(PropagationPhase::Capture);
+        scroll_forward.connect_scroll(clone!(
+            #[weak(rename_to = scale)]
+            self.release_threshold_scale,
+            #[upgrade_or]
+            glib::Propagation::Stop,
+            move |_, _dx, dy| {
+                let mut walker = scale.parent();
+                while let Some(w) = walker {
+                    if let Some(scrolled) = w.downcast_ref::<ScrolledWindow>() {
+                        let vadj = scrolled.vadjustment();
+                        // step_increment is the "wheel tick" unit; if
+                        // unset (rare), fall back to a sensible
+                        // pixel default so a single tick still moves.
+                        let step = if vadj.step_increment() > 0.0 {
+                            vadj.step_increment()
+                        } else {
+                            40.0
+                        };
+                        let target = (vadj.value() + dy * step)
+                            .clamp(vadj.lower(), vadj.upper() - vadj.page_size());
+                        vadj.set_value(target);
+                        break;
+                    }
+                    walker = w.parent();
+                }
+                glib::Propagation::Stop
+            }
+        ));
+        self.release_threshold_scale.add_controller(scroll_forward);
     }
 }
 

--- a/lan-mouse-gtk/src/window/imp.rs
+++ b/lan-mouse-gtk/src/window/imp.rs
@@ -4,7 +4,10 @@ use adw::subclass::prelude::*;
 use adw::{ActionRow, PreferencesGroup, ToastOverlay, prelude::*};
 use glib::subclass::InitializingObject;
 use gtk::glib::clone;
-use gtk::{Button, CompositeTemplate, Entry, Image, Label, ListBox, Scale, gdk, gio, glib};
+use gtk::{
+    Button, CompositeTemplate, Entry, EventControllerScroll, EventControllerScrollFlags, Image,
+    Label, ListBox, PropagationPhase, Scale, gdk, gio, glib,
+};
 
 use lan_mouse_ipc::{DEFAULT_PORT, FrontendRequestWriter};
 
@@ -230,6 +233,21 @@ impl ObjectImpl for Window {
             }
         ));
         self.release_threshold_handler.replace(Some(handler_id));
+
+        // Eat scroll-wheel events on the threshold slider. By default
+        // GtkScale treats vertical scroll as increment / decrement,
+        // which makes the threshold drift any time the user scrolls
+        // the window and the cursor passes over the slider. We
+        // intercept in the capture phase and return Stop so the scale's
+        // own controller never sees the event. Side effect: scrolling
+        // doesn't pass through to the parent ScrolledWindow while the
+        // cursor is on the slider — to scroll, move the cursor off it.
+        let scroll_block = EventControllerScroll::new(
+            EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::HORIZONTAL,
+        );
+        scroll_block.set_propagation_phase(PropagationPhase::Capture);
+        scroll_block.connect_scroll(|_, _, _| glib::Propagation::Stop);
+        self.release_threshold_scale.add_controller(scroll_block);
     }
 }
 

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -217,6 +217,9 @@ pub enum FrontendEvent {
     IncomingDisconnected(SocketAddr),
     /// failed connection attempt (approval for fingerprint required)
     ConnectionAttempt { fingerprint: String },
+    /// pixel threshold for the wall-press auto-release fallback.
+    /// 0 means disabled.
+    ReleaseThreshold(u32),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -255,6 +258,8 @@ pub enum FrontendRequest {
     UpdateEnterHook(u64, Option<String>),
     /// save config file
     SaveConfiguration,
+    /// set the wall-press auto-release pixel threshold (0 = disabled)
+    SetReleaseThreshold(u32),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -79,6 +79,15 @@ pub enum ProtoEvent {
     /// display bounds and the receiver-supplied [`ProtoEvent::Bounds`]
     /// from a prior Enter.
     MotionAbsolute { x: i32, y: i32 },
+    /// Self-sufficient counterpart to [`ProtoEvent::MotionAbsolute`].
+    /// Carries the host's cursor position normalized to the host's
+    /// own display bounds (0..1 along each axis) plus the entry
+    /// side from the receiver's frame. The receiver scales nx/ny
+    /// against its own bounds and pins the on-axis dimension to
+    /// the entry edge, eliminating the bootstrap problem where
+    /// MotionAbsolute couldn't be sent on the first crossing
+    /// because the host had no cached peer geometry.
+    CursorPos { pos: Position, nx: f32, ny: f32 },
 }
 
 impl Display for ProtoEvent {
@@ -98,6 +107,9 @@ impl Display for ProtoEvent {
             }
             ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
             ProtoEvent::MotionAbsolute { x, y } => write!(f, "MotionAbsolute({x}, {y})"),
+            ProtoEvent::CursorPos { pos, nx, ny } => {
+                write!(f, "CursorPos({pos}, {nx:.4}, {ny:.4})")
+            }
         }
     }
 }
@@ -118,6 +130,7 @@ pub enum EventType {
     Ack,
     Bounds,
     MotionAbsolute,
+    CursorPos,
 }
 
 impl ProtoEvent {
@@ -142,6 +155,7 @@ impl ProtoEvent {
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Bounds { .. } => EventType::Bounds,
             ProtoEvent::MotionAbsolute { .. } => EventType::MotionAbsolute,
+            ProtoEvent::CursorPos { .. } => EventType::CursorPos,
         }
     }
 }
@@ -203,6 +217,11 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::MotionAbsolute => Ok(Self::MotionAbsolute {
                 x: decode_i32(&mut buf)?,
                 y: decode_i32(&mut buf)?,
+            }),
+            EventType::CursorPos => Ok(Self::CursorPos {
+                pos: decode_u8(&mut buf)?.try_into()?,
+                nx: decode_f32(&mut buf)?,
+                ny: decode_f32(&mut buf)?,
             }),
         }
     }
@@ -276,6 +295,11 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                     encode_i32(buf, len, x);
                     encode_i32(buf, len, y);
                 }
+                ProtoEvent::CursorPos { pos, nx, ny } => {
+                    encode_u8(buf, len, pos as u8);
+                    encode_f32(buf, len, nx);
+                    encode_f32(buf, len, ny);
+                }
             }
         }
         (buf, len)
@@ -297,6 +321,7 @@ macro_rules! decode_impl {
 decode_impl!(u8);
 decode_impl!(u32);
 decode_impl!(i32);
+decode_impl!(f32);
 decode_impl!(f64);
 
 macro_rules! encode_impl {
@@ -317,4 +342,5 @@ macro_rules! encode_impl {
 encode_impl!(u8);
 encode_impl!(u32);
 encode_impl!(i32);
+encode_impl!(f32);
 encode_impl!(f64);

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -70,6 +70,15 @@ pub enum ProtoEvent {
     /// height are in pixels of the union of all displays on the
     /// emulating device.
     Bounds { width: u32, height: u32 },
+    /// Absolute cursor warp on the receiving device. Sent by the
+    /// capturing peer after [`ProtoEvent::Enter`] so the guest's
+    /// cursor lands at the position that visually corresponds to
+    /// where the user's physical cursor was at the moment of
+    /// crossing. `x` and `y` are pixel coordinates in the receiver's
+    /// screen space, computed by the capturing peer using its own
+    /// display bounds and the receiver-supplied [`ProtoEvent::Bounds`]
+    /// from a prior Enter.
+    MotionAbsolute { x: i32, y: i32 },
 }
 
 impl Display for ProtoEvent {
@@ -88,6 +97,7 @@ impl Display for ProtoEvent {
                 )
             }
             ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
+            ProtoEvent::MotionAbsolute { x, y } => write!(f, "MotionAbsolute({x}, {y})"),
         }
     }
 }
@@ -107,6 +117,7 @@ pub enum EventType {
     Leave,
     Ack,
     Bounds,
+    MotionAbsolute,
 }
 
 impl ProtoEvent {
@@ -130,6 +141,7 @@ impl ProtoEvent {
             ProtoEvent::Leave(_) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Bounds { .. } => EventType::Bounds,
+            ProtoEvent::MotionAbsolute { .. } => EventType::MotionAbsolute,
         }
     }
 }
@@ -187,6 +199,10 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::Bounds => Ok(Self::Bounds {
                 width: decode_u32(&mut buf)?,
                 height: decode_u32(&mut buf)?,
+            }),
+            EventType::MotionAbsolute => Ok(Self::MotionAbsolute {
+                x: decode_i32(&mut buf)?,
+                y: decode_i32(&mut buf)?,
             }),
         }
     }
@@ -255,6 +271,10 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                 ProtoEvent::Bounds { width, height } => {
                     encode_u32(buf, len, width);
                     encode_u32(buf, len, height);
+                }
+                ProtoEvent::MotionAbsolute { x, y } => {
+                    encode_i32(buf, len, x);
+                    encode_i32(buf, len, y);
                 }
             }
         }

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -63,6 +63,13 @@ pub enum ProtoEvent {
     Ping,
     /// Response to [`ProtoEvent::Ping`], true if emulation is enabled / available
     Pong(bool),
+    /// Display geometry of the receiving device. Sent by the
+    /// emulation side immediately after the [`ProtoEvent::Ack`] of
+    /// an [`ProtoEvent::Enter`] so the capturing peer can model the
+    /// guest cursor's position along the entry axis. Width and
+    /// height are in pixels of the union of all displays on the
+    /// emulating device.
+    Bounds { width: u32, height: u32 },
 }
 
 impl Display for ProtoEvent {
@@ -80,6 +87,7 @@ impl Display for ProtoEvent {
                     if *alive { "alive" } else { "not available" }
                 )
             }
+            ProtoEvent::Bounds { width, height } => write!(f, "Bounds({width}x{height})"),
         }
     }
 }
@@ -98,6 +106,7 @@ pub enum EventType {
     Enter,
     Leave,
     Ack,
+    Bounds,
 }
 
 impl ProtoEvent {
@@ -120,6 +129,7 @@ impl ProtoEvent {
             ProtoEvent::Enter(_) => EventType::Enter,
             ProtoEvent::Leave(_) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
+            ProtoEvent::Bounds { .. } => EventType::Bounds,
         }
     }
 }
@@ -174,6 +184,10 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             EventType::Enter => Ok(Self::Enter(decode_u8(&mut buf)?.try_into()?)),
             EventType::Leave => Ok(Self::Leave(decode_u32(&mut buf)?)),
             EventType::Ack => Ok(Self::Ack(decode_u32(&mut buf)?)),
+            EventType::Bounds => Ok(Self::Bounds {
+                width: decode_u32(&mut buf)?,
+                height: decode_u32(&mut buf)?,
+            }),
         }
     }
 }
@@ -238,6 +252,10 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                 ProtoEvent::Enter(pos) => encode_u8(buf, len, pos as u8),
                 ProtoEvent::Leave(serial) => encode_u32(buf, len, serial),
                 ProtoEvent::Ack(serial) => encode_u32(buf, len, serial),
+                ProtoEvent::Bounds { width, height } => {
+                    encode_u32(buf, len, width);
+                    encode_u32(buf, len, height);
+                }
             }
         }
         (buf, len)

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -61,6 +61,8 @@ enum CaptureRequest {
     Reenable,
     /// set release bind
     SetReleaseBind(Vec<scancode::Linux>),
+    /// set the auto-release pixel threshold (macOS only). 0 disables.
+    SetReleaseThreshold(u32),
 }
 
 impl Capture {
@@ -68,6 +70,7 @@ impl Capture {
         backend: Option<input_capture::Backend>,
         conn: LanMouseConnection,
         release_bind: Vec<scancode::Linux>,
+        release_threshold_px: u32,
     ) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
@@ -81,6 +84,7 @@ impl Capture {
             event_tx,
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
+            release_threshold_px: Rc::new(RefCell::new(release_threshold_px)),
             state: Default::default(),
         };
         let task = spawn_local(capture_task.run());
@@ -137,6 +141,12 @@ impl Capture {
     pub(crate) fn set_release_bind(&mut self, bind: Vec<scancode::Linux>) {
         let _ = self.request_tx.send(CaptureRequest::SetReleaseBind(bind));
     }
+
+    pub(crate) fn set_release_threshold(&mut self, threshold: u32) {
+        let _ = self
+            .request_tx
+            .send(CaptureRequest::SetReleaseThreshold(threshold));
+    }
 }
 
 /// debounce a statement `$st`, i.e. the statement is executed only if the
@@ -164,6 +174,7 @@ struct CaptureTask {
     conn: LanMouseConnection,
     event_tx: Sender<ICaptureEvent>,
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
+    release_threshold_px: Rc<RefCell<u32>>,
     request_rx: Receiver<CaptureRequest>,
     state: State,
 }
@@ -214,6 +225,9 @@ impl CaptureTask {
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
+                        CaptureRequest::SetReleaseThreshold(threshold) => {
+                            *self.release_threshold_px.borrow_mut() = threshold;
+                        }
                     },
                     _ = self.cancellation_token.cancelled() => return,
                 }
@@ -240,6 +254,11 @@ impl CaptureTask {
             capture.terminate().await?;
             return Err(e.into());
         }
+
+        // Push the configured auto-release threshold to the freshly
+        // created InputCapture. The wall-press detection is
+        // cross-platform — every backend benefits.
+        capture.set_release_threshold(*self.release_threshold_px.borrow());
 
         let r = self.do_capture_session(&mut capture).await;
 
@@ -307,6 +326,10 @@ impl CaptureTask {
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);
                     }
+                    CaptureRequest::SetReleaseThreshold(threshold) => {
+                        *self.release_threshold_px.borrow_mut() = threshold;
+                        capture.set_release_threshold(threshold);
+                    }
                 },
                 _ = self.cancellation_token.cancelled() => break,
             }
@@ -324,6 +347,15 @@ impl CaptureTask {
 
         if capture.keys_pressed(&self.release_bind.borrow()) {
             log::info!("releasing capture: release-bind pressed");
+            return self.release_capture(capture).await;
+        }
+
+        // Backend self-released (currently only macOS, when sustained
+        // back-toward-host motion crosses the configured threshold).
+        // Drive the same teardown path as the release-bind chord so
+        // the peer gets a Leave + key-up flush.
+        if matches!(event, CaptureEvent::AutoRelease) {
+            log::info!("releasing capture: backend auto-release");
             return self.release_capture(capture).await;
         }
 
@@ -363,6 +395,7 @@ impl CaptureTask {
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
                 State::Sending => ProtoEvent::Input(e),
             },
+            CaptureEvent::AutoRelease => unreachable!("handled in early return above"),
         };
 
         if let Err(e) = self.conn.send(event, handle).await {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -371,7 +371,7 @@ impl CaptureTask {
             return self.release_capture(capture).await;
         }
 
-        if event == CaptureEvent::Begin {
+        if matches!(event, CaptureEvent::Begin { .. }) {
             self.event_tx
                 .send(ICaptureEvent::CaptureBegin(handle))
                 .expect("channel closed");
@@ -390,7 +390,7 @@ impl CaptureTask {
         }
 
         // activated a new client
-        if event == CaptureEvent::Begin && Some(handle) != self.active_client {
+        if matches!(event, CaptureEvent::Begin { .. }) && Some(handle) != self.active_client {
             self.state = State::WaitingForAck;
             self.active_client.replace(handle);
             self.event_tx
@@ -400,8 +400,23 @@ impl CaptureTask {
 
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
-        let event = match event {
-            CaptureEvent::Begin => ProtoEvent::Enter(opposite_pos),
+        // If we're starting a fresh capture and the backend reported a
+        // cursor position at the moment of crossing, compute the
+        // visually-corresponding target on the peer's screen so we can
+        // follow Enter with a MotionAbsolute event. Falls back to the
+        // entry-edge-midpoint warp on the guest when this is None
+        // (host can't report cursor or peer hasn't sent Bounds yet).
+        let warp_target = if let CaptureEvent::Begin {
+            cursor: Some(cursor),
+        } = event
+        {
+            capture.peer_warp_target(self.get_pos(handle), cursor)
+        } else {
+            None
+        };
+
+        let proto_event = match event {
+            CaptureEvent::Begin { .. } => ProtoEvent::Enter(opposite_pos),
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
@@ -410,10 +425,27 @@ impl CaptureTask {
             CaptureEvent::AutoRelease => unreachable!("handled in early return above"),
         };
 
-        if let Err(e) = self.conn.send(event, handle).await {
+        if let Err(e) = self.conn.send(proto_event, handle).await {
             const DUR: Duration = Duration::from_millis(500);
             debounce!(PREV_LOG, DUR, log::warn!("releasing capture: {e}"));
             capture.release().await?;
+            return Ok(());
+        }
+
+        // Send MotionAbsolute right after Enter so the guest can warp
+        // its cursor to the right point on its own screen. Done as a
+        // separate event so peers running an older protocol just
+        // tolerate-and-skip via the forward-compat decode path; new
+        // peers warp to (x, y) and override the entry-edge-midpoint
+        // warp triggered by Enter.
+        if let Some((x, y)) = warp_target {
+            if let Err(e) = self
+                .conn
+                .send(ProtoEvent::MotionAbsolute { x, y }, handle)
+                .await
+            {
+                log::warn!("MotionAbsolute send failed: {e}");
+            }
         }
         Ok(())
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -401,18 +401,34 @@ impl CaptureTask {
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
         // If we're starting a fresh capture and the backend reported a
-        // cursor position at the moment of crossing, compute the
-        // visually-corresponding target on the peer's screen so we can
-        // follow Enter with a MotionAbsolute event. Falls back to the
-        // entry-edge-midpoint warp on the guest when this is None
-        // (host can't report cursor or peer hasn't sent Bounds yet).
-        let warp_target = if let CaptureEvent::Begin {
+        // cursor position at the moment of crossing, compute two
+        // representations to follow Enter with:
+        //
+        //   * `MotionAbsolute` (peer pixel coords): more precise when
+        //     the peer's geometry is already cached, but None on the
+        //     very first crossing because we haven't seen `Bounds`
+        //     from the peer yet.
+        //   * `CursorPos` (host-normalized fraction + entry side):
+        //     self-sufficient — the receiver scales against its own
+        //     bounds. Works on the first crossing.
+        //
+        // Both events are emitted when applicable; the receiver
+        // tolerates either order and the second warp wins. Old peers
+        // that don't recognize `CursorPos` skip it via the proto
+        // forward-compat path.
+        let (warp_target, cursor_pos) = if let CaptureEvent::Begin {
             cursor: Some(cursor),
         } = event
         {
-            capture.peer_warp_target(self.get_pos(handle), cursor)
+            let pos = self.get_pos(handle);
+            let warp = capture.peer_warp_target(pos, cursor);
+            let norm = capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
+                let proto_pos = to_proto_pos(pos.opposite());
+                (proto_pos, nx, ny)
+            });
+            (warp, norm)
         } else {
-            None
+            (None, None)
         };
 
         let proto_event = match event {
@@ -445,6 +461,21 @@ impl CaptureTask {
                 .await
             {
                 log::warn!("MotionAbsolute send failed: {e}");
+            }
+        }
+        // Self-sufficient companion event: doesn't need cached peer
+        // bounds, so the very first crossing also lands the cursor
+        // at the visually-corresponding point. Sent after
+        // MotionAbsolute so a new peer that handles both ends up
+        // with the more recent (and more accurate, since it uses
+        // the peer's *current* display bounds) CursorPos warp.
+        if let Some((pos, nx, ny)) = cursor_pos {
+            if let Err(e) = self
+                .conn
+                .send(ProtoEvent::CursorPos { pos, nx, ny }, handle)
+                .await
+            {
+                log::warn!("CursorPos send failed: {e}");
             }
         }
         Ok(())

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -309,6 +309,13 @@ impl CaptureTask {
                             log::info!("releasing capture: left remote client device region");
                             self.release_capture(capture).await?;
                         },
+                        // Peer reported its display geometry — cache it
+                        // so the wall-press model has a real upper
+                        // clamp on virtual_pos for this position.
+                        ProtoEvent::Bounds { width, height } => {
+                            let pos = self.get_pos(handle);
+                            capture.set_peer_bounds(pos, width, height);
+                        }
                         _ => {}
                     }
                 },
@@ -320,8 +327,13 @@ impl CaptureTask {
                         capture.create(h, p).await?;
                     }
                     CaptureRequest::Destroy(h) => {
+                        let pos = self.get_pos(h);
                         self.remove_capture(h);
                         capture.destroy(h).await?;
+                        // Drop the cached geometry — the next client
+                        // added at this position may report different
+                        // bounds.
+                        capture.clear_peer_bounds(pos);
                     }
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -307,10 +307,20 @@ impl CaptureTask {
                             log::info!("client {handle} acknowledged the connection!");
                             self.state = State::Sending;
                         }
-                        // client disconnected
+                        // Peer sent Leave — either they just released
+                        // their own outbound capture, or they're
+                        // taking over and want us to stop sending to
+                        // them. The "taking over" case is the common
+                        // one (CaptureBegin on the peer triggers a
+                        // send_leave_event to every incoming address)
+                        // and is followed by Enter+CursorPos from the
+                        // peer. Use the handover release so the local
+                        // host warp doesn't race against the peer's
+                        // upcoming proportional CursorPos warp on our
+                        // shared cursor.
                         ProtoEvent::Leave(_) => {
                             log::info!("releasing capture: left remote client device region");
-                            self.release_capture(capture).await?;
+                            self.release_capture_handover(capture).await?;
                         },
                         // Peer reported its display geometry — cache it
                         // so the wall-press model has a real upper

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -400,35 +400,25 @@ impl CaptureTask {
 
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
-        // If we're starting a fresh capture and the backend reported a
-        // cursor position at the moment of crossing, compute two
-        // representations to follow Enter with:
-        //
-        //   * `MotionAbsolute` (peer pixel coords): more precise when
-        //     the peer's geometry is already cached, but None on the
-        //     very first crossing because we haven't seen `Bounds`
-        //     from the peer yet.
-        //   * `CursorPos` (host-normalized fraction + entry side):
-        //     self-sufficient — the receiver scales against its own
-        //     bounds. Works on the first crossing.
-        //
-        // Both events are emitted when applicable; the receiver
-        // tolerates either order and the second warp wins. Old peers
-        // that don't recognize `CursorPos` skip it via the proto
-        // forward-compat path.
-        let (warp_target, cursor_pos) = if let CaptureEvent::Begin {
+        // If we're starting a fresh capture and the backend reported
+        // a cursor position at the moment of crossing, send a
+        // `CursorPos` (host-normalized fraction + entry side from the
+        // peer's frame) right after Enter. The peer scales against
+        // its own live bounds and pins the on-axis dimension to the
+        // matching edge — self-sufficient, no prior `Bounds`
+        // round-trip needed, so the very first crossing also lands
+        // the cursor at the visually-corresponding point.
+        let cursor_pos = if let CaptureEvent::Begin {
             cursor: Some(cursor),
         } = event
         {
             let pos = self.get_pos(handle);
-            let warp = capture.peer_warp_target(pos, cursor);
-            let norm = capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
+            capture.host_normalized_cursor(cursor).map(|(nx, ny)| {
                 let proto_pos = to_proto_pos(pos.opposite());
                 (proto_pos, nx, ny)
-            });
-            (warp, norm)
+            })
         } else {
-            (None, None)
+            None
         };
 
         let proto_event = match event {
@@ -448,27 +438,10 @@ impl CaptureTask {
             return Ok(());
         }
 
-        // Send MotionAbsolute right after Enter so the guest can warp
-        // its cursor to the right point on its own screen. Done as a
-        // separate event so peers running an older protocol just
-        // tolerate-and-skip via the forward-compat decode path; new
-        // peers warp to (x, y) and override the entry-edge-midpoint
-        // warp triggered by Enter.
-        if let Some((x, y)) = warp_target {
-            if let Err(e) = self
-                .conn
-                .send(ProtoEvent::MotionAbsolute { x, y }, handle)
-                .await
-            {
-                log::warn!("MotionAbsolute send failed: {e}");
-            }
-        }
-        // Self-sufficient companion event: doesn't need cached peer
-        // bounds, so the very first crossing also lands the cursor
-        // at the visually-corresponding point. Sent after
-        // MotionAbsolute so a new peer that handles both ends up
-        // with the more recent (and more accurate, since it uses
-        // the peer's *current* display bounds) CursorPos warp.
+        // Send CursorPos right after Enter so the receiver can warp
+        // its cursor to the visually-corresponding point on its own
+        // screen — overrides the entry-edge-midpoint warp the
+        // receiver otherwise applies on Enter.
         if let Some((pos, nx, ny)) = cursor_pos {
             if let Err(e) = self
                 .conn

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -443,6 +443,7 @@ impl CaptureTask {
         // screen — overrides the entry-edge-midpoint warp the
         // receiver otherwise applies on Enter.
         if let Some((pos, nx, ny)) = cursor_pos {
+            log::info!("[cursor-pos] send pos={pos:?} nx={nx:.3} ny={ny:.3}");
             if let Err(e) = self
                 .conn
                 .send(ProtoEvent::CursorPos { pos, nx, ny }, handle)
@@ -450,6 +451,10 @@ impl CaptureTask {
             {
                 log::warn!("CursorPos send failed: {e}");
             }
+        } else if matches!(event, CaptureEvent::Begin { .. }) {
+            log::info!(
+                "[cursor-pos] send skipped — Begin had no cursor or host_normalized_cursor returned None"
+            );
         }
         Ok(())
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -51,8 +51,11 @@ pub(crate) enum CaptureType {
 
 #[derive(Clone, Debug)]
 enum CaptureRequest {
-    /// capture must release the mouse
-    Release,
+    /// release because the remote peer is taking over (they sent
+    /// Enter+CursorPos). Skips the host-side warp so the peer's
+    /// proportional CursorPos warp doesn't get clobbered by a
+    /// racing local warp computed from stale virtual_cursor state.
+    ReleaseForHandover,
     /// add a capture client
     Create(CaptureHandle, Position, CaptureType),
     /// destory a capture client
@@ -128,9 +131,9 @@ impl Capture {
             .expect("channel closed");
     }
 
-    pub(crate) fn release(&self) {
+    pub(crate) fn release_for_handover(&self) {
         self.request_tx
-            .send(CaptureRequest::Release)
+            .send(CaptureRequest::ReleaseForHandover)
             .expect("channel closed");
     }
 
@@ -221,7 +224,7 @@ impl CaptureTask {
                         CaptureRequest::Reenable => break,
                         CaptureRequest::Create(h, p, t) => self.add_capture(h, p, t),
                         CaptureRequest::Destroy(h) => self.remove_capture(h),
-                        CaptureRequest::Release => { /* nothing to do */ }
+                        CaptureRequest::ReleaseForHandover => { /* nothing to do */ }
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
@@ -321,7 +324,7 @@ impl CaptureTask {
                 },
                 e = self.request_rx.recv() => match e.expect("channel closed") {
                     CaptureRequest::Reenable => { /* already active */ },
-                    CaptureRequest::Release => self.release_capture(capture).await?,
+                    CaptureRequest::ReleaseForHandover => self.release_capture_handover(capture).await?,
                     CaptureRequest::Create(h, p, t) => {
                         self.add_capture(h, p, t);
                         capture.create(h, p).await?;
@@ -460,6 +463,24 @@ impl CaptureTask {
     }
 
     async fn release_capture(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
+        self.notify_peer_of_leave(capture).await;
+        capture.release().await
+    }
+
+    /// Release path used when the peer is taking over (they sent
+    /// Enter+CursorPos). Same teardown — synthesize key-ups, reset
+    /// mods, send Leave — but skip the host-side cursor warp so it
+    /// doesn't race against the peer's authoritative CursorPos
+    /// warp on our shared cursor.
+    async fn release_capture_handover(
+        &mut self,
+        capture: &mut InputCapture,
+    ) -> Result<(), CaptureError> {
+        self.notify_peer_of_leave(capture).await;
+        capture.release_no_host_warp().await
+    }
+
+    async fn notify_peer_of_leave(&mut self, capture: &mut InputCapture) {
         // If we have an active client, notify them we're leaving
         if let Some(handle) = self.active_client.take() {
             // Synthesize key-up events for every key still held in the
@@ -502,7 +523,6 @@ impl CaptureTask {
                 log::warn!("failed to send Leave to client {handle}: {e}");
             }
         }
-        capture.release().await
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,10 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    /// pixel threshold for the wall-press auto-release fallback.
+    /// 0 (or absent) disables it; the cursor only releases on the
+    /// release-bind chord or a peer-side `Leave`.
+    release_threshold_px: Option<u32>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -477,6 +481,25 @@ impl Config {
             .as_ref()
             .and_then(|c| c.release_bind.clone())
             .unwrap_or(Vec::from_iter(DEFAULT_RELEASE_KEYS.iter().cloned()))
+    }
+
+    /// Pixel threshold for the wall-press auto-release fallback.
+    /// 0 disables it.
+    pub fn release_threshold_px(&self) -> u32 {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.release_threshold_px)
+            .unwrap_or(0)
+    }
+
+    pub fn set_release_threshold_px(&mut self, threshold: u32) {
+        if self.config_toml.is_none() {
+            self.config_toml = Some(Default::default());
+        }
+        self.config_toml
+            .as_mut()
+            .expect("config")
+            .release_threshold_px = Some(threshold);
     }
 
     /// set configured clients

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -141,6 +141,24 @@ impl ListenTask {
                                     log::info!("releasing capture: {addr} entered this device");
                                     self.event_tx.send(EmulationEvent::ReleaseNotify).expect("channel closed");
                                     self.listener.reply(addr, ProtoEvent::Ack(0)).await;
+                                    // Send the receiving device's display
+                                    // geometry so the capturing peer can
+                                    // model the guest cursor's position
+                                    // accurately. Old peers that don't
+                                    // recognize this event will skip it
+                                    // per the forward-compat fix.
+                                    if let Some((width, height)) = self.emulation_proxy.display_bounds() {
+                                        self.listener.reply(addr, ProtoEvent::Bounds { width, height }).await;
+                                        // Seat the local cursor at the
+                                        // entry edge so the host's
+                                        // virtual_pos = 0 corresponds to
+                                        // the guest's actual column 0
+                                        // (or width-1, etc.) instead of
+                                        // wherever the previous capture
+                                        // session left it.
+                                        let (x, y) = entry_edge_for(pos, width, height);
+                                        self.emulation_proxy.warp_cursor(x, y);
+                                    }
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
                                 }
                             }
@@ -206,6 +224,11 @@ pub(crate) struct EmulationProxy {
     request_tx: Sender<ProxyRequest>,
     event_rx: Receiver<EmulationEvent>,
     task: JoinHandle<()>,
+    /// Cached display bounds. Refreshed each time the underlying
+    /// InputEmulation is (re)created. `None` until the first
+    /// successful query, or if the active backend doesn't report
+    /// geometry.
+    display_bounds: Rc<Cell<Option<(u32, u32)>>>,
 }
 
 enum ProxyRequest {
@@ -213,6 +236,10 @@ enum ProxyRequest {
     Remove(SocketAddr),
     Terminate,
     Reenable,
+    /// Warp the local cursor to an absolute position. Used on
+    /// `Enter` to seat the cursor at the entry edge so the
+    /// capturing peer's wall-press model is synchronized.
+    Warp(i32, i32),
 }
 
 impl EmulationProxy {
@@ -221,9 +248,11 @@ impl EmulationProxy {
         let (event_tx, event_rx) = channel();
         let emulation_active = Rc::new(Cell::new(false));
         let exit_requested = Rc::new(Cell::new(false));
+        let display_bounds = Rc::new(Cell::new(None));
         let emulation_task = EmulationTask {
             backend,
             exit_requested: exit_requested.clone(),
+            display_bounds: display_bounds.clone(),
             request_rx,
             event_tx,
             handles: Default::default(),
@@ -236,7 +265,24 @@ impl EmulationProxy {
             request_tx,
             task,
             event_rx,
+            display_bounds,
         }
+    }
+
+    /// Display geometry of this device (cached). Refreshed each
+    /// time the input emulation backend is (re)created.
+    pub(crate) fn display_bounds(&self) -> Option<(u32, u32)> {
+        self.display_bounds.get()
+    }
+
+    /// Fire-and-forget cursor warp. Drops silently if emulation
+    /// isn't currently active (no live backend to receive the
+    /// request).
+    pub(crate) fn warp_cursor(&self, x: i32, y: i32) {
+        if !self.emulation_active.get() {
+            return;
+        }
+        let _ = self.request_tx.send(ProxyRequest::Warp(x, y));
     }
 
     async fn event(&mut self) -> EmulationEvent {
@@ -283,6 +329,9 @@ impl EmulationProxy {
 struct EmulationTask {
     backend: Option<input_emulation::Backend>,
     exit_requested: Rc<Cell<bool>>,
+    /// Shared cache; refreshed each time we (re)create the inner
+    /// InputEmulation. Read by `EmulationProxy::display_bounds`.
+    display_bounds: Rc<Cell<Option<(u32, u32)>>>,
     request_rx: Receiver<ProxyRequest>,
     event_tx: Sender<EmulationEvent>,
     handles: HashMap<SocketAddr, EmulationHandle>,
@@ -305,6 +354,7 @@ impl EmulationTask {
                     ProxyRequest::Terminate => return,
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::Warp(..) => { /* emulation inactive => ignore */ }
                 }
             }
         }
@@ -317,6 +367,11 @@ impl EmulationTask {
             // allow termination event while requesting input emulation
             _ = wait_for_termination(&mut self.request_rx) => return Ok(()),
         };
+
+        // Refresh the shared display-bounds cache. Goes through
+        // EmulationProxy::display_bounds() so the daemon can include
+        // it in the ProtoEvent::Bounds reply on Enter.
+        self.display_bounds.set(emulation.display_bounds());
 
         // used to send enabled and disabled events
         let _emulation_guard = DropGuard::new(
@@ -375,6 +430,11 @@ impl EmulationTask {
                             emulation.destroy(handle).await;
                         }
                     }
+                    ProxyRequest::Warp(x, y) => {
+                        if let Err(e) = emulation.warp_cursor(x, y).await {
+                            log::warn!("warp_cursor failed: {e}");
+                        }
+                    }
                     ProxyRequest::Terminate => break Ok(()),
                     ProxyRequest::Reenable => continue,
                 },
@@ -392,12 +452,31 @@ fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
     }
 }
 
+/// Where to seat the local cursor when this device is entered.
+/// `pos` is the protocol-level position in *this device's* frame
+/// (already inverted from the host's perspective by the capture
+/// side). For example, `Position::Left` means "the host is to my
+/// left, the cursor entered from my left edge", so the cursor
+/// should land at x=0. Y is centered along the entry edge for
+/// Left/Right; X is centered for Top/Bottom.
+fn entry_edge_for(pos: Position, width: u32, height: u32) -> (i32, i32) {
+    let w = width as i32;
+    let h = height as i32;
+    match pos {
+        Position::Left => (0, h / 2),
+        Position::Right => (w.saturating_sub(1), h / 2),
+        Position::Top => (w / 2, 0),
+        Position::Bottom => (w / 2, h.saturating_sub(1)),
+    }
+}
+
 async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
     loop {
         match rx.recv().await.expect("channel closed") {
             ProxyRequest::Terminate => return,
             ProxyRequest::Input(_, _) => continue,
             ProxyRequest::Remove(_) => continue,
+            ProxyRequest::Warp(_, _) => continue,
             ProxyRequest::Reenable => continue,
         }
     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -177,6 +177,37 @@ impl ListenTask {
                             ProtoEvent::MotionAbsolute { x, y } => {
                                 self.emulation_proxy.warp_cursor(x, y);
                             }
+                            // Self-sufficient counterpart to
+                            // MotionAbsolute. Carries the host's
+                            // cursor as a fraction of the host's own
+                            // screen plus the entry side. Scale by
+                            // our display bounds, pin the on-axis
+                            // dimension to the matching edge, and
+                            // warp. Works without a prior Bounds
+                            // round-trip — the bug MotionAbsolute hit
+                            // on the very first crossing, where the
+                            // host had no peer geometry to compute
+                            // pixel coords from.
+                            ProtoEvent::CursorPos { pos, nx, ny } => {
+                                if let Some((w, h)) = self.emulation_proxy.display_bounds() {
+                                    let pw = w as f32;
+                                    let ph = h as f32;
+                                    let pwi = w as i32;
+                                    let phi = h as i32;
+                                    let (tx, ty) = match pos {
+                                        // host on our left → cursor enters our left edge
+                                        Position::Left => (0, (ny * ph) as i32),
+                                        Position::Right => {
+                                            (pwi.saturating_sub(1), (ny * ph) as i32)
+                                        }
+                                        Position::Top => ((nx * pw) as i32, 0),
+                                        Position::Bottom => {
+                                            ((nx * pw) as i32, phi.saturating_sub(1))
+                                        }
+                                    };
+                                    self.emulation_proxy.warp_cursor(tx, ty);
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -149,16 +149,27 @@ impl ListenTask {
                                     // per the forward-compat fix.
                                     if let Some((width, height)) = self.emulation_proxy.display_bounds() {
                                         self.listener.reply(addr, ProtoEvent::Bounds { width, height }).await;
-                                        // Seat the local cursor at the
-                                        // entry edge so the host's
-                                        // virtual_pos = 0 corresponds to
-                                        // the guest's actual column 0
-                                        // (or width-1, etc.) instead of
-                                        // wherever the previous capture
-                                        // session left it.
-                                        let (x, y) = entry_edge_for(pos, width, height);
-                                        self.emulation_proxy.warp_cursor(x, y);
                                     }
+                                    // No entry-edge midpoint warp here:
+                                    // the host's CursorPos (sent right
+                                    // after Enter) carries the
+                                    // proportional landing point and
+                                    // pins the on-axis dimension to the
+                                    // matching edge. Warping to the
+                                    // midpoint first would briefly
+                                    // place the cursor at center-edge
+                                    // — and a quick re-cross by the
+                                    // user would have the local
+                                    // CGEventTap (or equivalent) snap
+                                    // its `cursor=` field from the
+                                    // midpoint, masquerading as a
+                                    // mid-screen crossing on the next
+                                    // CursorPos sent back the other
+                                    // way. Trusts the host: if it
+                                    // can't compute a proportional
+                                    // point the cursor stays where it
+                                    // was, which is preferable to a
+                                    // forced midpoint.
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
                                 }
                             }
@@ -496,17 +507,6 @@ fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
 /// left, the cursor entered from my left edge", so the cursor
 /// should land at x=0. Y is centered along the entry edge for
 /// Left/Right; X is centered for Top/Bottom.
-fn entry_edge_for(pos: Position, width: u32, height: u32) -> (i32, i32) {
-    let w = width as i32;
-    let h = height as i32;
-    match pos {
-        Position::Left => (0, h / 2),
-        Position::Right => (w.saturating_sub(1), h / 2),
-        Position::Top => (w / 2, 0),
-        Position::Bottom => (w / 2, h.saturating_sub(1)),
-    }
-}
-
 async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
     loop {
         match rx.recv().await.expect("channel closed") {

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -168,42 +168,32 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
-                            // Capturing peer told us where on our
-                            // screen the user's cursor was at the
-                            // moment of crossing — warp directly there
-                            // and override the entry-edge-midpoint
-                            // warp from the prior Enter so the
-                            // transition is visually continuous.
-                            ProtoEvent::MotionAbsolute { x, y } => {
-                                self.emulation_proxy.warp_cursor(x, y);
-                            }
-                            // Self-sufficient counterpart to
-                            // MotionAbsolute. Carries the host's
-                            // cursor as a fraction of the host's own
-                            // screen plus the entry side. Scale by
-                            // our display bounds, pin the on-axis
-                            // dimension to the matching edge, and
-                            // warp. Works without a prior Bounds
-                            // round-trip — the bug MotionAbsolute hit
-                            // on the very first crossing, where the
-                            // host had no peer geometry to compute
-                            // pixel coords from.
+                            // Capturing peer told us where on its own
+                            // screen the user's cursor was, as a
+                            // normalized fraction (nx, ny) ∈ [0, 1]
+                            // plus the entry side (from our frame).
+                            // Scale against our live display bounds
+                            // and pin the on-axis dimension to the
+                            // matching edge so the cursor lands at
+                            // the visually-corresponding point.
+                            // Works without a prior Bounds round-trip,
+                            // so the very first crossing of a session
+                            // also lands at the visually-corresponding
+                            // point. The cross-axis multiply is
+                            // clamped to dim - 1 so a host edge
+                            // (nx == 1.0 or ny == 1.0) doesn't compute
+                            // one pixel past the addressable column.
                             ProtoEvent::CursorPos { pos, nx, ny } => {
                                 if let Some((w, h)) = self.emulation_proxy.display_bounds() {
-                                    let pw = w as f32;
-                                    let ph = h as f32;
                                     let pwi = w as i32;
                                     let phi = h as i32;
+                                    let cx = ((nx * w as f32) as i32).clamp(0, pwi.saturating_sub(1));
+                                    let cy = ((ny * h as f32) as i32).clamp(0, phi.saturating_sub(1));
                                     let (tx, ty) = match pos {
-                                        // host on our left → cursor enters our left edge
-                                        Position::Left => (0, (ny * ph) as i32),
-                                        Position::Right => {
-                                            (pwi.saturating_sub(1), (ny * ph) as i32)
-                                        }
-                                        Position::Top => ((nx * pw) as i32, 0),
-                                        Position::Bottom => {
-                                            ((nx * pw) as i32, phi.saturating_sub(1))
-                                        }
+                                        Position::Left => (0, cy),
+                                        Position::Right => (pwi.saturating_sub(1), cy),
+                                        Position::Top => (cx, 0),
+                                        Position::Bottom => (cx, phi.saturating_sub(1)),
                                     };
                                     self.emulation_proxy.warp_cursor(tx, ty);
                                 }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -168,6 +168,15 @@ impl ListenTask {
                             }
                             ProtoEvent::Input(event) => self.emulation_proxy.consume(event, addr),
                             ProtoEvent::Ping => self.listener.reply(addr, ProtoEvent::Pong(self.emulation_proxy.emulation_active.get())).await,
+                            // Capturing peer told us where on our
+                            // screen the user's cursor was at the
+                            // moment of crossing — warp directly there
+                            // and override the entry-edge-midpoint
+                            // warp from the prior Enter so the
+                            // transition is visually continuous.
+                            ProtoEvent::MotionAbsolute { x, y } => {
+                                self.emulation_proxy.warp_cursor(x, y);
+                            }
                             _ => {}
                         }
                     }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -195,7 +195,14 @@ impl ListenTask {
                                         Position::Top => (cx, 0),
                                         Position::Bottom => (cx, phi.saturating_sub(1)),
                                     };
+                                    log::info!(
+                                        "[cursor-pos] recv pos={pos:?} nx={nx:.3} ny={ny:.3} display_bounds=({w},{h}) → warp=({tx},{ty})"
+                                    );
                                     self.emulation_proxy.warp_cursor(tx, ty);
+                                } else {
+                                    log::info!(
+                                        "[cursor-pos] recv pos={pos:?} nx={nx:.3} ny={ny:.3} but display_bounds=None — skipping warp"
+                                    );
                                 }
                             }
                             _ => {}

--- a/src/service.rs
+++ b/src/service.rs
@@ -101,7 +101,12 @@ impl Service {
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
-        let capture = Capture::new(capture_backend, conn, config.release_bind());
+        let capture = Capture::new(
+            capture_backend,
+            conn,
+            config.release_bind(),
+            config.release_threshold_px(),
+        );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
 
@@ -218,6 +223,12 @@ impl Service {
                 self.update_enter_hook(handle, enter_hook)
             }
             FrontendRequest::SaveConfiguration => self.save_config(),
+            FrontendRequest::SetReleaseThreshold(threshold) => {
+                self.config.set_release_threshold_px(threshold);
+                self.capture.set_release_threshold(threshold);
+                self.notify_frontend(FrontendEvent::ReleaseThreshold(threshold));
+                self.save_config();
+            }
         }
     }
 
@@ -258,6 +269,9 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
+        let release_threshold = self.config.release_threshold_px();
+        self.capture.set_release_threshold(release_threshold);
+        self.notify_frontend(FrontendEvent::ReleaseThreshold(release_threshold));
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()
@@ -378,6 +392,9 @@ impl Service {
         self.notify_frontend(FrontendEvent::PortChanged(self.port, None));
         self.notify_frontend(FrontendEvent::PublicKeyFingerprint(
             self.public_key_fingerprint.clone(),
+        ));
+        self.notify_frontend(FrontendEvent::ReleaseThreshold(
+            self.config.release_threshold_px(),
         ));
         let keys = self.authorized_keys.read().expect("lock").clone();
         self.notify_frontend(FrontendEvent::AuthorizedUpdated(keys));

--- a/src/service.rs
+++ b/src/service.rs
@@ -329,7 +329,7 @@ impl Service {
                 self.emulation_status = Status::Enabled;
                 self.notify_frontend(FrontendEvent::EmulationStatus(self.emulation_status));
             }
-            EmulationEvent::ReleaseNotify => self.capture.release(),
+            EmulationEvent::ReleaseNotify => self.capture.release_for_handover(),
             EmulationEvent::Connected { addr, fingerprint } => {
                 self.notify_frontend(FrontendEvent::DeviceConnected { addr, fingerprint });
             }


### PR DESCRIPTION
Splits the cursor-sync portion of the original cursor-and-walls work (PR #420) into its own focused PR.

**Review-only focused diff** (just this PR's commits, vs. `split/01-cursor-and-walls`): https://github.com/jondkinney/lan-mouse/compare/split/01-cursor-and-walls...split/01-cursorpos

## Summary
- New `CursorPos` proto event for bounds-free cross-machine warps
- Layer-shell capture reports screen-space cursor on Enter
- Refinements: union-origin normalization, retroactive virtual_cursor seeding, handover-release path
- Drops MotionAbsolute in favor of CursorPos

## Test plan
- [ ] Cross between two machines and verify cursor lands at the matching cross-axis position
- [ ] Test with mismatched display sizes
- [ ] Ensure handover release works on peer-Leave