### PR TITLE
feat: make key repeat delay and interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,14 @@ release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
 # optional port (defaults to 4242)
 port = 4242
 
+# optional key-repeat timing for the *receiving* side, in milliseconds. Only the
+# macOS and Windows emulation backends use these (other platforms let the OS
+# generate key repeat): `key_repeat_delay` is how long a key must be held before
+# it starts repeating, `key_repeat_interval` is the time between repeats.
+# Defaults: 500 and 32.
+key_repeat_delay = 500
+key_repeat_interval = 32
+
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic
 [authorized_fingerprints]

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,14 @@ release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
 # optional port (defaults to 4242)
 port = 4242
 
+# optional key-repeat timing for the *receiving* side, in milliseconds. Only the
+# macOS and Windows emulation backends use these (other platforms let the OS
+# generate key repeat): `key_repeat_delay` is how long a key must be held before
+# it starts repeating, `key_repeat_interval` is the time between repeats.
+# Defaults: 500 and 32.
+key_repeat_delay = 500
+key_repeat_interval = 32
+
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic
 [authorized_fingerprints]

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
+    time::Duration,
 };
 
 use input_event::{Event, KeyboardEvent};
@@ -31,6 +32,35 @@ mod dummy;
 mod error;
 
 pub type EmulationHandle = u64;
