### PR TITLE
fix(macos): correct scroll direction for remote clients

### DIFF
--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -12,7 +12,7 @@ use core_graphics::{
     base::{CGError, kCGErrorSuccess},
     display::{CGDisplay, CGPoint},
     event::{
-        CGEvent, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
+        CGEvent, CGEventField, CGEventFlags, CGEventTap, CGEventTapLocation, CGEventTapOptions,
         CGEventTapPlacement, CGEventTapProxy, CGEventType, CallbackResult, EventField,
     },
     event_source::{CGEventSource, CGEventSourceStateID},
@@ -357,11 +357,20 @@ fn get_events(
             })))
         }
         CGEventType::ScrollWheel => {
+            // macOS scroll deltas use the opposite sign convention
+            // from evdev when Natural Scrolling is OFF. When it is ON
+            // the system already negates the deltas, matching evdev.
+            // Field 137 = isDirectionInvertedFromDevice (non-zero when
+            // Natural Scrolling is active).
+            const DIRECTION_INVERTED_FROM_DEVICE: CGEventField = 137;
+            let natural = ev.get_integer_value_field(DIRECTION_INVERTED_FROM_DEVICE) != 0;
+            let sign: i64 = if natural { 1 } else { -1 };
+
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
-                let v =
-                    ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
-                let h =
-                    ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
+                let v = sign
+                    * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
+                let h = sign
+                    * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2);
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
@@ -380,8 +389,10 @@ fn get_events(
                 // line based scrolling
                 const LINES_PER_STEP: i32 = 3;
                 const V120_STEPS_PER_LINE: i32 = 120 / LINES_PER_STEP;
-                let v = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
-                let h = ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
+                let v =
+                    sign * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
+                let h =
+                    sign * ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
                 if v != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {


### PR DESCRIPTION
Closes #451

## Problem

macOS scroll deltas use the opposite sign convention from evdev when Natural Scrolling is OFF. When Natural Scrolling is ON, the system negates the deltas, which happens to match evdev. This causes remote Linux/Windows clients to receive inverted scroll events depending on the macOS sender's scroll preference.

## Fix

Read CGEvent field 137 (`isDirectionInvertedFromDevice`) to detect whether Natural Scrolling is active. When it is not, negate both continuous (trackpad) and discrete (mouse wheel) scroll deltas so the network protocol always carries evdev-compatible values.

Field 137 corresponds to `NSEvent.isDirectionInvertedFromDevice` and is defined in Apple's `CGEventTypes.h`.

## Testing

Verified on macOS (Apple Silicon) with both Natural Scrolling ON and OFF — scroll direction on Linux remote client is now correct in both cases.

## Changes

- `input-capture/src/macos.rs`: Check `isDirectionInvertedFromDevice` and conditionally negate scroll deltas for both continuous and discrete scroll paths.