### PR TITLE
Make layer-shell edge capture less fragile

### DIFF
--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -144,6 +144,10 @@ impl AsRawFd for Inner {
 
 pub struct LayerShellInputCapture(AsyncFd<Inner>);
 
+// A 1px layer can miss edge entry on compositors that clamp cursor
+// coordinates just inside the logical output bounds.
+const EDGE_CAPTURE_THICKNESS: u32 = 4;
+
 struct Window {
     buffer: wl_buffer::WlBuffer,
     surface: WlSurface,
@@ -163,8 +167,8 @@ impl Window {
         let g = &state.globals;
 
         let (width, height) = match pos {
-            Position::Left | Position::Right => (1, size.1 as u32),
-            Position::Top | Position::Bottom => (size.0 as u32, 1),
+            Position::Left | Position::Right => (EDGE_CAPTURE_THICKNESS, size.1 as u32),
+            Position::Top | Position::Bottom => (size.0 as u32, EDGE_CAPTURE_THICKNESS),
         };
         let mut file = tempfile::tempfile().unwrap();
         draw(&mut file, (width, height));


### PR DESCRIPTION
Layer-shell capture currently uses 1px edge surfaces. On at least Hyprland with a scaled output, the cursor can be clamped just inside the logical output bounds and never enter the 1px left-edge surface.\n\nIncreasing the capture thickness to 4px makes edge entry reliable while keeping the capture area narrow.\n\nTested with:\n- Hyprland\n- lan-mouse layer-shell capture backend\n- left-edge capture on a 2560x1440 logical output at scale 1.5\n\nChecks run:\n- cargo fmt --check\n- git diff --check\n- cargo test --no-default-features --features layer_shell_capture,wlroots_emulation