### PR TITLE
macos: fix Option+Arrow chords + modifier-state corruption in repeat-task cleanup

### DIFF
--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -106,8 +106,14 @@ impl MacOSEmulation {
                     }
                 }
             }
-            // release key when cancelled
-            update_modifiers(&modifiers, key as u32, 0);
+            // release key when cancelled.
+            // Do NOT call update_modifiers here: `key` is a Mac CGKeyCode but
+            // update_modifiers expects a Linux evdev scancode, and the two
+            // codespaces collide (e.g. Mac LeftShift=56 == Linux KeyLeftAlt=56,
+            // Mac Down=125 == Linux KeyLeftMeta=125), corrupting modifier
+            // state for chords like Shift+Option+X or Cmd+Down. Modifier state
+            // is owned by the main consume() loop, which calls update_modifiers
+            // with the correct Linux scancode on the real release event.
             key_event(event_source.clone(), key, 0, modifiers.get());
         });
         self.repeat_task = Some(repeat_task);

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -106,14 +106,19 @@ impl MacOSEmulation {
                     }
                 }
             }
-            // release key when cancelled.
+            // Always release the key with the correct CGKeyCode, regardless of
+            // whether the repeat loop ran. This matches @feschber's review
+            // request: "still release the key repeat task but with the correct
+            // code."
+            //
             // Do NOT call update_modifiers here: `key` is a Mac CGKeyCode but
             // update_modifiers expects a Linux evdev scancode, and the two
             // codespaces collide (e.g. Mac LeftShift=56 == Linux KeyLeftAlt=56,
             // Mac Down=125 == Linux KeyLeftMeta=125), corrupting modifier
             // state for chords like Shift+Option+X or Cmd+Down. Modifier state
-            // is owned by the main consume() loop, which calls update_modifiers
-            // with the correct Linux scancode on the real release event.
+            // is owned by the main consume() loop, which already calls
+            // update_modifiers with the correct Linux scancode on the real key
+            // release event from the client.
             key_event(event_source.clone(), key, 0, modifiers.get());
         });
         self.repeat_task = Some(repeat_task);

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -157,6 +157,19 @@ extern "C" {
     fn AXIsProcessTrusted() -> bool;
 }
 
+/// Mac virtual key codes for the four arrow keys.
+const MAC_KEY_LEFT: u16 = 0x7B;
+const MAC_KEY_RIGHT: u16 = 0x7C;
+const MAC_KEY_DOWN: u16 = 0x7D;
+const MAC_KEY_UP: u16 = 0x7E;
+
+fn is_arrow_key(key: u16) -> bool {
+    matches!(
+        key,
+        MAC_KEY_LEFT | MAC_KEY_RIGHT | MAC_KEY_DOWN | MAC_KEY_UP
+    )
+}
+
 fn key_event(event_source: CGEventSource, key: u16, state: u8, modifiers: XMods) {
     let event = match CGEvent::new_keyboard_event(event_source, key, state != 0) {
         Ok(e) => e,
@@ -165,7 +178,15 @@ fn key_event(event_source: CGEventSource, key: u16, state: u8, modifiers: XMods)
             return;
         }
     };
-    event.set_flags(to_cgevent_flags(modifiers));
+    let mut flags = to_cgevent_flags(modifiers);
+    // Hardware-generated arrow keys on macOS carry NumericPad + SecondaryFn.
+    // CGEventTap-based hotkey matchers (e.g. tiling window managers) check
+    // these flags to recognize navigation keys; without them synthesized
+    // arrow chords fall through to the focused app.
+    if is_arrow_key(key) {
+        flags |= CGEventFlags::CGEventFlagNumericPad | CGEventFlags::CGEventFlagSecondaryFn;
+    }
+    event.set_flags(flags);
     event.post(CGEventTapLocation::HID);
     log::trace!("key event: {key} {state}");
 }


### PR DESCRIPTION
Fixes #440.

Two related bugs in the macOS input-emulation backend, each addressed in its own commit so they can be reviewed and bisected independently.

## Commit 1 — `macos: post NumericPad and SecondaryFn flags for synthesized arrow keys`

Hardware-generated arrow key `CGEvent`s on macOS carry `kCGEventFlagMaskNumericPad` and `kCGEventFlagMaskSecondaryFn` in addition to any user-pressed modifiers. CGEventTap-based hotkey matchers (tiling window managers, accessibility tools) often check for those flags to disambiguate navigation keys from generic chords. Synthesized arrow chords without them fall through to the focused app instead of being captured by the WM.

Fix: set both flags on arrow key events (Mac key codes `0x7B`–`0x7E`).

```rust
if is_arrow_key(key) {
    flags |= CGEventFlags::CGEventFlagNumericPad | CGEventFlags::CGEventFlagSecondaryFn;
}
```

## Commit 2 — `macos: stop corrupting modifier state in repeat-task cleanup`

`spawn_repeat_task()` takes a Mac `CGKeyCode`, but the cleanup block was passing that value to `update_modifiers()`, which expects a Linux evdev scancode (it calls `scancode::Linux::try_from(key)`). The two codespaces collide on several values, silently clearing still-held modifiers when the repeat task is cancelled by a follow-up key:

| Mac code | Mac key | Linux scancode | Cleanup effect |
|---:|---|---|---|
| 56 | LeftShift | KeyLeftAlt (56) | **clears Mod1Mask** |
| 125 | Down arrow | KeyLeftMeta (125) | **clears Mod4Mask** |
| 126 | Up arrow | KeyRightMeta (126) | **clears Mod4Mask** |

This made `Shift+Option+X` arrive as `Shift+X` and `Cmd+Up`/`Cmd+Down` arrive without `Cmd` — see issue #440 for the full trace.

Fix: remove the buggy `update_modifiers` call. The main `consume()` loop already updates modifier state with the correct Linux scancode on the real release event.

## Verification

- Built with `cargo build --workspace` and `cargo bundle --release` on macOS 26 (Sequoia, arm64)
- `cargo clippy --workspace --all-targets --all-features`: clean
- `cargo fmt --check`: clean
- `cargo test --workspace`: passes (no unit tests for the macOS backend; `AGENTS.md` says \"OS-specific backends: test via GTK/CLI on target OS or document manual verification\")
- Manual verification on a Mac receiver with OmniWM and a Linux sender:
  - ✅ Option+Arrow → WM focus moves (was: focused app got the arrow)
  - ✅ Shift+Option+Arrow → both modifiers in flags
  - ✅ Option+1/2/3/4 → WM workspace switch (regression check, still works)
  - ✅ Shift+Option+1/2/3/4 → both modifiers in flags (was: only Shift)
  - ✅ Cmd+Up/Cmd+Down → Cmd in flags (was: missing)
  - ✅ Plain typing and Down-arrow auto-repeat behave normally (regression checks)

## Notes / follow-ups deliberately left out of this PR

- Other navigation keys (Home/End/PgUp/PgDn/ForwardDelete/Help/F-row) also carry `SecondaryFn` on hardware. They aren't part of the reported symptom, but a follow-up could extend the same pattern.
- Numeric-keypad number keys also carry `NumericPad`. Same situation.
- The cleanup still posts a `KeyUp` for the cancelled key even when the user hasn't released it (because a *different* key was pressed). This is independently questionable behavior but doesn't visibly misbehave once the codespace bug is fixed, so left alone.