### PR TITLE
fix(macos): undo natural scrolling inversion in captured scroll events

### DIFF
--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -12,7 +12,7 @@ use core_graphics::{
     base::{CGError, kCGErrorSuccess},
     display::{CGDisplay, CGPoint},
     event::{
-        CGEvent, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
+        CGEvent, CGEventField, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
         CGEventTapPlacement, CGEventTapProxy, CGEventType, CallbackResult, EventField,
     },
     event_source::{CGEventSource, CGEventSourceStateID},
@@ -357,11 +357,34 @@ fn get_events(
             })))
         }
         CGEventType::ScrollWheel => {
+            // macOS applies the user's "Natural Scrolling" preference to all
+            // scroll delta fields before they reach the event tap. When natural
+            // scrolling is active the deltas represent content-movement
+            // direction, which is the opposite of the hardware (wheel rotation)
+            // direction that Linux and Windows expect.
+            //
+            // CGEvent field 137 corresponds to NSEvent.isDirectionInvertedFromDevice
+            // and is non-zero when the system has inverted the scroll direction.
+            // Not exposed by the core-graphics crate; the value is defined in
+            // Apple's CGEventTypes.h and is widely relied upon by established
+            // macOS input utilities (mac-mouse-fix, iina, Scroll Reverser, etc.).
+            //
+            // We undo that inversion here so the network protocol always carries
+            // device-direction deltas — each receiving OS can then apply its own
+            // scroll preference independently.
+            const DIRECTION_INVERTED_FROM_DEVICE: CGEventField = 137;
+            let direction_inverted =
+                ev.get_integer_value_field(DIRECTION_INVERTED_FROM_DEVICE) != 0;
+
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
-                let v =
+                let mut v =
                     ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
-                let h =
+                let mut h =
                     ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
+                if direction_inverted {
+                    v = -v;
+                    h = -h;
+                }
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
@@ -380,8 +403,12 @@ fn get_events(
                 // line based scrolling
                 const LINES_PER_STEP: i32 = 3;
                 const V120_STEPS_PER_LINE: i32 = 120 / LINES_PER_STEP;
-                let v = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
-                let h = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
+                let mut v = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
+                let mut h = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
+                if direction_inverted {
+                    v = -v;
+                    h = -h;
+                }
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {


### PR DESCRIPTION
Closes #451

## Problem

When Natural Scrolling is enabled on the macOS sending side (the default on MacBooks), the system inverts scroll deltas before they reach the CGEvent tap. This causes remote clients to receive content-movement direction instead of device/wheel direction, resulting in inverted scrolling on the receiving end.

## Fix

Check CGEvent field 137 (`isDirectionInvertedFromDevice`) — non-zero when the system has inverted scroll direction. When set, negate both continuous (trackpad) and discrete (mouse wheel) scroll deltas before sending them over the network.

This ensures the protocol always carries device-direction deltas, allowing each receiving OS to apply its own scroll preference independently.

Field 137 is defined in Apple's `CGEventTypes.h` and is widely used by established macOS input utilities (mac-mouse-fix, Scroll Reverser, IINA, etc.).

## Changes

- `input-capture/src/macos.rs`: Read `DIRECTION_INVERTED_FROM_DEVICE` (field 137) on scroll events and negate deltas when the system has inverted them. Applies to both continuous (`SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_{1,2}`) and discrete (`SCROLL_WHEEL_EVENT_DELTA_AXIS_{1,2}`) scroll paths.