### PR TITLE
fix(macos): correct inverted scroll direction (wl_pointer/libei sign)

### DIFF
--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -357,6 +357,13 @@ fn get_events(
             })))
         }
         CGEventType::ScrollWheel => {
+            // CGEvent scroll deltas use the opposite sign convention from
+            // wl_pointer.axis / libei, where positive means scroll down / right.
+            // That wl_pointer/libei convention is what the wire protocol and the
+            // Linux/Windows capture backends already use, so negate here to keep
+            // the forwarded scroll sign source-agnostic no matter which OS
+            // captured it. The matching conversion back to the CGEvent sign is
+            // done by the macOS emulation backend (see input-emulation/src/macos.rs).
             if ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0 {
                 let v =
                     ev.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1);
@@ -366,14 +373,14 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
                         axis: 0, // Vertical
-                        value: v as f64,
+                        value: -v as f64,
                     })));
                 }
                 if h != 0 {
                     result.push(CaptureEvent::Input(Event::Pointer(PointerEvent::Axis {
                         time: 0,
                         axis: 1, // Horizontal
-                        value: h as f64,
+                        value: -h as f64,
                     })));
                 }
             } else {
@@ -386,7 +393,7 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {
                             axis: 0, // Vertical
-                            value: V120_STEPS_PER_LINE * v as i32,
+                            value: -V120_STEPS_PER_LINE * v as i32,
                         },
                     )));
                 }
@@ -394,7 +401,7 @@ fn get_events(
                     result.push(CaptureEvent::Input(Event::Pointer(
                         PointerEvent::AxisDiscrete120 {
                             axis: 1, // Horizontal
-                            value: V120_STEPS_PER_LINE * h as i32,
+                            value: -V120_STEPS_PER_LINE * h as i32,
                         },
                     )));
                 }

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -28,6 +28,22 @@ const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
 const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Converts a scroll delta from the wire's wl_pointer/libei sign convention
+/// (positive = scroll down / right) into the sign expected by
+/// `CGEventCreateScrollWheelEvent`, which is inverted relative to it. Without
+/// this, scroll from a non-macOS sender is reversed on the receiving Mac.
+///
+/// This is a fixed conversion and is deliberately *not* gated on the receiver's
+/// `com.apple.swipescrolldirection` ("natural scrolling") preference: events
+/// posted at the HID event tap bypass the window server's natural-scroll
+/// transform, so toggling that preference has no effect on emulated scrolling
+/// (verified empirically). The wire protocol is source-agnostic, so a single
+/// fixed sign is correct for every sender. `saturating_neg` guards against a
+/// malformed `i32::MIN` arriving on the wire (plain negation would overflow).
+fn wire_scroll_to_cgevent(value: i32) -> i32 {
+    value.saturating_neg()
+}
+
 pub(crate) struct MacOSEmulation {
     /// global event source for all events
     event_source: CGEventSource,
@@ -420,7 +436,8 @@ impl Emulation for MacOSEmulation {
                         axis,
                         value,
                     } => {
-                        let value = value as i32;
+                        // wl_pointer/libei uses the opposite scroll sign to CGEvent.
+                        let value = wire_scroll_to_cgevent(value as i32);
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value, 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value, 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)
@@ -447,6 +464,8 @@ impl Emulation for MacOSEmulation {
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
                         const LINES_PER_STEP: i32 = 3;
+                        // wl_pointer/libei uses the opposite scroll sign to CGEvent.
+                        let value = wire_scroll_to_cgevent(value);
                         let (count, wheel1, wheel2, wheel3) = match axis {
                             0 => (1, value / (120 / LINES_PER_STEP), 0, 0), // 0 = vertical => 1 scroll wheel device (y axis)
                             1 => (2, 0, value / (120 / LINES_PER_STEP), 0), // 1 = horizontal => 2 scroll wheel devices (y, x) -> (0, x)


### PR DESCRIPTION
## Problem

Scrolling from a non-macOS sender (e.g. Linux/Hyprland via the layer-shell or
libei capture backend, or Windows) onto a macOS receiver running the `macos`
emulation backend is **inverted** — vertically and horizontally, on both
mouse-wheel (discrete) and trackpad (continuous) input.

Symmetrically, a macOS *sender* scrolls **backwards** on non-macOS receivers,
because the two sides of the wire disagree on the scroll-sign convention.

## Root cause

`wl_pointer.axis` / libei use *positive = scroll down / right*. That is the
convention the wire protocol and the Linux and Windows capture backends already
use (`input-capture/src/windows/event_thread.rs` even negates `WM_MOUSEWHEEL`
to match). `CGEvent` scroll deltas use the **opposite** sign, and two places
never reconcile it:

1. **Emulation** (`input-emulation/src/macos.rs`) posts the wire delta straight
   into `CGEvent`, so a wl-convention sender scrolls backwards on the Mac.
2. **Capture** (`input-capture/src/macos.rs`) forwards the raw `CGEvent` delta
   un-negated, so the wire sign is inconsistent across capture backends and a
   Mac sender scrolls backwards on everyone else.

## Fix

- **Capture** (commit 1): negate the macOS scroll delta so the wire stays
  source-agnostic (both PIXEL and v120 paths, both axes).
- **Emulation** (commit 2): convert the wire sign back to the `CGEvent` sign
  with a single fixed negation (`wire_scroll_to_cgevent`), on both paths and
  both axes.

Together these make the wire consistent for every capture backend and fix
scrolling in every direction (non-mac → mac, mac → non-mac, and mac → mac
without double-inversion).

### Why not read `com.apple.swipescrolldirection`?

An alternative (#460) flips the sign based on the receiver's *natural scrolling*
preference. That turns out to be unnecessary and only correct at one toggle
position: **scroll events posted at the HID event tap bypass the window
server's natural-scroll transform**, so the receiver's preference has no effect
on injected scrolling. I confirmed this on hardware — a receiving Mac scrolls
identically with natural scrolling ON and OFF. Because the wire is
source-agnostic, one fixed conversion is correct for every sender regardless of
the receiver's setting, and no CoreFoundation preference read / FFI is needed.

## Testing

- `cargo check` and `cargo clippy --all-targets -- -D warnings` are clean for
  `input-capture` and `input-emulation`; the headless daemon
  (`cargo check --no-default-features`) builds.
- Confirmed on hardware that a wl-convention sender (Linux/Hyprland) scrolls
  **inverted** on `main`, and that toggling the receiver's natural-scrolling
  setting makes no difference — which is what motivates the fixed conversion.

Manual matrix worth confirming before merge (non-mac sender → mac receiver):

| path | axis | before | after |
|------|------|--------|-------|
| trackpad (PIXEL)  | vertical   | inverted | correct |
| trackpad (PIXEL)  | horizontal | inverted | correct |
| wheel (v120/LINE) | vertical   | inverted | correct |
| wheel (v120/LINE) | horizontal | inverted | correct |

With two Macs, mac → mac should no longer double-invert (the limitation
documented in #460).

## Prior art / coordination

This consolidates scroll-direction work that's been split across several PRs:

- #415 / `bb17cf0` (@jondkinney) — the capture-side negation; reproduced here as
  commit 1.
- #460 (@jtjones09) — the receiver-side flip, but gated on the natural-scrolling
  preference; see the note above on why a fixed conversion is used instead.
- #347 (@NeoTheFox) — an `invert_scroll` config toggle; orthogonal, and could
  sit on top of this as a manual override.

Happy to adjust the approach (keep it emulation-only, add a config override,
etc.) if you'd prefer.
