### PR TITLE
include commit hash in pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,8 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: ${{ github.event.inputs.name || github.ref_name }}
-        name: ${{ github.event.inputs.name || github.ref_name }}
+        tag_name: ${{ format('{0}-{1}', github.event.inputs.name || github.ref_name, substring(github.sha, 0, 7)) }}
+        name: ${{ format('{0}-{1}', github.event.inputs.name || github.ref_name, substring(github.sha, 0, 7)) }}
         prerelease: true
         generate_release_notes: true
         files: |


### PR DESCRIPTION
this solves the "create new release" issue as well as tag conflicts with branch name