### PR TITLE
Add configurable input post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,13 @@ release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
 # optional port (defaults to 4242)
 port = 4242
 
+# optional transformations applied to input received from other devices
+[input_post_processing]
+# scale relative pointer motion (defaults to 1.0)
+mouse_sensitivity = 1.0
+# invert continuous and discrete scrolling (defaults to false)
+invert_scroll = false
+
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic
 [authorized_fingerprints]
@@ -414,6 +421,13 @@ port = 4242
 ```
 
 Where `left` can be either `left`, `right`, `top` or `bottom`.
+Input post-processing is configured on the receiving device and applies only to
+events emulated there. Both options can also be changed at runtime:
+
+```sh
+lan-mouse cli set-mouse-sensitivity 1.5
+lan-mouse cli invert-scrolling true
+```
 
 ## Roadmap
 - [x] Graphical frontend (gtk + libadwaita)

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,16 @@
 # example configuration
 
 # configure release bind
-release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
+release_bind = ["KeyA", "KeyS", "KeyD", "KeyF"]
 
 # optional port (defaults to 4242)
 port = 4242
+
+[input_post_processing]
+# scale relative pointer motion received from other devices
+mouse_sensitivity = 1.0
+# invert scroll events received from other devices
+invert_scroll = false
 
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Display,
 };
 
-use input_event::{Event, KeyboardEvent};
+use input_event::{Event, KeyboardEvent, PointerEvent};
 
 pub use self::error::{EmulationCreationError, EmulationError, InputEmulationError};
 
@@ -69,14 +69,59 @@ impl Display for Backend {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct InputConfig {
+    pub invert_scroll: bool,
+    pub mouse_sensitivity: f64,
+}
+
+impl Default for InputConfig {
+    fn default() -> Self {
+        Self {
+            invert_scroll: false,
+            mouse_sensitivity: 1.0,
+        }
+    }
+}
+
+fn post_process_event(event: Event, config: InputConfig) -> Event {
+    match event {
+        Event::Pointer(PointerEvent::Motion { time, dx, dy }) => {
+            Event::Pointer(PointerEvent::Motion {
+                time,
+                dx: dx * config.mouse_sensitivity,
+                dy: dy * config.mouse_sensitivity,
+            })
+        }
+        Event::Pointer(PointerEvent::AxisDiscrete120 { axis, value }) if config.invert_scroll => {
+            Event::Pointer(PointerEvent::AxisDiscrete120 {
+                axis,
+                value: -value,
+            })
+        }
+        Event::Pointer(PointerEvent::Axis { time, axis, value }) if config.invert_scroll => {
+            Event::Pointer(PointerEvent::Axis {
+                time,
+                axis,
+                value: -value,
+            })
+        }
+        _ => event,
+    }
+}
+
 pub struct InputEmulation {
     emulation: Box<dyn Emulation>,
     handles: HashSet<EmulationHandle>,
+    input_config: InputConfig,
     pressed_keys: HashMap<EmulationHandle, HashSet<u32>>,
 }
 
 impl InputEmulation {
-    async fn with_backend(backend: Backend) -> Result<InputEmulation, EmulationCreationError> {
+    async fn with_backend(
+        backend: Backend,
+        input_config: InputConfig,
+    ) -> Result<InputEmulation, EmulationCreationError> {
         let emulation: Box<dyn Emulation> = match backend {
             #[cfg(wlroots)]
             Backend::Wlroots => Box::new(wlroots::WlrootsEmulation::new()?),
@@ -94,14 +139,18 @@ impl InputEmulation {
         };
         Ok(Self {
             emulation,
+            input_config,
             handles: HashSet::new(),
             pressed_keys: HashMap::new(),
         })
     }
 
-    pub async fn new(backend: Option<Backend>) -> Result<InputEmulation, EmulationCreationError> {
+    pub async fn new(
+        backend: Option<Backend>,
+        input_config: InputConfig,
+    ) -> Result<InputEmulation, EmulationCreationError> {
         if let Some(backend) = backend {
-            let b = Self::with_backend(backend).await;
+            let b = Self::with_backend(backend, input_config).await;
             if b.is_ok() {
                 log::info!("using emulation backend: {backend}");
             }
@@ -123,7 +172,7 @@ impl InputEmulation {
             Backend::MacOs,
             Backend::Dummy,
         ] {
-            match Self::with_backend(backend).await {
+            match Self::with_backend(backend, input_config).await {
                 Ok(b) => {
                     log::info!("using emulation backend: {backend}");
                     return Ok(b);
@@ -141,6 +190,7 @@ impl InputEmulation {
         event: Event,
         handle: EmulationHandle,
     ) -> Result<(), EmulationError> {
+        let event = post_process_event(event, self.input_config);
         match event {
             Event::Keyboard(KeyboardEvent::Key { key, state, .. }) => {
                 // prevent double pressed / released keys
@@ -210,6 +260,10 @@ impl InputEmulation {
             .is_some_and(|p| !p.is_empty())
     }
 
+    pub fn update_config(&mut self, input_config: InputConfig) {
+        self.input_config = input_config;
+    }
+
     /// update the pressed_keys for the given handle
     /// returns whether the event should be processed
     fn update_pressed_keys(&mut self, handle: EmulationHandle, key: u32, state: u8) -> bool {
@@ -237,4 +291,88 @@ trait Emulation: Send {
     async fn create(&mut self, handle: EmulationHandle);
     async fn destroy(&mut self, handle: EmulationHandle);
     async fn terminate(&mut self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_processing_scales_pointer_motion() {
+        let event = Event::Pointer(PointerEvent::Motion {
+            time: 42,
+            dx: 3.0,
+            dy: -4.0,
+        });
+        let config = InputConfig {
+            mouse_sensitivity: 1.5,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            post_process_event(event, config),
+            Event::Pointer(PointerEvent::Motion {
+                time: 42,
+                dx: 4.5,
+                dy: -6.0,
+            })
+        );
+    }
+
+    #[test]
+    fn post_processing_inverts_continuous_and_discrete_scrolling() {
+        let config = InputConfig {
+            invert_scroll: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            post_process_event(
+                Event::Pointer(PointerEvent::Axis {
+                    time: 7,
+                    axis: 0,
+                    value: 2.5,
+                }),
+                config,
+            ),
+            Event::Pointer(PointerEvent::Axis {
+                time: 7,
+                axis: 0,
+                value: -2.5,
+            })
+        );
+        assert_eq!(
+            post_process_event(
+                Event::Pointer(PointerEvent::AxisDiscrete120 {
+                    axis: 1,
+                    value: 120,
+                }),
+                config,
+            ),
+            Event::Pointer(PointerEvent::AxisDiscrete120 {
+                axis: 1,
+                value: -120,
+            })
+        );
+    }
+
+    #[test]
+    fn post_processing_leaves_other_events_unchanged() {
+        let event = Event::Pointer(PointerEvent::Button {
+            time: 5,
+            button: 0x110,
+            state: 1,
+        });
+
+        assert_eq!(
+            post_process_event(
+                event,
+                InputConfig {
+                    invert_scroll: true,
+                    mouse_sensitivity: 2.0,
+                },
+            ),
+            event
+        );
+    }
 }

--- a/lan-mouse-cli/src/lib.rs
+++ b/lan-mouse-cli/src/lib.rs
@@ -18,7 +18,7 @@ pub enum CliError {
     Ipc(#[from] IpcError),
 }
 
-#[derive(Parser, Clone, Debug, PartialEq, Eq)]
+#[derive(Parser, Clone, Debug, PartialEq)]
 #[command(name = "lan-mouse-cli", about = "LanMouse CLI interface")]
 pub struct CliArgs {
     #[command(subcommand)]
@@ -37,7 +37,7 @@ struct Client {
     enter_hook: Option<String>,
 }
 
-#[derive(Clone, Subcommand, Debug, PartialEq, Eq)]
+#[derive(Clone, Subcommand, Debug, PartialEq)]
 enum CliSubcommand {
     /// add a new client
     AddClient(Client),
@@ -56,6 +56,13 @@ enum CliSubcommand {
     },
     /// change port
     SetPort { id: ClientHandle, port: u16 },
+    /// invert scrolling direction
+    InvertScrolling {
+        #[arg(action = clap::ArgAction::Set)]
+        invert_scroll: bool,
+    },
+    /// set mouse sensitivity
+    SetMouseSensitivity { mouse_sensitivity: f64 },
     /// set position
     SetPosition { id: ClientHandle, pos: Position },
     /// set ips
@@ -142,6 +149,14 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
         CliSubcommand::SetPort { id, port } => {
             tx.request(FrontendRequest::UpdatePort(id, port)).await?
         }
+        CliSubcommand::InvertScrolling { invert_scroll } => {
+            tx.request(FrontendRequest::UpdateScrollingInversion(invert_scroll))
+                .await?
+        }
+        CliSubcommand::SetMouseSensitivity { mouse_sensitivity } => {
+            tx.request(FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity))
+                .await?
+        }
         CliSubcommand::SetPosition { id, pos } => {
             tx.request(FrontendRequest::UpdatePosition(id, pos)).await?
         }
@@ -167,4 +182,35 @@ async fn execute(cmd: CliSubcommand) -> Result<(), CliError> {
         CliSubcommand::SaveConfig => tx.request(FrontendRequest::SaveConfiguration).await?,
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_scroll_inversion_value() {
+        let args = CliArgs::try_parse_from(["lan-mouse-cli", "invert-scrolling", "true"])
+            .expect("valid scroll inversion command");
+
+        assert_eq!(
+            args.command,
+            CliSubcommand::InvertScrolling {
+                invert_scroll: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_mouse_sensitivity_value() {
+        let args = CliArgs::try_parse_from(["lan-mouse-cli", "set-mouse-sensitivity", "1.5"])
+            .expect("valid mouse sensitivity command");
+
+        assert_eq!(
+            args.command,
+            CliSubcommand::SetMouseSensitivity {
+                mouse_sensitivity: 1.5,
+            }
+        );
+    }
 }

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -225,7 +225,7 @@ pub enum FrontendEvent {
     ConnectionAttempt { fingerprint: String },
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum FrontendRequest {
     /// activate/deactivate client
     Activate(ClientHandle, bool),
@@ -261,6 +261,9 @@ pub enum FrontendRequest {
     UpdateEnterHook(u64, Option<String>),
     /// save config file
     SaveConfiguration,
+    /// update the input post-processing settings (invert-scroll, mouse_sensitivity)
+    UpdateScrollingInversion(bool),
+    UpdateMouseSensitivity(f64),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,14 @@ struct ConfigToml {
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
+    input_post_processing: Option<InputConfig>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct InputConfig {
+    // TODO: implement scroll_sensitivity and mouse_acceleration
+    invert_scroll: Option<bool>,
+    mouse_sensitivity: Option<f64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -117,7 +125,7 @@ struct Args {
     command: Option<Command>,
 }
 
-#[derive(Subcommand, Clone, Debug, Eq, PartialEq)]
+#[derive(Subcommand, Clone, Debug, PartialEq)]
 pub enum Command {
     /// test input emulation
     TestEmulation(TestEmulationArgs),
@@ -474,6 +482,22 @@ impl Config {
             .unwrap_or(DEFAULT_PORT)
     }
 
+    pub fn invert_scroll(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_post_processing.as_ref())
+            .and_then(|i| i.invert_scroll)
+            .unwrap_or(false)
+    }
+
+    pub fn mouse_sensitivity(&self) -> f64 {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_post_processing.as_ref())
+            .and_then(|i| i.mouse_sensitivity)
+            .unwrap_or(1.0)
+    }
+
     /// list of configured clients
     pub fn clients(&self) -> Vec<ConfigClient> {
         self.config_toml
@@ -518,7 +542,7 @@ impl Config {
     }
 
     pub fn read_from_disk(&mut self) -> Result<bool, io::Error> {
-        log::info!("reading config from {:?}", &self.config_path);
+        log::info!("reading config from {:?}", self.config_path);
 
         let current_config = fs::read_to_string(&self.config_path)?;
         let current_config = match current_config.parse::<DocumentMut>() {
@@ -548,7 +572,7 @@ impl Config {
     }
 
     pub fn write_back(&mut self) -> Result<(), io::Error> {
-        log::info!("writing config to {:?}", &self.config_path);
+        log::info!("writing config to {:?}", self.config_path);
         /* the new config */
         let new_config = self.config_toml.clone().unwrap_or_default();
         let new_config = toml_edit::ser::to_string_pretty(&new_config).expect("config");

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -1,7 +1,7 @@
 use crate::config::local_commit;
 use crate::listen::{LanMouseListener, ListenEvent, ListenerCreationError};
 use futures::StreamExt;
-use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError};
+use input_emulation::{EmulationHandle, InputConfig, InputEmulation, InputEmulationError};
 use input_event::Event;
 use lan_mouse_proto::{Position, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -71,14 +71,21 @@ enum EmulationRequest {
     Release(SocketAddr),
     ChangePort(u16),
     Terminate,
+    UpdateScrollingInversion(bool),
+    UpdateMouseSensitivity(f64),
 }
 
 impl Emulation {
     pub(crate) fn new(
         backend: Option<input_emulation::Backend>,
         listener: LanMouseListener,
+        input_config: (bool, f64),
     ) -> Self {
-        let emulation_proxy = EmulationProxy::new(backend);
+        let input_config = InputConfig {
+            invert_scroll: input_config.0,
+            mouse_sensitivity: input_config.1,
+        };
+        let emulation_proxy = EmulationProxy::new(backend, input_config);
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_task = ListenTask {
@@ -110,6 +117,18 @@ impl Emulation {
     pub(crate) fn request_port_change(&self, port: u16) {
         self.request_tx
             .send(EmulationRequest::ChangePort(port))
+            .expect("channel closed")
+    }
+
+    pub(crate) fn request_scrolling_inversion(&self, invert_scroll: bool) {
+        self.request_tx
+            .send(EmulationRequest::UpdateScrollingInversion(invert_scroll))
+            .expect("channel closed")
+    }
+
+    pub(crate) fn request_mouse_sensitivity_change(&self, mouse_sensitivity: f64) {
+        self.request_tx
+            .send(EmulationRequest::UpdateMouseSensitivity(mouse_sensitivity))
             .expect("channel closed")
     }
 
@@ -199,6 +218,14 @@ impl ListenTask {
                     EmulationRequest::Reenable => self.emulation_proxy.reenable(),
                     // notify the other end that we hit a barrier (should release capture)
                     EmulationRequest::Release(addr) => self.listener.reply(addr, ProtoEvent::Leave(0)).await,
+                    EmulationRequest::UpdateScrollingInversion(invert_scroll) => {
+                        self.emulation_proxy.input_config.invert_scroll = invert_scroll;
+                        self.emulation_proxy.update_config();
+                    }
+                    EmulationRequest::UpdateMouseSensitivity(mouse_sensitivity) => {
+                        self.emulation_proxy.input_config.mouse_sensitivity = mouse_sensitivity;
+                        self.emulation_proxy.update_config();
+                    }
                     EmulationRequest::ChangePort(port) => {
                         self.listener.request_port_change(port);
                         let result = self.listener.port_changed().await;
@@ -233,6 +260,7 @@ pub(crate) struct EmulationProxy {
     request_tx: Sender<ProxyRequest>,
     event_rx: Receiver<EmulationEvent>,
     task: JoinHandle<()>,
+    input_config: InputConfig,
 }
 
 enum ProxyRequest {
@@ -240,10 +268,11 @@ enum ProxyRequest {
     Remove(SocketAddr),
     Terminate,
     Reenable,
+    UpdateConfig(InputConfig),
 }
 
 impl EmulationProxy {
-    fn new(backend: Option<input_emulation::Backend>) -> Self {
+    fn new(backend: Option<input_emulation::Backend>, input_config: InputConfig) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
         let emulation_active = Rc::new(Cell::new(false));
@@ -255,6 +284,7 @@ impl EmulationProxy {
             event_tx,
             handles: Default::default(),
             next_id: 0,
+            input_config,
         };
         let task = spawn_local(emulation_task.run());
         Self {
@@ -263,6 +293,7 @@ impl EmulationProxy {
             request_tx,
             task,
             event_rx,
+            input_config,
         }
     }
 
@@ -298,6 +329,12 @@ impl EmulationProxy {
             .expect("channel closed");
     }
 
+    fn update_config(&self) {
+        self.request_tx
+            .send(ProxyRequest::UpdateConfig(self.input_config))
+            .expect("channel closed");
+    }
+
     async fn terminate(&mut self) {
         self.exit_requested.replace(true);
         self.request_tx
@@ -314,6 +351,7 @@ struct EmulationTask {
     event_tx: Sender<EmulationEvent>,
     handles: HashMap<SocketAddr, EmulationHandle>,
     next_id: EmulationHandle,
+    input_config: InputConfig,
 }
 
 impl EmulationTask {
@@ -332,6 +370,9 @@ impl EmulationTask {
                     ProxyRequest::Terminate => return,
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::UpdateConfig(input_config) => {
+                        self.input_config = input_config;
+                    }
                 }
             }
         }
@@ -340,7 +381,7 @@ impl EmulationTask {
     async fn do_emulation(&mut self) -> Result<(), InputEmulationError> {
         log::info!("creating input emulation ...");
         let mut emulation = tokio::select! {
-            r = InputEmulation::new(self.backend) => r?,
+            r = InputEmulation::new(self.backend, self.input_config) => r?,
             // allow termination event while requesting input emulation
             _ = wait_for_termination(&mut self.request_rx) => return Ok(()),
         };
@@ -402,6 +443,10 @@ impl EmulationTask {
                             emulation.destroy(handle).await;
                         }
                     }
+                    ProxyRequest::UpdateConfig(input_config) => {
+                        self.input_config = input_config;
+                        emulation.update_config(input_config);
+                    }
                     ProxyRequest::Terminate => break Ok(()),
                     ProxyRequest::Reenable => continue,
                 },
@@ -426,6 +471,7 @@ async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
             ProxyRequest::Input(_, _) => continue,
             ProxyRequest::Remove(_) => continue,
             ProxyRequest::Reenable => continue,
+            ProxyRequest::UpdateConfig(_) => continue,
         }
     }
 }

--- a/src/emulation_test.rs
+++ b/src/emulation_test.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use clap::Args;
-use input_emulation::{InputEmulation, InputEmulationError};
+use input_emulation::{InputConfig, InputEmulation, InputEmulationError};
 use input_event::{Event, PointerEvent};
 use std::f64::consts::PI;
 use std::time::{Duration, Instant};
@@ -22,7 +22,11 @@ pub async fn run(config: Config, _args: TestEmulationArgs) -> Result<(), InputEm
     log::info!("running input emulation test");
 
     let backend = config.emulation_backend().map(|b| b.into());
-    let mut emulation = InputEmulation::new(backend).await?;
+    let input_config: InputConfig = InputConfig {
+        invert_scroll: config.invert_scroll(),
+        mouse_sensitivity: config.mouse_sensitivity(),
+    };
+    let mut emulation = InputEmulation::new(backend, input_config).await?;
     emulation.create(0).await;
 
     let start = Instant::now();

--- a/src/service.rs
+++ b/src/service.rs
@@ -100,7 +100,11 @@ impl Service {
         let capture_backend = config.capture_backend().map(|b| b.into());
         let capture = Capture::new(capture_backend, conn, config.release_bind());
         let emulation_backend = config.emulation_backend().map(|b| b.into());
-        let emulation = Emulation::new(emulation_backend, listener);
+        let emulation = Emulation::new(
+            emulation_backend,
+            listener,
+            (config.invert_scroll(), config.mouse_sensitivity()),
+        );
 
         // create dns resolver
         let resolver = DnsResolver::new()?;
@@ -215,6 +219,12 @@ impl Service {
                 self.update_enter_hook(handle, enter_hook)
             }
             FrontendRequest::SaveConfiguration => self.save_config(),
+            FrontendRequest::UpdateScrollingInversion(invert_scroll) => {
+                self.update_scrolling_inversion(invert_scroll)
+            }
+            FrontendRequest::UpdateMouseSensitivity(mouse_sensitivity) => {
+                self.update_mouse_sensitivity(mouse_sensitivity)
+            }
         }
     }
 
@@ -255,6 +265,8 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
+        self.update_scrolling_inversion(self.config.invert_scroll());
+        self.update_mouse_sensitivity(self.config.mouse_sensitivity());
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()
@@ -580,6 +592,15 @@ impl Service {
             .map(|(c, s)| FrontendEvent::State(handle, c, s))
             .unwrap_or(FrontendEvent::NoSuchClient(handle));
         self.notify_frontend(event);
+    }
+
+    fn update_scrolling_inversion(&mut self, invert_scroll: bool) {
+        self.emulation.request_scrolling_inversion(invert_scroll);
+    }
+
+    fn update_mouse_sensitivity(&mut self, mouse_sensitivity: f64) {
+        self.emulation
+            .request_mouse_sensitivity_change(mouse_sensitivity);
     }
 
     fn spawn_hook_command(&self, handle: ClientHandle) {


### PR DESCRIPTION
## Summary

- add optional `[input_post_processing]` settings for pointer sensitivity and scroll inversion
- apply configuration changes immediately to active input emulation, including CLI-triggered updates
- add `set-mouse-sensitivity` and `invert-scrolling` CLI commands
- document the settings and cover event transformation and CLI parsing with unit tests

If the new configuration section is omitted, behavior remains unchanged (`mouse_sensitivity = 1.0`, `invert_scroll = false`).

## Motivation

Pointer speed and scroll direction can feel inconsistent when input crosses operating systems. Receiver-side post-processing lets users compensate without changing the local mouse settings on either machine.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- manually verified macOS-to-Arch/Hyprland pointer sensitivity adjustment

## Attribution

This refreshes and supersedes #347 by @NeoTheFox, rebasing the work onto current `main` and adding runtime propagation, documentation, and tests. The implementation commit retains the original author as a co-author.
