### PR TITLE
feat: add leave_hook symmetric to enter_hook

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,3 +32,8 @@ hostname = "thorium"
 ips = ["192.168.178.189", "192.168.178.172"]
 # optional port
 port = 4242
+# optional shell command run via `sh -c` when the cursor enters this client
+enter_hook = "notify-send 'entered thorium'"
+# optional shell command run via `sh -c` when capture for this client is
+# released (release_bind chord, peer Leave, or `cli deactivate`)
+leave_hook = "notify-send 'left thorium'"

--- a/lan-mouse-cli/src/lib.rs
+++ b/lan-mouse-cli/src/lib.rs
@@ -35,6 +35,8 @@ struct Client {
     ips: Option<Vec<IpAddr>>,
     #[arg(long)]
     enter_hook: Option<String>,
+    #[arg(long)]
+    leave_hook: Option<String>,
 }
 
 #[derive(Clone, Subcommand, Debug, PartialEq, Eq)]
@@ -88,6 +90,7 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
             port,
             ips,
             enter_hook,
+            leave_hook,
         }) => {
             tx.request(FrontendRequest::Create).await?;
             while let Some(e) = rx.next().await {
@@ -106,6 +109,10 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
                     }
                     if let Some(enter_hook) = enter_hook {
                         tx.request(FrontendRequest::UpdateEnterHook(handle, Some(enter_hook)))
+                            .await?;
+                    }
+                    if let Some(leave_hook) = leave_hook {
+                        tx.request(FrontendRequest::UpdateLeaveHook(handle, Some(leave_hook)))
                             .await?;
                     }
                     break;

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -140,6 +140,8 @@ pub struct ClientConfig {
     pub pos: Position,
     /// enter hook
     pub cmd: Option<String>,
+    /// leave hook
+    pub leave_cmd: Option<String>,
 }
 
 impl Default for ClientConfig {
@@ -150,6 +152,7 @@ impl Default for ClientConfig {
             fix_ips: Default::default(),
             pos: Default::default(),
             cmd: None,
+            leave_cmd: None,
         }
     }
 }