+
+/// Default delay before a held key begins repeating.
+pub const DEFAULT_KEY_REPEAT_DELAY: Duration = Duration::from_millis(500);
+
+/// Default interval between repeats once a held key has started repeating.
+pub const DEFAULT_KEY_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
+
+/// Tunable options for input-emulation backends.
+///
+/// These currently only affect the macOS and Windows backends: on those
+/// platforms synthetic key events are not auto-repeated by the OS, so lan-mouse
+/// regenerates key repeats itself. The other backends leave key repeat to the
+/// receiving compositor / OS and ignore these values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EmulationOptions {
+    /// How long a key must be held before it starts repeating.
+    pub key_repeat_delay: Duration,
+    /// The interval between repeats once a key has started repeating.
+    pub key_repeat_interval: Duration,
+}
+
+impl Default for EmulationOptions {
+    fn default() -> Self {
+        Self {
+            key_repeat_delay: DEFAULT_KEY_REPEAT_DELAY,
+            key_repeat_interval: DEFAULT_KEY_REPEAT_INTERVAL,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Backend {
@@ -76,7 +106,11 @@ pub struct InputEmulation {
 }
 
 impl InputEmulation {
-    async fn with_backend(backend: Backend) -> Result<InputEmulation, EmulationCreationError> {
+    #[cfg_attr(not(any(target_os = "macos", windows)), allow(unused_variables))]
+    async fn with_backend(
+        backend: Backend,
+        options: EmulationOptions,
+    ) -> Result<InputEmulation, EmulationCreationError> {
         let emulation: Box<dyn Emulation> = match backend {
             #[cfg(wlroots)]
             Backend::Wlroots => Box::new(wlroots::WlrootsEmulation::new()?),
@@ -87,9 +121,9 @@ impl InputEmulation {
             #[cfg(rdp)]
             Backend::Xdp => Box::new(xdg_desktop_portal::DesktopPortalEmulation::new().await?),
             #[cfg(windows)]
-            Backend::Windows => Box::new(windows::WindowsEmulation::new()?),
+            Backend::Windows => Box::new(windows::WindowsEmulation::new(options)?),
             #[cfg(target_os = "macos")]
-            Backend::MacOs => Box::new(macos::MacOSEmulation::new()?),
+            Backend::MacOs => Box::new(macos::MacOSEmulation::new(options)?),
             Backend::Dummy => Box::new(dummy::DummyEmulation::new()),
         };
         Ok(Self {
@@ -99,9 +133,12 @@ impl InputEmulation {
         })
     }
 
-    pub async fn new(backend: Option<Backend>) -> Result<InputEmulation, EmulationCreationError> {
+    pub async fn new(
+        backend: Option<Backend>,
+        options: EmulationOptions,
+    ) -> Result<InputEmulation, EmulationCreationError> {
         if let Some(backend) = backend {
-            let b = Self::with_backend(backend).await;
+            let b = Self::with_backend(backend, options).await;
             if b.is_ok() {
                 log::info!("using emulation backend: {backend}");
             }
@@ -123,7 +160,7 @@ impl InputEmulation {
             Backend::MacOs,
             Backend::Dummy,
         ] {
-            match Self::with_backend(backend).await {
+            match Self::with_backend(backend, options).await {
                 Ok(b) => {
                     log::info!("using emulation backend: {backend}");
                     return Ok(b);

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -1,4 +1,4 @@
-use super::{Emulation, EmulationHandle, error::EmulationError};
+use super::{Emulation, EmulationHandle, EmulationOptions, error::EmulationError};
 use async_trait::async_trait;
 use bitflags::bitflags;
 use core_graphics::base::CGFloat;
@@ -24,8 +24,6 @@ use tokio::{sync::Notify, task::JoinHandle};
 
 use super::error::MacOSEmulationCreationError;
 
-const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
-const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 
 pub(crate) struct MacOSEmulation {
@@ -45,6 +43,8 @@ pub(crate) struct MacOSEmulation {
     modifier_state: Rc<Cell<XMods>>,
     /// notify to cancel key repeats
     notify_repeat_task: Arc<Notify>,
+    /// key-repeat timing (initial delay + interval between repeats)
+    options: EmulationOptions,
 }
 
 /// Maps an evdev button code to the CGEventType used for drag events.
@@ -60,7 +60,7 @@ fn drag_event_type(button: u32) -> CGEventType {
 unsafe impl Send for MacOSEmulation {}
 
 impl MacOSEmulation {
-    pub(crate) fn new() -> Result<Self, MacOSEmulationCreationError> {
+    pub(crate) fn new(options: EmulationOptions) -> Result<Self, MacOSEmulationCreationError> {
         request_macos_emulation_permissions()?;
 
         let event_source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
@@ -74,6 +74,7 @@ impl MacOSEmulation {
             repeat_task: None,
             notify_repeat_task: Arc::new(Notify::new()),
             modifier_state: Rc::new(Cell::new(XMods::empty())),
+            options,
         })
     }
 
@@ -92,16 +93,18 @@ impl MacOSEmulation {
         let event_source = self.event_source.clone();
         let notify = self.notify_repeat_task.clone();
         let modifiers = self.modifier_state.clone();
+        let repeat_delay = self.options.key_repeat_delay;
+        let repeat_interval = self.options.key_repeat_interval;
         let repeat_task = tokio::task::spawn_local(async move {
             let stop = tokio::select! {
-                _ = tokio::time::sleep(DEFAULT_REPEAT_DELAY) => false,
+                _ = tokio::time::sleep(repeat_delay) => false,
                 _ = notify.notified() => true,
             };
             if !stop {
                 loop {
                     key_event(event_source.clone(), key, 1, modifiers.get());
                     tokio::select! {
-                        _ = tokio::time::sleep(DEFAULT_REPEAT_INTERVAL) => {},
+                        _ = tokio::time::sleep(repeat_interval) => {},
                         _ = notify.notified() => break,
                     }
                 }

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -6,7 +6,6 @@ use input_event::{
 
 use async_trait::async_trait;
 use std::ops::BitOrAssign;
-use std::time::Duration;
 use tokio::task::AbortHandle;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE,
@@ -19,18 +18,19 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
 
-use super::{Emulation, EmulationHandle};
-
-const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
-const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
+use super::{Emulation, EmulationHandle, EmulationOptions};
 
 pub(crate) struct WindowsEmulation {
     repeat_task: Option<AbortHandle>,
+    options: EmulationOptions,
 }
 
 impl WindowsEmulation {
-    pub(crate) fn new() -> Result<Self, WindowsEmulationCreationError> {
-        Ok(Self { repeat_task: None })
+    pub(crate) fn new(options: EmulationOptions) -> Result<Self, WindowsEmulationCreationError> {
+        Ok(Self {
+            repeat_task: None,
+            options,
+        })
     }
 }
 
@@ -87,11 +87,13 @@ impl WindowsEmulation {
         // there can only be one repeating key and it's
         // always the last to be pressed
         self.kill_repeat_task();
+        let repeat_delay = self.options.key_repeat_delay;
+        let repeat_interval = self.options.key_repeat_interval;
         let repeat_task = tokio::task::spawn_local(async move {
-            tokio::time::sleep(DEFAULT_REPEAT_DELAY).await;
+            tokio::time::sleep(repeat_delay).await;
             loop {
                 key_event(key, 1);
-                tokio::time::sleep(DEFAULT_REPEAT_INTERVAL).await;
+                tokio::time::sleep(repeat_interval).await;
             }
         });
         self.repeat_task = Some(repeat_task.abort_handle());

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{collections::HashSet, io};
 use thiserror::Error;
 use toml;
@@ -53,6 +54,8 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    key_repeat_delay: Option<u64>,
+    key_repeat_interval: Option<u64>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -477,6 +480,24 @@ impl Config {
             .as_ref()
             .and_then(|c| c.release_bind.clone())
             .unwrap_or(Vec::from_iter(DEFAULT_RELEASE_KEYS.iter().cloned()))
+    }
+
+    /// key-repeat timing for emulation backends that regenerate repeats
+    /// themselves (macOS and Windows). Values are read in milliseconds; unset
+    /// fields fall back to the [`input_emulation::EmulationOptions`] defaults.
+    pub fn emulation_options(&self) -> input_emulation::EmulationOptions {
+        let defaults = input_emulation::EmulationOptions::default();
+        let config_toml = self.config_toml.as_ref();
+        input_emulation::EmulationOptions {
+            key_repeat_delay: config_toml
+                .and_then(|c| c.key_repeat_delay)
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.key_repeat_delay),
+            key_repeat_interval: config_toml
+                .and_then(|c| c.key_repeat_interval)
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.key_repeat_interval),
+        }
     }
 
     /// set configured clients

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -1,6 +1,6 @@
 use crate::listen::{LanMouseListener, ListenEvent, ListenerCreationError};
 use futures::StreamExt;
-use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError};
+use input_emulation::{EmulationHandle, EmulationOptions, InputEmulation, InputEmulationError};
 use input_event::Event;
 use lan_mouse_proto::{Position, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -64,9 +64,10 @@ enum EmulationRequest {
 impl Emulation {
     pub(crate) fn new(
         backend: Option<input_emulation::Backend>,
+        options: EmulationOptions,
         listener: LanMouseListener,
     ) -> Self {
-        let emulation_proxy = EmulationProxy::new(backend);
+        let emulation_proxy = EmulationProxy::new(backend, options);
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_task = ListenTask {
@@ -216,13 +217,14 @@ enum ProxyRequest {
 }
 
 impl EmulationProxy {
-    fn new(backend: Option<input_emulation::Backend>) -> Self {
+    fn new(backend: Option<input_emulation::Backend>, options: EmulationOptions) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_active = Rc::new(Cell::new(false));
         let exit_requested = Rc::new(Cell::new(false));
         let emulation_task = EmulationTask {
             backend,
+            options,
             exit_requested: exit_requested.clone(),
             request_rx,
             event_tx,
@@ -282,6 +284,7 @@ impl EmulationProxy {
 
 struct EmulationTask {
     backend: Option<input_emulation::Backend>,
+    options: EmulationOptions,
     exit_requested: Rc<Cell<bool>>,
     request_rx: Receiver<ProxyRequest>,
     event_tx: Sender<EmulationEvent>,
@@ -313,7 +316,7 @@ impl EmulationTask {
     async fn do_emulation(&mut self) -> Result<(), InputEmulationError> {
         log::info!("creating input emulation ...");
         let mut emulation = tokio::select! {
-            r = InputEmulation::new(self.backend) => r?,
+            r = InputEmulation::new(self.backend, self.options) => r?,
             // allow termination event while requesting input emulation
             _ = wait_for_termination(&mut self.request_rx) => return Ok(()),
         };

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -22,7 +22,7 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     log::info!("running input emulation test");
 
     let backend = config.emulation_backend().map(|b| b.into());
-    let mut emulation = InputEmulation::new(backend).await?;
+    let mut emulation = InputEmulation::new(backend, config.emulation_options()).await?;
     emulation.create(0).await;
 
     let start = Instant::now();

--- a/src/service.rs
+++ b/src/service.rs
@@ -103,7 +103,7 @@ impl Service {
         let capture_backend = config.capture_backend().map(|b| b.into());
         let capture = Capture::new(capture_backend, conn, config.release_bind());
         let emulation_backend = config.emulation_backend().map(|b| b.into());
-        let emulation = Emulation::new(emulation_backend, listener);
+        let emulation = Emulation::new(emulation_backend, config.emulation_options(), listener);
 
         // create dns resolver
         let resolver = DnsResolver::new()?;


### PR DESCRIPTION
## Summary

On macOS and Windows the OS does not auto-repeat *synthetic* key events, so
lan-mouse regenerates key repeats itself. The repeat delay and interval were
hardcoded to 500 ms / 32 ms, which can feel off compared to the sender's own
keyboard settings. This makes both values configurable, defaulting to the
current behaviour when unset.

## Changes

- **`input-emulation`**: add `EmulationOptions { key_repeat_delay,
  key_repeat_interval }` (with `Default` = 500 ms / 32 ms, exposed via
  `DEFAULT_KEY_REPEAT_DELAY` / `DEFAULT_KEY_REPEAT_INTERVAL`) and thread it
  through `InputEmulation::new` / `with_backend` into the macOS and Windows
  backends, replacing the per-backend hardcoded constants. The other backends
  leave key repeat to the OS and ignore the value (guarded so there are no
  unused-variable warnings on those targets).
- **config**: add optional `key_repeat_delay` / `key_repeat_interval`
  (milliseconds) and a `Config::emulation_options()` accessor that maps them
  onto `EmulationOptions`, falling back to the defaults per field.
- **docs**: document the options in `config.toml` and the README.

There is no behaviour change unless the new keys are set.

```toml
# milliseconds; only the macOS and Windows backends use these
key_repeat_delay = 300
key_repeat_interval = 20
```

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p input-emulation --no-default-features --all-targets -- -D warnings` — clean
- [x] root crate `cargo check --no-default-features` — clean (macOS)
- [ ] CI: `cargo fmt` / `clippy` / `test --workspace --all-targets --all-features`
      on Linux + the Windows emulation backend. I could not build `--all-features`
      locally: the gtk frontend pulls in libadwaita, which does not link on my
      macOS/nix toolchain, so the Linux backends and the Windows path are only
      compile-checked by mirroring the macOS change.
