### PR TITLE
linux: run as tray icon app with StatusNotifierItem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9eeb3f510b6148ae68f963af2c1fbb0de4d9e4e05f82813cfb319837c3ad2b"
+dependencies = [
+ "futures-util",
+ "pastey",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "lan-mouse"
 version = "0.11.0"
 dependencies = [
@@ -1796,6 +1809,7 @@ dependencies = [
  "glib-build-tools",
  "gtk4",
  "hostname",
+ "ksni",
  "lan-mouse-ipc",
  "libadwaita",
  "log",
@@ -2228,6 +2242,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"

--- a/README.md
+++ b/README.md
@@ -318,6 +318,23 @@ It is of the form "aa:bb:cc:..."
 Authorized devices can be persisted using the configuration file (see [Configuration](#configuration)).
 
 If the device still can not be entered, make sure you have UDP port `4242` (or the one selected) opened up in your firewall.
+
+#### Tray icon (Linux & macOS)
+
+On macOS and on Linux desktops with a system tray, Lan Mouse runs as a tray icon application:
+Closing the window only hides it and Lan Mouse keeps running in the tray,
+where the icon offers a menu to re-open the window or quit the app entirely.
+Launching `lan-mouse` while it is already running re-presents the window of the running instance.
+Set `LAN_MOUSE_HIDDEN=1` in the environment to start quietly into the tray without opening the window.
+
+On Linux the tray icon uses the StatusNotifierItem specification, which is supported
+out of the box on most desktops (KDE Plasma, XFCE, waybar, ...).
+GNOME requires the [AppIndicator extension](https://extensions.gnome.org/extension/615/appindicator-support/).
+If no tray is available, Lan Mouse falls back to the previous behavior: closing the window quits the app.
+
+When the GUI connects to an already running daemon (e.g. the [systemd service](#systemd-service)),
+it acts as a plain client window instead: no tray icon is created and closing the window
+only quits the GUI, leaving the daemon running.
 </details>
 
 <details>

--- a/lan-mouse-gtk/Cargo.toml
+++ b/lan-mouse-gtk/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.20"
 lan-mouse-ipc = { path = "../lan-mouse-ipc", version = "0.3.0" }
 thiserror = "2.0.0"
 
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 ksni = { version = "0.3.5", features = ["blocking"] }
 
 [build-dependencies]

--- a/lan-mouse-gtk/Cargo.toml
+++ b/lan-mouse-gtk/Cargo.toml
@@ -15,5 +15,8 @@ log = "0.4.20"
 lan-mouse-ipc = { path = "../lan-mouse-ipc", version = "0.3.0" }
 thiserror = "2.0.0"
 
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+ksni = { version = "0.3.5", features = ["blocking"] }
+
 [build-dependencies]
 glib-build-tools = { version = "0.20.0" }

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -4,6 +4,8 @@ mod client_row;
 mod fingerprint_window;
 mod key_object;
 mod key_row;
+#[cfg(all(unix, not(target_os = "macos")))]
+mod linux_status_item;
 #[cfg(target_os = "macos")]
 mod macos_privacy;
 #[cfg(target_os = "macos")]
@@ -20,6 +22,13 @@ use window::Window;
 /// peer's [`lan_mouse_ipc::ClientState::peer_commit`] for the
 /// soft-warn version-mismatch indicator.
 pub(crate) static LOCAL_COMMIT: OnceLock<[u8; 8]> = OnceLock::new();
+
+/// Whether the lan-mouse service is a child of this process, set once
+/// by [`run`] before the GTK main loop starts. When `false` the GUI is
+/// a pure client of an external daemon (e.g. a systemd service): it
+/// then runs as a plain window — no tray icon, closing the window
+/// quits the frontend and leaves the daemon untouched.
+pub(crate) static OWNS_SERVICE: OnceLock<bool> = OnceLock::new();
 
 /// Convenience: returns the local commit as an 8-char ASCII string,
 /// or a placeholder if unset (which would indicate a programmer
@@ -49,11 +58,14 @@ pub enum GtkError {
     NonZeroExitCode(i32),
 }
 
-pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
+pub fn run(local_commit: [u8; 8], owns_service: bool) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
     LOCAL_COMMIT
         .set(local_commit)
         .expect("local_commit set once");
+    OWNS_SERVICE
+        .set(owns_service)
+        .expect("owns_service set once");
 
     #[cfg(windows)]
     let ret = std::thread::Builder::new()
@@ -199,6 +211,15 @@ fn setup_menu(app: &adw::Application) {
 }
 
 fn build_ui(app: &Application) {
+    // GApplication is single-instance: launching the binary again
+    // activates the primary instance instead. Re-present the existing
+    // window rather than building a second UI — this is the "reopen"
+    // path while the window is hidden in the tray.
+    if let Some(window) = app.windows().into_iter().next() {
+        window.present();
+        return;
+    }
+
     log::debug!("connecting to lan-mouse-socket");
     let (mut frontend_rx, frontend_tx) = match lan_mouse_ipc::connect() {
         Ok(conn) => conn,
@@ -260,6 +281,29 @@ fn build_ui(app: &Application) {
         });
     }
 
+    // Mirror the macOS menu bar behavior: when a StatusNotifierItem
+    // host is available, closing the window only hides it and the
+    // tray menu is used to re-open or quit. Without a tray host the
+    // default close-means-quit behavior is kept, since a hidden
+    // window would otherwise be unreachable. When the service belongs
+    // to an external daemon the GUI is a pure client and gets no tray
+    // at all — quitting it must not suggest stopping the service.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let tray_active = {
+        let owns_service = OWNS_SERVICE.get().copied().unwrap_or(true);
+        if !owns_service {
+            log::debug!("client of an external lan-mouse daemon, not creating a tray icon");
+        }
+        let tray_active = owns_service && linux_status_item::setup(app, &window);
+        if tray_active {
+            window.connect_close_request(|window| {
+                window.set_visible(false);
+                glib::Propagation::Stop
+            });
+        }
+        tray_active
+    };
+
     glib::spawn_future_local(clone!(
         #[weak]
         window,
@@ -307,8 +351,16 @@ fn build_ui(app: &Application) {
         }
     ));
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
     window.present();
+
+    // Like on macOS below: present on every launch unless
+    // `LAN_MOUSE_HIDDEN=1` requests a quiet start into the tray.
+    // Without a tray the window is always presented.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    if !tray_active || env::var_os("LAN_MOUSE_HIDDEN").is_none() {
+        window.present();
+    }
 
     // On macOS, default to presenting the main window on every launch
     // so the user gets a visible confirmation that the app is running

--- a/lan-mouse-gtk/src/lib.rs
+++ b/lan-mouse-gtk/src/lib.rs
@@ -4,7 +4,7 @@ mod client_row;
 mod fingerprint_window;
 mod key_object;
 mod key_row;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 mod linux_status_item;
 #[cfg(target_os = "macos")]
 mod macos_privacy;
@@ -24,11 +24,34 @@ use window::Window;
 pub(crate) static LOCAL_COMMIT: OnceLock<[u8; 8]> = OnceLock::new();
 
 /// Whether the lan-mouse service is a child of this process, set once
-/// by [`run`] before the GTK main loop starts. When `false` the GUI is
-/// a pure client of an external daemon (e.g. a systemd service): it
-/// then runs as a plain window — no tray icon, closing the window
-/// quits the frontend and leaves the daemon untouched.
+/// by [`run_with_options`] before the GTK main loop starts. When `false`
+/// the GUI is a pure client of an external daemon (e.g. a systemd
+/// service): it then runs as a plain window — no tray icon, closing the
+/// window quits the frontend and leaves the daemon untouched.
 pub(crate) static OWNS_SERVICE: OnceLock<bool> = OnceLock::new();
+
+/// Options controlling how the GTK frontend integrates with its service.
+#[derive(Clone, Copy, Debug)]
+pub struct RunOptions {
+    owns_service: bool,
+}
+
+impl RunOptions {
+    /// Marks whether the service is owned by the process running the frontend.
+    ///
+    /// On Linux, externally managed services use plain-window semantics rather
+    /// than creating a tray icon. This option has no effect on other platforms.
+    pub fn with_service_ownership(mut self, owns_service: bool) -> Self {
+        self.owns_service = owns_service;
+        self
+    }
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self { owns_service: true }
+    }
+}
 
 /// Convenience: returns the local commit as an 8-char ASCII string,
 /// or a placeholder if unset (which would indicate a programmer
@@ -58,13 +81,19 @@ pub enum GtkError {
     NonZeroExitCode(i32),
 }
 
-pub fn run(local_commit: [u8; 8], owns_service: bool) -> Result<(), GtkError> {
+/// Runs the GTK frontend assuming it owns the service it connects to.
+pub fn run(local_commit: [u8; 8]) -> Result<(), GtkError> {
+    run_with_options(local_commit, RunOptions::default())
+}
+
+/// Runs the GTK frontend with explicit lifecycle integration options.
+pub fn run_with_options(local_commit: [u8; 8], options: RunOptions) -> Result<(), GtkError> {
     log::debug!("running gtk frontend");
     LOCAL_COMMIT
         .set(local_commit)
         .expect("local_commit set once");
     OWNS_SERVICE
-        .set(owns_service)
+        .set(options.owns_service)
         .expect("owns_service set once");
 
     #[cfg(windows)]
@@ -288,7 +317,7 @@ fn build_ui(app: &Application) {
     // window would otherwise be unreachable. When the service belongs
     // to an external daemon the GUI is a pure client and gets no tray
     // at all — quitting it must not suggest stopping the service.
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(target_os = "linux")]
     let tray_active = {
         let owns_service = OWNS_SERVICE.get().copied().unwrap_or(true);
         if !owns_service {
@@ -351,13 +380,13 @@ fn build_ui(app: &Application) {
         }
     ));
 
-    #[cfg(windows)]
+    #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
     window.present();
 
     // Like on macOS below: present on every launch unless
     // `LAN_MOUSE_HIDDEN=1` requests a quiet start into the tray.
     // Without a tray the window is always presented.
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(target_os = "linux")]
     if !tray_active || env::var_os("LAN_MOUSE_HIDDEN").is_none() {
         window.present();
     }

--- a/lan-mouse-gtk/src/linux_status_item.rs
+++ b/lan-mouse-gtk/src/linux_status_item.rs
@@ -1,0 +1,190 @@
+//! StatusNotifierItem (system tray) integration for Linux.
+//!
+//! Counterpart to `macos_status_item`: registers a tray icon with an
+//! "Open / Quit" menu so the main window can close into the tray
+//! instead of quitting the application. Uses the StatusNotifierItem
+//! D-Bus specification via `ksni` — desktops without an SNI host
+//! (e.g. GNOME without the AppIndicator extension) are detected at
+//! registration time and reported via [`setup`] returning `false`.
+
+use std::cell::RefCell;
+
+use adw::prelude::*;
+use gtk::{gdk_pixbuf, gio, glib, glib::clone};
+use ksni::blocking::TrayMethods;
+
+use crate::window::Window;
+
+/// Sizes (px) the tray icon pixmap is pre-rendered at. SNI hosts pick
+/// the closest size; 24 covers common panels, 48 hidpi ones.
+const ICON_SIZES: [i32; 2] = [24, 48];
+
+const APP_ICON_RESOURCE: &str = "/de/feschber/LanMouse/icons/de.feschber.LanMouse.svg";
+
+enum TrayEvent {
+    Open,
+    Quit,
+}
+
+struct StatusItem {
+    /// Keeps the application running while no window is visible.
+    _hold: gio::ApplicationHoldGuard,
+    _handle: ksni::blocking::Handle<LanMouseTray>,
+}
+
+thread_local! {
+    static STATUS_ITEM: RefCell<Option<StatusItem>> = const { RefCell::new(None) };
+}
+
+struct LanMouseTray {
+    tx: async_channel::Sender<TrayEvent>,
+    icons: Vec<ksni::Icon>,
+}
+
+impl LanMouseTray {
+    fn send(&self, event: TrayEvent) {
+        // ksni invokes menu callbacks on its own service thread; hand
+        // the event to the GTK main loop instead of touching UI here.
+        if self.tx.send_blocking(event).is_err() {
+            log::warn!("tray event dropped: frontend channel closed");
+        }
+    }
+}
+
+impl ksni::Tray for LanMouseTray {
+    fn id(&self) -> String {
+        "de.feschber.LanMouse".into()
+    }
+
+    fn title(&self) -> String {
+        "Lan Mouse".into()
+    }
+
+    fn icon_name(&self) -> String {
+        // resolved from the icon theme where the app is installed
+        "de.feschber.LanMouse".into()
+    }
+
+    fn icon_pixmap(&self) -> Vec<ksni::Icon> {
+        // fallback for setups without the themed icon (e.g. AppImage)
+        self.icons.clone()
+    }
+
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        use ksni::menu::*;
+        vec![
+            StandardItem {
+                label: "Open Lan Mouse".into(),
+                activate: Box::new(|tray: &mut Self| tray.send(TrayEvent::Open)),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            StandardItem {
+                label: "Quit Lan Mouse".into(),
+                activate: Box::new(|tray: &mut Self| tray.send(TrayEvent::Quit)),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+
+    fn activate(&mut self, _x: i32, _y: i32) {
+        self.send(TrayEvent::Open);
+    }
+}
+
+/// Set up the tray icon. Returns whether it was registered; on `false`
+/// the caller must keep the default close-means-quit behavior, or the
+/// application would become unreachable once the window is hidden.
+pub fn setup(app: &adw::Application, window: &Window) -> bool {
+    let already_initialized = STATUS_ITEM.with(|item| item.borrow().is_some());
+    if already_initialized {
+        return true;
+    }
+
+    let (tx, rx) = async_channel::bounded(4);
+    let tray = LanMouseTray {
+        tx,
+        icons: render_icon_pixmaps(),
+    };
+
+    let handle = match tray.spawn() {
+        Ok(handle) => handle,
+        Err(e) => {
+            log::warn!("no system tray available ({e}), closing the window will quit");
+            return false;
+        }
+    };
+    log::debug!("linux_status_item registered");
+
+    STATUS_ITEM.with(|item| {
+        item.replace(Some(StatusItem {
+            _hold: app.hold(),
+            _handle: handle,
+        }));
+    });
+
+    glib::spawn_future_local(clone!(
+        #[weak]
+        app,
+        #[weak]
+        window,
+        async move {
+            while let Ok(event) = rx.recv().await {
+                match event {
+                    TrayEvent::Open => window.present(),
+                    TrayEvent::Quit => app.quit(),
+                }
+            }
+        }
+    ));
+
+    true
+}
+
+fn render_icon_pixmaps() -> Vec<ksni::Icon> {
+    ICON_SIZES
+        .iter()
+        .filter_map(|&size| render_icon_pixmap(size))
+        .collect()
+}
+
+fn render_icon_pixmap(size: i32) -> Option<ksni::Icon> {
+    let pixbuf =
+        match gdk_pixbuf::Pixbuf::from_resource_at_scale(APP_ICON_RESOURCE, size, size, true) {
+            Ok(pixbuf) => pixbuf,
+            Err(e) => {
+                log::warn!("failed to render tray icon at {size}px: {e}");
+                return None;
+            }
+        };
+
+    let width = pixbuf.width();
+    let height = pixbuf.height();
+    let rowstride = pixbuf.rowstride() as usize;
+    let n_channels = pixbuf.n_channels() as usize;
+    if pixbuf.bits_per_sample() != 8 || !(3..=4).contains(&n_channels) {
+        log::warn!("unexpected pixbuf format for tray icon");
+        return None;
+    }
+    let bytes = pixbuf.read_pixel_bytes();
+
+    // pixbuf rows are RGB(A) with padding; SNI wants packed ARGB32 in
+    // network byte order.
+    let mut data = Vec::with_capacity(width as usize * height as usize * 4);
+    for row in 0..height as usize {
+        let row = &bytes[row * rowstride..];
+        for pixel in 0..width as usize {
+            let pixel = &row[pixel * n_channels..][..n_channels];
+            let alpha = if n_channels == 4 { pixel[3] } else { 0xff };
+            data.extend_from_slice(&[alpha, pixel[0], pixel[1], pixel[2]]);
+        }
+    }
+
+    Some(ksni::Icon {
+        width,
+        height,
+        data,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,14 @@ fn run() -> Result<(), LanMouseError> {
             //  run a frontend
             #[cfg(feature = "gtk")]
             {
+                // Probe before spawning the child: once it binds the
+                // socket, an external daemon is indistinguishable from
+                // our own. The probe only decides the tray semantics —
+                // the child is spawned either way, so it still takes
+                // over should the external daemon exit right after.
+                let owns_service = !external_service_running();
                 let mut service = start_service()?;
-                let res = lan_mouse_gtk::run(config::local_commit());
+                let res = lan_mouse_gtk::run(config::local_commit(), owns_service);
                 #[cfg(unix)]
                 {
                     // on unix we give the service a chance to terminate gracefully
@@ -116,6 +122,22 @@ where
 
     // run async event loop
     Ok(runtime.block_on(LocalSet::new().run_until(f))?)
+}
+
+/// Whether a lan-mouse service not owned by this process is already
+/// listening on the lan-mouse socket. In that case the GUI acts as a
+/// pure client: quitting it must not suggest stopping the service.
+#[cfg(all(feature = "gtk", unix, not(target_os = "macos")))]
+fn external_service_running() -> bool {
+    let Ok(path) = lan_mouse_ipc::default_socket_path() else {
+        return false;
+    };
+    std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
+#[cfg(all(feature = "gtk", any(not(unix), target_os = "macos")))]
+fn external_service_running() -> bool {
+    false
 }
 
 fn start_service() -> Result<Child, io::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,9 @@ fn run() -> Result<(), LanMouseError> {
                 // over should the external daemon exit right after.
                 let owns_service = !external_service_running();
                 let mut service = start_service()?;
-                let res = lan_mouse_gtk::run(config::local_commit(), owns_service);
+                let options =
+                    lan_mouse_gtk::RunOptions::default().with_service_ownership(owns_service);
+                let res = lan_mouse_gtk::run_with_options(config::local_commit(), options);
                 #[cfg(unix)]
                 {
                     // on unix we give the service a chance to terminate gracefully
@@ -127,7 +129,7 @@ where
 /// Whether a lan-mouse service not owned by this process is already
 /// listening on the lan-mouse socket. In that case the GUI acts as a
 /// pure client: quitting it must not suggest stopping the service.
-#[cfg(all(feature = "gtk", unix, not(target_os = "macos")))]
+#[cfg(all(feature = "gtk", target_os = "linux"))]
 fn external_service_running() -> bool {
     let Ok(path) = lan_mouse_ipc::default_socket_path() else {
         return false;
@@ -135,7 +137,7 @@ fn external_service_running() -> bool {
     std::os::unix::net::UnixStream::connect(path).is_ok()
 }
 
-#[cfg(all(feature = "gtk", any(not(unix), target_os = "macos")))]
+#[cfg(all(feature = "gtk", not(target_os = "linux")))]
 fn external_service_running() -> bool {
     false
 }


### PR DESCRIPTION
## Summary

Add Linux system-tray support through the StatusNotifierItem D-Bus specification, mirroring the existing macOS menu-bar application behavior:

- closing the main window hides it while Lan Mouse keeps running;
- the tray icon can present the window or quit the application;
- `LAN_MOUSE_HIDDEN=1` starts the application quietly in the tray;
- launching Lan Mouse again presents an existing hidden window;
- desktops without a StatusNotifierItem host retain the previous close-to-quit behavior; and
- a GUI connected to an externally managed daemon remains a plain window and does not claim ownership through a tray icon.

Related to #291.

Windows notification-area support is intentionally being submitted separately,so this PR does not close the issue.

## Behavior

| Startup state                                     | Tray behavior                                  | Closing the window                          |
| ------------------------------------------------- | ---------------------------------------------- | ------------------------------------------- |
| GUI owns the service and an SNI host is available | Register the tray icon                         | Hide the window and keep running            |
| GUI owns the service but no SNI host is available | Log a warning and continue without a tray icon | Quit as before                              |
| An external daemon already owns the IPC socket    | Do not create a tray icon                      | Quit only the GUI; leave the daemon running |

The tray is owned by the graphical frontend rather than the daemon. A standalone daemon may run without a graphical session or session D-Bus, so making it own desktop UI would couple headless operation to the desktop environment. The frontend therefore creates the tray only when it also owns the service lifecycle.

The socket is probed before spawning the normal service child. The child is still spawned so it can win the bind if the external daemon exits during that startup race.

## Implementation

- Use `ksni` for StatusNotifierItem registration without introducing a GTK3 tray dependency.
- Restrict the module, dependency, daemon probe, and tray-specific window behavior to `target_os = "linux"`.
- Render fallback ARGB icon pixmaps from the existing bundled application icon for environments where the themed icon cannot be resolved.
- Hold the `gio::Application` while the window is hidden so the frontend stays alive.
- Forward tray callbacks from the SNI service thread to the GTK main loop through an async channel.
- Preserve the existing public `lan_mouse_gtk::run(local_commit)` API. The main binary uses documented `RunOptions` only when it needs to describe external service ownership.
- Document the tray behavior, GNOME limitation, fallback behavior, and `LAN_MOUSE_HIDDEN` in the README.

## Desktop compatibility and fallback

StatusNotifierItem is supported by environments such as KDE Plasma, XFCE, and panels such as waybar. GNOME does not expose an SNI host by default and requires an extension such as AppIndicator and KStatusNotifierItem Support.

Registration failure is intentionally non-fatal. If no host is available, the window is always shown and closing it quits the application, preventing an unreachable hidden process.

The xdg background portal and automatic installation of desktop extensions are outside the scope of this PR.

## Relationship to #407

This PR partially overlaps #407 in two limited startup areas:

- it probes the daemon socket to decide tray ownership semantics; and
- its `GApplication::activate` handler presents an existing hidden window instead of constructing another window.

It does not attempt to replace #407's broader daemon-reuse, reconnect, or cross-platform singleton design. If #407 lands first, the overlapping startup code can be reconciled during rebase while keeping the Linux tray behavior unchanged.

## Test plan

Automated checks completed locally on Linux:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] [Fork CI matrix](https://github.com/inaiii/lan-mouse/actions/runs/29193904905): formatting plus build, check, clippy, and test passed on Ubuntu 24.04, Windows 2022, macOS 15, and macOS 15 Intel. The workflow was dispatched from the fork's `main` branch, and its source jobs checked out `feature/linux-tray-icon` at `e93f769`.

Manual smoke test environment:

- Distribution: Arch Linux (rolling), kernel `7.1.3-arch1-2`
- Desktop/compositor: niri `26.04` (`8ed0da4`)
- Session type: Wayland
- Tray host/panel: Waybar `0.15.0`, with its `tray` module enabled
- Display: BOE eDP-1, 3840x2160 physical / 1536x864 logical, scale factor 3
- Capture/emulation selected during the test: layer-shell / wlroots

Smoke tests completed on this environment:

- [x] The StatusNotifierWatcher reports a registered Lan Mouse SNI item while Waybar's tray host is active.
- [x] `LAN_MOUSE_HIDDEN=1 lan-mouse` starts both the frontend and child daemon without mapping a Lan Mouse window.
- [x] Activating the SNI item presents the existing Lan Mouse window.
- [x] Closing the main window removes it from niri's window list while the frontend, child daemon, and SNI registration remain alive.
- [x] The tray menu exposes `Open Lan Mouse` and `Quit Lan Mouse` actions.
- [x] The tray menu's Open action presents the hidden window.
- [x] Launching Lan Mouse again exits the secondary invocation and presents the existing hidden window without leaving duplicate processes.
- [x] The tray menu's Quit action exits the frontend, gracefully terminates its child service, and removes the IPC socket.
 - [x] Input forwarding continues while the main window is hidden.
 - [x] Without an SNI host, the main window remains reachable and closing it quits.
 - [x] With `lan-mouse daemon` already running, the GUI creates no tray icon and closing it leaves the daemon running.

All manual smoke-test cases above were completed successfully.

No protocol or serialization changes are included, so no protocol version bump is required.
