### PR TITLE
fix(macos): Handle @rpath references in dylib bundling script

### DIFF
--- a/scripts/copy-macos-dylib.sh
+++ b/scripts/copy-macos-dylib.sh
@@ -57,8 +57,11 @@ share_path="$resources_path/share"
 fix_references() {
   local bin="$1"
 
-  # Get all Homebrew libraries referenced by the binary
+  # Get all Homebrew libraries referenced by the binary (absolute paths)
   libs=$(otool -L "$bin" | awk -v homebrew="$homebrew_path" '$0 ~ homebrew {print $1}')
+
+  # Also get @rpath references and try to resolve them from Homebrew
+  rpath_libs=$(otool -L "$bin" | awk '$1 ~ /^@rpath\// {print $1}')
 
   echo "$libs" | while IFS= read -r old_path; do
     if [ -z "$old_path" ]; then
@@ -83,6 +86,37 @@ fix_references() {
 
     echo "Updating $bin to reference @rpath/$base_name..."
     install_name_tool -change "$old_path" "@rpath/$base_name" "$bin"
+  done
+
+  # Process @rpath references
+  echo "$rpath_libs" | while IFS= read -r rpath_ref; do
+    if [ -z "$rpath_ref" ]; then
+      continue
+    fi
+
+    local base_name="$(basename "$rpath_ref")"
+    local dest="$fwks_path/$base_name"
+
+    # Skip if already processed
+    if [ -e "$dest" ]; then
+      continue
+    fi
+
+    # Try to find the library in Homebrew
+    local source_path="$homebrew_path/lib/$base_name"
+    if [ -e "$source_path" ]; then
+      echo "Copying @rpath library $source_path -> $dest"
+      cp -f "$source_path" "$dest"
+      chmod 644 "$dest"
+
+      echo "Updating $dest to have install_name of @rpath/$base_name..."
+      install_name_tool -id "@rpath/$base_name" "$dest"
+
+      # Recursively process this dylib
+      fix_references "$dest"
+    else
+      echo "Warning: Could not find @rpath library $base_name in $homebrew_path/lib"
+    fi
   done
 }
 


### PR DESCRIPTION
## Summary

**Fix macOS runtime crash caused by missing transitive `@rpath` dependencies.**

The `copy-macos-dylib.sh` script previously only copied dynamic libraries with absolute Homebrew paths. This caused runtime crashes (e.g., `dyld: library not loaded`) because it missed transitive dependencies that rely on relative `@rpath` references—such as `libwebp.7.dylib` failing to load `libsharpyuv.0.dylib`.

This PR enhances the dependency resolution inside `scripts/copy-macos-dylib.sh` to recursively discover, copy, and link both absolute and `@rpath` Homebrew libraries.

## Key Changes

* **Dynamic `@rpath` Extraction**: Uses `otool -L` to scan binaries and discover all nested `@rpath` dependencies.
* **Recursive Dependency Resolution**: Locates the missing `@rpath` libraries within Homebrew, copies them to the app bundle, and updates their install names.
* **Error Prevention**: Emits clear warnings if an `@rpath` library cannot be found in the expected Homebrew path to simplify troubleshooting.

## Evidence / Error Log

```sh
dyld[17093]: library not loaded: @rpath/libsharpyuv.0.dylib
  referenced from: <d5d18de0-5439-3b6e-8118-b5d7b486ec66> /applications/lan mouse.app/contents/frameworks/libwebp.7.dylib
  reason: tried: 
    '/applications/lan mouse.app/contents/frameworks/../lib/libsharpyuv.0.dylib' (no such file), 
    '/applications/lan mouse.app/contents/frameworks/libsharpyuv.0.dylib' (no such file), 
    '/applications/lan mouse.app/contents/frameworks/libsharpyuv.0.dylib' (no such file)
zsh: abort      /applications/lan\ mouse.app/contents/macos/lan-mouse