@@ -259,6 +262,8 @@ pub enum FrontendRequest {
     RemoveAuthorizedKey(String),
     /// change the hook command
     UpdateEnterHook(u64, Option<String>),
+    /// change the leave hook command
+    UpdateLeaveHook(u64, Option<String>),
     /// save config file
     SaveConfiguration,
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -37,6 +37,13 @@ pub(crate) enum ICaptureEvent {
     /// either the remote client leaving its device region,
     /// a new device entering the screen or the release bind.
     ClientEntered(u64),
+    /// The previously active client was left, i.e. capture
+    /// was released for the given handle. Mirrors
+    /// [`ICaptureEvent::ClientEntered`] for the leave side
+    /// and fires on every release path (release-bind chord,
+    /// remote `Leave`, explicit `Release` request, send
+    /// failure, or destroy of the active capture).
+    ClientLeft(u64),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -301,6 +308,16 @@ impl CaptureTask {
                         capture.create(h, p).await?;
                     }
                     CaptureRequest::Destroy(h) => {
+                        // If the capture we're tearing down is the
+                        // currently-active one, treat this as a
+                        // release for hook purposes. The release_capture
+                        // path also clears active_client and flushes
+                        // pressed-key state to the peer; without this,
+                        // `cli deactivate` (or a hostname change
+                        // re-creating the client) would skip leave_hook.
+                        if self.active_client == Some(h) {
+                            self.release_capture(capture).await?;
+                        }
                         self.remove_capture(h);
                         capture.destroy(h).await?;
                     }
@@ -368,7 +385,11 @@ impl CaptureTask {
         if let Err(e) = self.conn.send(event, handle).await {
             const DUR: Duration = Duration::from_millis(500);
             debounce!(PREV_LOG, DUR, log::warn!("releasing capture: {e}"));
-            capture.release().await?;
+            // Funnel through release_capture so the leave_hook
+            // fires and active_client is cleared (without this the
+            // active_client field would stay stale until the next
+            // Begin from a different handle).
+            self.release_capture(capture).await?;
         }
         Ok(())
     }
@@ -376,6 +397,13 @@ impl CaptureTask {
     async fn release_capture(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
         // If we have an active client, notify them we're leaving
         if let Some(handle) = self.active_client.take() {
+            // Surface the leave to the service layer so it can fire
+            // the per-client leave_hook. Sent before the network
+            // teardown below so we never race against the peer
+            // disappearing.
+            self.event_tx
+                .send(ICaptureEvent::ClientLeft(handle))
+                .expect("channel closed");
             // Synthesize key-up events for every key still held in the
             // capture's pressed_keys set BEFORE sending Leave. Without
             // this, pressing the release-bind chord (typically all four

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,7 @@ impl ClientManager {
             port: config_client.port,
             pos: config_client.pos,
             cmd: config_client.enter_hook,
+            leave_cmd: config_client.leave_hook,
         };
         let state = ClientState {
             active: config_client.active,
@@ -236,6 +237,13 @@ impl ClientManager {
         }
     }
 
+    /// update the leave hook command of the client
+    pub(crate) fn set_leave_hook(&self, handle: ClientHandle, leave_hook: Option<String>) {
+        if let Some((c, _s)) = self.clients.borrow_mut().get_mut(handle as usize) {
+            c.leave_cmd = leave_hook;
+        }
+    }
+
     /// set resolving status of the client
     pub(crate) fn set_resolving(&self, handle: ClientHandle, status: bool) {
         if let Some((_, s)) = self.clients.borrow_mut().get_mut(handle as usize) {
@@ -249,6 +257,14 @@ impl ClientManager {
             .borrow()
             .get(handle as usize)
             .and_then(|(c, _)| c.cmd.clone())
+    }
+
+    /// get the leave hook command
+    pub(crate) fn get_leave_cmd(&self, handle: ClientHandle) -> Option<String> {
+        self.clients
+            .borrow()
+            .get(handle as usize)
+            .and_then(|(c, _)| c.leave_cmd.clone())
     }
 
     /// returns all clients that are currently registered

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,7 @@ struct TomlClient {
     position: Option<Position>,
     activate_on_startup: Option<bool>,
     enter_hook: Option<String>,
+    leave_hook: Option<String>,
 }
 
 impl ConfigToml {
@@ -275,12 +276,14 @@ pub struct ConfigClient {
     pub pos: Position,
     pub active: bool,
     pub enter_hook: Option<String>,
+    pub leave_hook: Option<String>,
 }
 
 impl From<TomlClient> for ConfigClient {
     fn from(toml: TomlClient) -> Self {
         let active = toml.activate_on_startup.unwrap_or(false);
         let enter_hook = toml.enter_hook;
+        let leave_hook = toml.leave_hook;
         let hostname = toml.hostname;
         let ips = HashSet::from_iter(toml.ips.into_iter().flatten());
         let port = toml.port.unwrap_or(DEFAULT_PORT);
@@ -292,6 +295,7 @@ impl From<TomlClient> for ConfigClient {
             pos,
             active,
             enter_hook,
+            leave_hook,
         }
     }
 }
@@ -311,6 +315,7 @@ impl From<ConfigClient> for TomlClient {
         let position = Some(client.pos);
         let activate_on_startup = if client.active { Some(true) } else { None };
         let enter_hook = client.enter_hook;
+        let leave_hook = client.leave_hook;
         Self {
             hostname,
             host_name,
@@ -319,6 +324,7 @@ impl From<ConfigClient> for TomlClient {
             position,
             activate_on_startup,
             enter_hook,
+            leave_hook,
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -214,6 +214,9 @@ impl Service {
             FrontendRequest::UpdateEnterHook(handle, enter_hook) => {
                 self.update_enter_hook(handle, enter_hook)
             }
+            FrontendRequest::UpdateLeaveHook(handle, leave_hook) => {
+                self.update_leave_hook(handle, leave_hook)
+            }
             FrontendRequest::SaveConfiguration => self.save_config(),
         }
     }
@@ -229,6 +232,7 @@ impl Service {
                 pos: c.pos,
                 active: s.active,
                 enter_hook: c.cmd,
+                leave_hook: c.leave_cmd,
             })
             .collect();
         self.config.set_clients(clients);
@@ -350,6 +354,10 @@ impl Service {
             ICaptureEvent::ClientEntered(handle) => {
                 log::info!("entering client {handle} ...");
                 self.spawn_hook_command(handle);
+            }
+            ICaptureEvent::ClientLeft(handle) => {
+                log::info!("leaving client {handle} ...");
+                self.spawn_leave_hook_command(handle);
             }
         }
     }
@@ -573,6 +581,11 @@ impl Service {
         self.broadcast_client(handle);
     }
 
+    fn update_leave_hook(&mut self, handle: ClientHandle, leave_hook: Option<String>) {
+        self.client_manager.set_leave_hook(handle, leave_hook);
+        self.broadcast_client(handle);
+    }
+
     fn broadcast_client(&mut self, handle: ClientHandle) {
         let event = self
             .client_manager
@@ -592,6 +605,32 @@ impl Service {
                 Ok(c) => c,
                 Err(e) => {
                     log::warn!("could not execute cmd: {e}");
+                    return;
+                }
+            };
+            match child.wait().await {
+                Ok(s) => {
+                    if s.success() {
+                        log::info!("{cmd} exited successfully");
+                    } else {
+                        log::warn!("{cmd} exited with {s}");
+                    }
+                }
+                Err(e) => log::warn!("{cmd}: {e}"),
+            }
+        });
+    }
+
+    fn spawn_leave_hook_command(&self, handle: ClientHandle) {
+        let Some(cmd) = self.client_manager.get_leave_cmd(handle) else {
+            return;
+        };
+        tokio::task::spawn_local(async move {
+            log::info!("spawning leave command!");
+            let mut child = match Command::new("sh").arg("-c").arg(cmd.as_str()).spawn() {
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!("could not execute leave cmd: {e}");
                     return;
                 }
             };

--- a/src/service.rs
+++ b/src/service.rs
@@ -353,11 +353,11 @@ impl Service {
             }
             ICaptureEvent::ClientEntered(handle) => {
                 log::info!("entering client {handle} ...");
-                self.spawn_hook_command(handle);
+                self.spawn_hook_command(handle, HookKind::Enter);
             }
             ICaptureEvent::ClientLeft(handle) => {
                 log::info!("leaving client {handle} ...");
-                self.spawn_leave_hook_command(handle);
+                self.spawn_hook_command(handle, HookKind::Leave);
             }
         }
     }
@@ -595,55 +595,46 @@ impl Service {
         self.notify_frontend(event);
     }
 
-    fn spawn_hook_command(&self, handle: ClientHandle) {
-        let Some(cmd) = self.client_manager.get_enter_cmd(handle) else {
-            return;
+    fn spawn_hook_command(&self, handle: ClientHandle, kind: HookKind) {
+        let cmd = match kind {
+            HookKind::Enter => self.client_manager.get_enter_cmd(handle),
+            HookKind::Leave => self.client_manager.get_leave_cmd(handle),
         };
+        let Some(cmd) = cmd else { return };
         tokio::task::spawn_local(async move {
-            log::info!("spawning command!");
+            log::info!("spawning {kind} hook for client {handle}");
             let mut child = match Command::new("sh").arg("-c").arg(cmd.as_str()).spawn() {
                 Ok(c) => c,
                 Err(e) => {
-                    log::warn!("could not execute cmd: {e}");
+                    log::warn!("could not execute {kind} hook for client {handle}: {e}");
                     return;
                 }
             };
             match child.wait().await {
                 Ok(s) => {
                     if s.success() {
-                        log::info!("{cmd} exited successfully");
+                        log::info!("{kind} hook for client {handle} ({cmd}) exited successfully");
                     } else {
-                        log::warn!("{cmd} exited with {s}");
+                        log::warn!("{kind} hook for client {handle} ({cmd}) exited with {s}");
                     }
                 }
-                Err(e) => log::warn!("{cmd}: {e}"),
+                Err(e) => log::warn!("{kind} hook for client {handle} ({cmd}): {e}"),
             }
         });
     }
+}
 
-    fn spawn_leave_hook_command(&self, handle: ClientHandle) {
-        let Some(cmd) = self.client_manager.get_leave_cmd(handle) else {
-            return;
-        };
-        tokio::task::spawn_local(async move {
-            log::info!("spawning leave command!");
-            let mut child = match Command::new("sh").arg("-c").arg(cmd.as_str()).spawn() {
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("could not execute leave cmd: {e}");
-                    return;
-                }
-            };
-            match child.wait().await {
-                Ok(s) => {
-                    if s.success() {
-                        log::info!("{cmd} exited successfully");
-                    } else {
-                        log::warn!("{cmd} exited with {s}");
-                    }
-                }
-                Err(e) => log::warn!("{cmd}: {e}"),
-            }
-        });
+#[derive(Clone, Copy, Debug)]
+enum HookKind {
+    Enter,
+    Leave,
+}
+
+impl std::fmt::Display for HookKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HookKind::Enter => f.write_str("enter"),
+            HookKind::Leave => f.write_str("leave"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Mirrors the existing `enter_hook` mechanism with a `leave_hook` that fires when capture for a client is released.

Motivation: external scripts that change host state on cross (e.g. swapping keyboard layout, toggling natural scroll, repositioning windows) currently have no symmetric "you're back" signal — `enter_hook` fires deterministically but the only way to detect release today is to poll `hyprctl cursorpos` / similar, which is fragile because the local cursor isn't actually pinned during capture on Wayland.

## Design

A single new IPC capture event `ICaptureEvent::ClientLeft(handle)` emitted from `release_capture()` in `src/capture.rs`. Every release path funnels through that function:

- release_bind chord
- peer `Leave` event over the wire
- `CaptureRequest::Destroy` when the active client is being torn down (with an explicit note about hostname-change client recreation)
- `CaptureRequest::Release`

Wiring otherwise exactly mirrors `enter_hook`:

| Layer | enter_hook | leave_hook |
|---|---|---|
| `src/config.rs` | `enter_hook: Option<String>` | + `leave_hook: Option<String>` |
| `lan-mouse-ipc/src/lib.rs` | `enter_cmd` on `ClientConfig`, `UpdateEnterHook` request | + `leave_cmd`, `UpdateLeaveHook` |
| `src/client.rs` | `set_enter_hook` / `get_enter_cmd` | + `set_leave_hook` / `get_leave_cmd` |
| `src/service.rs` | `update_enter_hook`, `spawn_hook_command`, dispatch on `ClientEntered` | + `update_leave_hook`, `spawn_leave_hook_command`, dispatch on `ClientLeft` |
| `lan-mouse-cli/src/lib.rs` | `--enter-hook` flag on `add-client` | + `--leave-hook` flag |

## Docs

The existing `enter_hook` has been undocumented since #130. Second commit backfills both in the example `config.toml` so the per-client hook surface is discoverable.

## Out of scope

- GUI surface in `lan-mouse-gtk` for the new field (text-config only for now)
- Unit tests (no test infrastructure exists in the project today; manual smoke-tested with `notify-send` hooks across crossing + release_bind release on Wayland/Hyprland)

## Test plan

- [x] Builds clean: `cargo build --release` (1m 20s, no warnings)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] Manual smoke: `enter_hook` and `leave_hook` set to `notify-send` strings, daemon restarted from built binary, cross to client and release via chord — both notifications fire as expected
- [x] Verify behavior with peer-initiated `Leave` (cross-back from the remote side)
- [x] Verify behavior on `cli deactivate` of the active client