### PR TITLE
fix(macos): modifier-key injection for apps & VM guests, scroll, and Caps Lock (#450)

### DIFF
--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -279,6 +279,60 @@ fn modifier_flags_changed_flags(depressed: XMods) -> CGEventFlags {
     CGEventFlags::from_bits_retain(flags.bits() | device_bits)
 }
 
+/// Reads the global "natural scrolling" preference (`com.apple.swipescrolldirection`).
+///
+/// macOS applies this preference to scroll events from *real* devices but NOT to
+/// synthetic `CGEvent`s, so injected scrolling ignores it and feels backwards on
+/// a Mac whose owner uses the default (natural) setting. We read the preference
+/// ourselves and flip the sign so injected scrolling matches what a physical
+/// trackpad/mouse would do on *this* Mac — i.e. we honour the receiver's own
+/// preference rather than inheriting the sender's scroll convention.
+///
+/// An absent key means `true` (the modern macOS default). A change to the setting
+/// is picked up on the next scroll event.
+fn natural_scroll_enabled() -> bool {
+    use std::ffi::{c_char, c_void};
+    type CFTypeRef = *const c_void;
+    type CFStringRef = *const c_void;
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(
+            alloc: CFTypeRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CFStringRef;
+        fn CFPreferencesCopyAppValue(key: CFStringRef, application_id: CFStringRef) -> CFTypeRef;
+        fn CFRelease(cf: CFTypeRef);
+        static kCFPreferencesAnyApplication: CFStringRef;
+        static kCFBooleanTrue: CFTypeRef;
+    }
+
+    unsafe {
+        let key = CFStringCreateWithCString(
+            std::ptr::null(),
+            c"com.apple.swipescrolldirection".as_ptr(),
+            K_CF_STRING_ENCODING_UTF8,
+        );
+        if key.is_null() {
+            return true;
+        }
+        let value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication);
+        CFRelease(key);
+        match value.is_null() {
+            // key not set => modern default is natural scrolling
+            true => true,
+            false => {
+                let enabled = value == kCFBooleanTrue;
+                CFRelease(value);
+                enabled
+            }
+        }
+    }
+}
+
 fn get_display_at_point(x: CGFloat, y: CGFloat) -> Option<CGDirectDisplayID> {
     let mut displays: [CGDirectDisplayID; 16] = [0; 16];
     let mut display_count: u32 = 0;
@@ -485,7 +539,16 @@ impl Emulation for MacOSEmulation {
                         axis,
                         value,
                     } => {
+                        // macOS does not apply the "natural scrolling" preference to
+                        // synthetic events, so honour the receiver's own preference
+                        // here (see natural_scroll_enabled) — injected scrolling then
+                        // feels native on this Mac regardless of the sender's OS.
                         let value = value as i32;
+                        let value = if natural_scroll_enabled() {
+                            -value
+                        } else {
+                            value
+                        };
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value, 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value, 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)
@@ -512,6 +575,13 @@ impl Emulation for MacOSEmulation {
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         const LINES_PER_STEP: i32 = 3;
+                        // honour the receiver's natural-scroll preference (see the
+                        // Axis arm above and natural_scroll_enabled).
+                        let value = if natural_scroll_enabled() {
+                            -value
+                        } else {
+                            value
+                        };
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value / (120 / LINES_PER_STEP), 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value / (120 / LINES_PER_STEP), 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -202,16 +202,81 @@ fn key_event(event_source: CGEventSource, key: u16, state: u8, modifiers: XMods)
     log::trace!("key event: {key} {state}");
 }
 
-fn modifier_event(event_source: CGEventSource, depressed: XMods) {
-    let Ok(event) = CGEvent::new(event_source) else {
-        log::warn!("could not create CGEvent");
+/// Posts a `FlagsChanged` event for a modifier key.
+///
+/// The event MUST carry the modifier's real virtual keycode. A bare
+/// `CGEvent::new()` defaults to keycode 0 (`kVK_ANSI_A`), so every modifier
+/// change arrived in apps as a phantom "A" key event — holding Ctrl registered
+/// as Ctrl+A and shortcut recorders captured "A" (issue #450).
+///
+/// Carrying the real keycode also matters for consumers that track *physical*
+/// modifier transitions through AppKit's `flagsChanged(with:)` rather than the
+/// flags on the key-down event — notably Apple Virtualization.framework guest
+/// views (`VZVirtualMachineView`), which derive guest modifier state from these
+/// `FlagsChanged` events. The event is built as a key-down so it gets a valid
+/// keycode; the type is then overridden to `FlagsChanged` and the *current*
+/// modifier flags (already updated by the caller) describe the new state.
+fn modifier_key_event(event_source: CGEventSource, key: u16, depressed: XMods) {
+    let Ok(event) = CGEvent::new_keyboard_event(event_source, key, true) else {
+        log::warn!("could not create modifier key event");
         return;
     };
-    let flags = to_cgevent_flags(depressed);
     event.set_type(CGEventType::FlagsChanged);
-    event.set_flags(flags);
+    event.set_flags(modifier_flags_changed_flags(depressed));
     event.post(CGEventTapLocation::HID);
-    log::trace!("modifiers updated: {depressed:?}");
+    log::trace!("modifier key event: {key} {depressed:?}");
+}
+
+/// Builds the flag set for a modifier `FlagsChanged` event.
+///
+/// Combines the device-INDEPENDENT modifier word (what ordinary AppKit apps
+/// read) with the device-DEPENDENT low-word bits (IOKit `NX_DEVICE*KEYMASK` from
+/// `IOKit/hidsystem/IOLLEvent.h`) that a real hardware keyboard sets.
+///
+/// This matters for Apple Virtualization.framework guest views
+/// (`VZVirtualMachineView`, used by UTM's Apple backend, Parallels' macOS
+/// guests, VirtualBuddy, etc.): they derive the guest's modifier state from the
+/// `flagsChanged(with:)` responder method and read the device-dependent low
+/// word, not the per-key flags. macOS does NOT synthesize the low-word bits for
+/// posted (synthetic) events, so until we set them ourselves Cmd/Ctrl/Shift/Opt
+/// chords reached the guest unmodified (Shift+2 → "2", Cmd+C did nothing).
+///
+/// Ordinary apps mask incoming events to the device-independent word
+/// (`deviceIndependentFlagsMask`) and ignore these bits, so emitting them is
+/// hardware-faithful and safe for every app — no VM/bundle-id detection is
+/// required. See issue #450 and https://developer.apple.com/forums/thread/766014
+fn modifier_flags_changed_flags(depressed: XMods) -> CGEventFlags {
+    // Device-dependent left/right modifier bits (IOLLEvent.h). lan-mouse collapses
+    // left and right modifiers into a single mask, so we emit the left-hand device
+    // bit; AltGr (Mod5 / ISO_Level3_Shift) is physically the right Alt, so it maps
+    // to the right Option bit.
+    const NX_DEVICE_L_CTRL: u64 = 0x0000_0001;
+    const NX_DEVICE_L_SHIFT: u64 = 0x0000_0002;
+    const NX_DEVICE_L_CMD: u64 = 0x0000_0008;
+    const NX_DEVICE_L_ALT: u64 = 0x0000_0020;
+    const NX_DEVICE_R_ALT: u64 = 0x0000_0040;
+
+    let mut device_bits: u64 = 0;
+    if depressed.contains(XMods::ShiftMask) {
+        device_bits |= NX_DEVICE_L_SHIFT;
+    }
+    if depressed.contains(XMods::ControlMask) {
+        device_bits |= NX_DEVICE_L_CTRL;
+    }
+    if depressed.contains(XMods::Mod1Mask) {
+        device_bits |= NX_DEVICE_L_ALT;
+    }
+    if depressed.contains(XMods::Mod5Mask) {
+        device_bits |= NX_DEVICE_R_ALT;
+    }
+    if depressed.contains(XMods::Mod4Mask) {
+        device_bits |= NX_DEVICE_L_CMD;
+    }
+
+    // CGEventFlagNonCoalesced is bit 8 (0x100), the marker a real hardware
+    // FlagsChanged carries on both press and release; VZ expects it present.
+    let flags = to_cgevent_flags(depressed) | CGEventFlags::CGEventFlagNonCoalesced;
+    CGEventFlags::from_bits_retain(flags.bits() | device_bits)
 }
 
 fn get_display_at_point(x: CGFloat, y: CGFloat) -> Option<CGDirectDisplayID> {
@@ -493,12 +558,23 @@ impl Emulation for MacOSEmulation {
                     };
                     let is_modifier = update_modifiers(&self.modifier_state, key, state);
                     if is_modifier {
-                        modifier_event(self.event_source.clone(), self.modifier_state.get());
-                    }
-                    match state {
-                        // pressed
-                        1 => self.spawn_repeat_task(code).await,
-                        _ => self.cancel_repeat_task().await,
+                        // Modifier keys are posted as FlagsChanged events carrying
+                        // their real keycode (see modifier_key_event). They must NOT
+                        // enter the key-repeat machinery: there is only one repeat
+                        // slot, so pressing a second modifier would cancel the first
+                        // modifier's repeat task and post a keyUp while it is still
+                        // physically held, tearing chords apart (issue #450, #357).
+                        modifier_key_event(
+                            self.event_source.clone(),
+                            code,
+                            self.modifier_state.get(),
+                        );
+                    } else {
+                        match state {
+                            // pressed
+                            1 => self.spawn_repeat_task(code).await,
+                            _ => self.cancel_repeat_task().await,
+                        }
                     }
                 }
                 KeyboardEvent::Modifiers {
@@ -507,8 +583,13 @@ impl Emulation for MacOSEmulation {
                     locked,
                     group,
                 } => {
+                    // Only update internal modifier state here. The per-key handler
+                    // above already posts a FlagsChanged event (with the real
+                    // keycode) for each modifier Key event the client sends
+                    // alongside this state update. Posting one here as well would
+                    // duplicate it — and with the old bare CGEvent it injected a
+                    // phantom keycode-0 ("A") key on every modifier change (#450).
                     set_modifiers(&self.modifier_state, depressed, latched, locked, group);
-                    modifier_event(self.event_source.clone(), self.modifier_state.get());
                 }
             },
         }
@@ -576,7 +657,11 @@ fn to_cgevent_flags(depressed: XMods) -> CGEventFlags {
     if depressed.contains(XMods::ControlMask) {
         flags |= CGEventFlags::CGEventFlagControl;
     }
-    if depressed.contains(XMods::Mod1Mask) {
+    // Mod1 is Alt. Mod5 is ISO_Level3_Shift (AltGr), which is how the Alt key is
+    // reported on many xkb keymaps (including COSMIC's default) in the wholesale
+    // Modifiers state events. Map both to Option so Alt/Option chords are not
+    // silently dropped (issue #450).
+    if depressed.contains(XMods::Mod1Mask) || depressed.contains(XMods::Mod5Mask) {
         flags |= CGEventFlags::CGEventFlagAlternate;
     }
     if depressed.contains(XMods::Mod4Mask) {

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -676,9 +676,23 @@ impl Emulation for MacOSEmulation {
 
 fn update_modifiers(modifiers: &Cell<XMods>, key: u32, state: u8) -> bool {
     if let Ok(key) = scancode::Linux::try_from(key) {
+        // Caps Lock is a LOCKING modifier: a press toggles a persistent state
+        // rather than being active only while physically held. Toggle on
+        // key-down and ignore key-up, so the AlphaShift flag stays set on every
+        // following keystroke until Caps Lock is pressed again. (A synthetic
+        // CGEvent can't flip the hardware Caps Lock LED, but carrying the flag
+        // produces the correct upper-case output — and, like real Caps Lock,
+        // leaves the number-row symbols unshifted.)
+        if matches!(key, scancode::Linux::KeyCapsLock) {
+            if state == 1 {
+                let mut mods = modifiers.get();
+                mods.toggle(XMods::LockMask);
+                modifiers.set(mods);
+            }
+            return true;
+        }
         let mask = match key {
             scancode::Linux::KeyLeftShift | scancode::Linux::KeyRightShift => XMods::ShiftMask,
-            scancode::Linux::KeyCapsLock => XMods::LockMask,
             scancode::Linux::KeyLeftCtrl | scancode::Linux::KeyRightCtrl => XMods::ControlMask,
             scancode::Linux::KeyLeftAlt | scancode::Linux::KeyRightalt => XMods::Mod1Mask,
             scancode::Linux::KeyLeftMeta | scancode::Linux::KeyRightmeta => XMods::Mod4Mask,

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -288,48 +288,39 @@ fn modifier_flags_changed_flags(depressed: XMods) -> CGEventFlags {
 /// trackpad/mouse would do on *this* Mac — i.e. we honour the receiver's own
 /// preference rather than inheriting the sender's scroll convention.
 ///
-/// An absent key means `true` (the modern macOS default). A change to the setting
-/// is picked up on the next scroll event.
+/// An absent or non-boolean key means `true` (the modern macOS default). A change
+/// to the setting is picked up on the next scroll event.
 fn natural_scroll_enabled() -> bool {
-    use std::ffi::{c_char, c_void};
-    type CFTypeRef = *const c_void;
-    type CFStringRef = *const c_void;
+    use core_foundation::base::TCFType;
+    use core_foundation::string::CFString;
+    use core_foundation_sys::base::Boolean;
+    use core_foundation_sys::preferences::{
+        CFPreferencesGetAppBooleanValue, kCFPreferencesAnyApplication,
+    };
 
-    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+    let key = CFString::new("com.apple.swipescrolldirection");
+    let mut exists: Boolean = 0;
+    // SAFETY: `key` outlives the call; kCFPreferencesAnyApplication is a CF constant.
+    let enabled = unsafe {
+        CFPreferencesGetAppBooleanValue(
+            key.as_concrete_TypeRef(),
+            kCFPreferencesAnyApplication,
+            &mut exists,
+        )
+    };
+    // Absent / non-boolean key => modern macOS default is natural scrolling.
+    if exists != 0 { enabled != 0 } else { true }
+}
 
-    #[link(name = "CoreFoundation", kind = "framework")]
-    extern "C" {
-        fn CFStringCreateWithCString(
-            alloc: CFTypeRef,
-            c_str: *const c_char,
-            encoding: u32,
-        ) -> CFStringRef;
-        fn CFPreferencesCopyAppValue(key: CFStringRef, application_id: CFStringRef) -> CFTypeRef;
-        fn CFRelease(cf: CFTypeRef);
-        static kCFPreferencesAnyApplication: CFStringRef;
-        static kCFBooleanTrue: CFTypeRef;
-    }
-
-    unsafe {
-        let key = CFStringCreateWithCString(
-            std::ptr::null(),
-            c"com.apple.swipescrolldirection".as_ptr(),
-            K_CF_STRING_ENCODING_UTF8,
-        );
-        if key.is_null() {
-            return true;
-        }
-        let value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication);
-        CFRelease(key);
-        match value.is_null() {
-            // key not set => modern default is natural scrolling
-            true => true,
-            false => {
-                let enabled = value == kCFBooleanTrue;
-                CFRelease(value);
-                enabled
-            }
-        }
+/// Applies the receiver's natural-scroll preference to a scroll delta.
+///
+/// `saturating_neg` guards against a malformed `i32::MIN` arriving from the wire
+/// (plain negation of `i32::MIN` would overflow).
+fn apply_natural_scroll(value: i32) -> i32 {
+    if natural_scroll_enabled() {
+        value.saturating_neg()
+    } else {
+        value
     }
 }
 
@@ -539,16 +530,9 @@ impl Emulation for MacOSEmulation {
                         axis,
                         value,
                     } => {
-                        // macOS does not apply the "natural scrolling" preference to
-                        // synthetic events, so honour the receiver's own preference
-                        // here (see natural_scroll_enabled) — injected scrolling then
-                        // feels native on this Mac regardless of the sender's OS.
-                        let value = value as i32;
-                        let value = if natural_scroll_enabled() {
-                            -value
-                        } else {
-                            value
-                        };
+                        // honour the receiver's natural-scroll preference (macOS
+                        // doesn't apply it to synthetic events); see apply_natural_scroll.
+                        let value = apply_natural_scroll(value as i32);
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value, 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value, 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)
@@ -575,13 +559,7 @@ impl Emulation for MacOSEmulation {
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         const LINES_PER_STEP: i32 = 3;
-                        // honour the receiver's natural-scroll preference (see the
-                        // Axis arm above and natural_scroll_enabled).
-                        let value = if natural_scroll_enabled() {
-                            -value
-                        } else {
-                            value
-                        };
+                        let value = apply_natural_scroll(value);
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value / (120 / LINES_PER_STEP), 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value / (120 / LINES_PER_STEP), 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)


### PR DESCRIPTION
## Problem

On macOS, lan-mouse injects keystrokes via `CGEvent` posted to the HID tap. Plain typing worked, but modifier chords were broken in several ways (#450):

- holding a modifier injected a phantom **"A"** (a bare `CGEvent` defaults to keycode 0 = `kVK_ANSI_A`), breaking hotkey listeners and shortcut recorders;
- modifiers were torn down by the single-slot **key-repeat task** (sticky / dropped modifiers — also #357);
- **AltGr / `Mod5`** was dropped, so Alt/Option chords silently lost Option;
- and even with correct flags, modifier chords did **not** register inside Apple **Virtualization.framework** guest windows (`VZVirtualMachineView`) — e.g. `Shift+2` produced `2`, `Cmd`/`Ctrl` combos did nothing.

Scroll direction was also wrong on the receiving Mac — it ignored the Mac's own *Natural scrolling* setting.

## Fix

### Modifiers (commit 1)

**Layer 1 — the four `CGEvent` bugs from #450 (diagnosed and originally patched by @bmajewski):**
1. `FlagsChanged` events now carry the modifier's **real keycode** (was a bare `CGEvent` → keycode 0 → phantom "A").
2. Modifier keys no longer enter the key-repeat machinery, so a second modifier no longer releases the first while it's still held.
3. The wholesale `Modifiers` state handler only updates internal state now (no duplicate / phantom-"A" post).
4. `to_cgevent_flags()` maps both `Mod1` and `Mod5` (AltGr) to Option.

**Layer 2 — Virtualization.framework guest modifiers:**
`VZVirtualMachineView` derives guest modifier state from AppKit's `flagsChanged(with:)` and reads the **device-dependent low-word** flag bits, which macOS does **not** synthesize for posted (synthetic) events. The synthetic `FlagsChanged` now also sets the IOKit `NX_DEVICE*KEYMASK` bits + `CGEventFlagNonCoalesced`, making it byte-faithful to a real hardware modifier event. Ordinary apps mask incoming events to the device-independent word and ignore these bits, so this is safe for every app and needs **no VM/bundle-id detection**.

> Note: the forums-documented NSEvent / `NSWindow.postEvent` approach is in-process only and can't work from a separate process like lan-mouse. Setting the device-dependent bits on the `CGEvent` is the cross-process equivalent. See https://developer.apple.com/forums/thread/766014

### Scroll (commit 2 — separable)

macOS applies *Natural scrolling* to real input devices but not to synthetic events. The receiver now reads its own `com.apple.swipescrolldirection` and flips the scroll sign accordingly — honouring the **receiver's** preference (Synergy-style) rather than the sender's convention. Kept as its own commit so it can be dropped independently.

> **Known limitation:** this fixes the common cross-OS case (a non-macOS sender → macOS receiver, where the wire delta is in a fixed convention). When *both* peers are macOS with natural scrolling enabled, the macOS sender already forwards a natural-oriented delta, so the receiver-side flip double-inverts; fixing that cleanly needs scroll normalization on the macOS *capture* side, which is out of scope for this PR. The same double-inversion shows up when scrolling into a **nested macOS VM guest** (e.g. a Parallels macOS guest), since the guest OS applies its *own* natural-scrolling on top of the receiver-side flip — workaround: disable Natural Scrolling in the guest.

### Caps Lock (commit 3)

Rerouting modifiers out of the key-repeat path (above) made Caps Lock momentary, because it's classified as a modifier. Caps Lock is a *locking* modifier, so `update_modifiers()` now toggles it on key-down and ignores key-up — it latches correctly. (A synthetic `CGEvent` can't flip the hardware Caps Lock LED, but the typed output is correct, and number-row symbols stay unshifted like real Caps Lock.)

## Hypervisor coverage

Layer 2 targets `VZVirtualMachineView` specifically, so it covers every Apple Virtualization.framework guest: **UTM's Apple-Virtualization backend, Parallels Desktop macOS guests, VirtualBuddy**, and Apple's own Virtualization samples. Hypervisors with their own input layers (UTM-QEMU, VMware Fusion, VirtualBox) use different code paths and aren't addressed here — though Layer 1 still improves normal modifier handling everywhere.

## Testing

Tested end-to-end on a **Windows 11 sender → macOS client**:
- modifier chords (`Shift+2` → `@`, `Cmd+C`/`Cmd+V`, `Ctrl` and `Option` combos) in normal macOS apps **and inside a Parallels macOS guest** ✅
- scroll direction correct on the Mac, and it tracks the macOS *Natural scrolling* toggle ✅
- Caps Lock latches (tap → capitals, tap again → lowercase) ✅ — the hardware LED doesn't light (synthetic-event limitation), but typed output is correct

## References
- Issue: #450 (root-cause analysis and original patch by @bmajewski)
- Apple Developer Forums: https://developer.apple.com/forums/thread/766014

---

Co-developed with **Claude Opus 4.8** · 🤖 Generated with [Claude Code](https://claude.com/claude-code)

