### PR TITLE
fix(macos): prevent bidirectional capture loops

### DIFF
--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -42,6 +42,10 @@ impl Capture for DummyInputCapture {
         Ok(())
     }
 
+    async fn set_enter_only(&mut self, _pos: Position, _enabled: bool) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -628,6 +628,10 @@ impl Capture for LayerShellInputCapture {
         Ok(inner.flush_events()?)
     }
 
+    async fn set_enter_only(&mut self, _pos: Position, _enabled: bool) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
         log::debug!("releasing pointer");
         let inner = self.0.get_mut();

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Display,
-    mem::swap,
     task::{Poll, ready},
 };
 
@@ -119,6 +118,10 @@ impl Display for Backend {
 pub struct InputCapture {
     /// capture backend
     capture: Box<dyn Capture>,
+    /// handles used only to return an incoming emulated pointer
+    enter_only_handles: HashSet<CaptureHandle>,
+    /// number of enter-only handles at each position
+    enter_only_positions: HashMap<Position, usize>,
     /// keys pressed by active capture
     pressed_keys: HashSet<scancode::Linux>,
     /// map from position to ids
@@ -132,17 +135,46 @@ pub struct InputCapture {
 impl InputCapture {
     /// create a new client with the given id
     pub async fn create(&mut self, id: CaptureHandle, pos: Position) -> Result<(), CaptureError> {
+        self.create_inner(id, pos, false).await
+    }
+
+    /// Create a capture used only to return an incoming emulated pointer.
+    pub async fn create_enter_only(
+        &mut self,
+        id: CaptureHandle,
+        pos: Position,
+    ) -> Result<(), CaptureError> {
+        self.create_inner(id, pos, true).await
+    }
+
+    async fn create_inner(
+        &mut self,
+        id: CaptureHandle,
+        pos: Position,
+        enter_only: bool,
+    ) -> Result<(), CaptureError> {
         assert!(!self.id_map.contains_key(&id));
 
         self.id_map.insert(id, pos);
 
-        if let Some(v) = self.position_map.get_mut(&pos) {
+        let result = if let Some(v) = self.position_map.get_mut(&pos) {
             v.push(id);
             Ok(())
         } else {
             self.position_map.insert(pos, vec![id]);
             self.capture.create(pos).await
+        };
+        result?;
+
+        if enter_only {
+            self.enter_only_handles.insert(id);
+            let count = self.enter_only_positions.entry(pos).or_default();
+            *count += 1;
+            if *count == 1 {
+                self.capture.set_enter_only(pos, true).await?;
+            }
         }
+        Ok(())
     }
 
     /// destroy the client with the given id, if it exists
@@ -151,6 +183,18 @@ impl InputCapture {
             .id_map
             .remove(&id)
             .expect("no position for this handle");
+
+        if self.enter_only_handles.remove(&id) {
+            let count = self
+                .enter_only_positions
+                .get_mut(&pos)
+                .expect("no enter-only count for this handle");
+            *count -= 1;
+            if *count == 0 {
+                self.enter_only_positions.remove(&pos);
+                self.capture.set_enter_only(pos, false).await?;
+            }
+        }
 
         log::debug!("destroying capture {id} @ {pos}");
         let remaining = self.position_map.get_mut(&pos).expect("id vector");
@@ -194,6 +238,8 @@ impl InputCapture {
         let capture = create(backend).await?;
         Ok(Self {
             capture,
+            enter_only_handles: Default::default(),
+            enter_only_positions: Default::default(),
             id_map: Default::default(),
             pending: Default::default(),
             position_map: Default::default(),
@@ -228,49 +274,53 @@ impl Stream for InputCapture {
             return Poll::Ready(Some(Ok(e)));
         }
 
-        // ready
-        let event = ready!(self.capture.poll_next_unpin(cx));
+        loop {
+            // ready
+            let event = ready!(self.capture.poll_next_unpin(cx));
 
-        // stream closed
-        let event = match event {
-            Some(e) => e,
-            None => return Poll::Ready(None),
-        };
+            // stream closed
+            let event = match event {
+                Some(e) => e,
+                None => return Poll::Ready(None),
+            };
 
-        // error occurred
-        let (pos, event) = match event {
-            Ok(e) => e,
-            Err(e) => return Poll::Ready(Some(Err(e))),
-        };
+            // error occurred
+            let (pos, event) = match event {
+                Ok(e) => e,
+                Err(e) => return Poll::Ready(Some(Err(e))),
+            };
+            let event_requires_enter_only = self.capture.last_event_requires_enter_only();
 
-        // handle key presses
-        if let CaptureEvent::Input(Event::Keyboard(KeyboardEvent::Key { key, state, .. })) = event {
-            self.update_pressed_keys(key, state);
-        }
+            // handle key presses
+            if let CaptureEvent::Input(Event::Keyboard(KeyboardEvent::Key { key, state, .. })) =
+                event
+            {
+                self.update_pressed_keys(key, state);
+            }
 
-        let len = self
-            .position_map
-            .get(&pos)
-            .map(|ids| ids.len())
-            .unwrap_or(0);
+            let handles = self
+                .position_map
+                .get(&pos)
+                .map(|ids| {
+                    route_handles(
+                        ids,
+                        &self.enter_only_handles,
+                        event,
+                        event_requires_enter_only,
+                    )
+                })
+                .unwrap_or_default();
 
-        match len {
-            0 => Poll::Pending,
-            1 => Poll::Ready(Some(Ok((
-                self.position_map.get(&pos).expect("no id")[0],
-                event,
-            )))),
-            _ => {
-                let mut position_map = HashMap::new();
-                swap(&mut self.position_map, &mut position_map);
-                {
-                    for &id in position_map.get(&pos).expect("position") {
+            match handles.len() {
+                0 => continue,
+                1 => return Poll::Ready(Some(Ok((handles[0], event)))),
+                _ => {
+                    for id in handles {
                         self.pending.push_back((id, event));
                     }
-                }
-                swap(&mut self.position_map, &mut position_map);
 
-                Poll::Ready(Some(Ok(self.pending.pop_front().expect("event"))))
+                    return Poll::Ready(Some(Ok(self.pending.pop_front().expect("event"))));
+                }
             }
         }
     }
@@ -284,11 +334,36 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
     /// destroy the client with the given id, if it exists
     async fn destroy(&mut self, pos: Position) -> Result<(), CaptureError>;
 
+    /// Mark a position as an incoming-pointer return edge.
+    async fn set_enter_only(&mut self, pos: Position, enabled: bool) -> Result<(), CaptureError>;
+
+    /// Whether the most recently yielded event must go only to enter-only handles.
+    fn last_event_requires_enter_only(&self) -> bool {
+        false
+    }
+
     /// release mouse
     async fn release(&mut self) -> Result<(), CaptureError>;
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;
+}
+
+fn route_handles(
+    handles: &[CaptureHandle],
+    enter_only_handles: &HashSet<CaptureHandle>,
+    event: CaptureEvent,
+    event_requires_enter_only: bool,
+) -> Vec<CaptureHandle> {
+    if event == CaptureEvent::Begin && event_requires_enter_only {
+        handles
+            .iter()
+            .copied()
+            .filter(|handle| enter_only_handles.contains(handle))
+            .collect()
+    } else {
+        handles.to_vec()
+    }
 }
 
 async fn create_backend(
@@ -348,4 +423,113 @@ async fn create(
         }
     }
     Err(CaptureCreationError::NoAvailableBackend)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet, VecDeque},
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use async_trait::async_trait;
+    use futures::task::noop_waker_ref;
+    use futures_core::Stream;
+
+    use super::{Capture, CaptureError, CaptureEvent, InputCapture, Position, route_handles};
+
+    struct QueuedCapture {
+        events: VecDeque<(Position, CaptureEvent, bool)>,
+        last_event_requires_enter_only: bool,
+    }
+
+    impl Stream for QueuedCapture {
+        type Item = Result<(Position, CaptureEvent), CaptureError>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.events.pop_front() {
+                Some((pos, event, requires_enter_only)) => {
+                    self.last_event_requires_enter_only = requires_enter_only;
+                    Poll::Ready(Some(Ok((pos, event))))
+                }
+                None => Poll::Pending,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Capture for QueuedCapture {
+        async fn create(&mut self, _pos: Position) -> Result<(), CaptureError> {
+            Ok(())
+        }
+
+        async fn destroy(&mut self, _pos: Position) -> Result<(), CaptureError> {
+            Ok(())
+        }
+
+        async fn set_enter_only(
+            &mut self,
+            _pos: Position,
+            _enabled: bool,
+        ) -> Result<(), CaptureError> {
+            Ok(())
+        }
+
+        fn last_event_requires_enter_only(&self) -> bool {
+            self.last_event_requires_enter_only
+        }
+
+        async fn release(&mut self) -> Result<(), CaptureError> {
+            Ok(())
+        }
+
+        async fn terminate(&mut self) -> Result<(), CaptureError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn emulated_begin_is_routed_only_to_enter_only_handles() {
+        let enter_only = HashSet::from([2]);
+        assert_eq!(
+            route_handles(&[1, 2], &enter_only, CaptureEvent::Begin, true),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn physical_begin_is_routed_to_all_handles() {
+        let enter_only = HashSet::from([2]);
+        assert_eq!(
+            route_handles(&[1, 2], &enter_only, CaptureEvent::Begin, false),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn unroutable_event_does_not_stall_the_next_ready_event() {
+        let backend = QueuedCapture {
+            events: VecDeque::from([
+                (Position::Left, CaptureEvent::Begin, true),
+                (Position::Left, CaptureEvent::Begin, false),
+            ]),
+            last_event_requires_enter_only: false,
+        };
+        let mut capture = InputCapture {
+            capture: Box::new(backend),
+            enter_only_handles: HashSet::new(),
+            enter_only_positions: HashMap::new(),
+            pressed_keys: HashSet::new(),
+            id_map: HashMap::from([(7, Position::Left)]),
+            pending: VecDeque::new(),
+            position_map: HashMap::from([(Position::Left, vec![7])]),
+        };
+        let mut context = Context::from_waker(noop_waker_ref());
+
+        match Pin::new(&mut capture).poll_next(&mut context) {
+            Poll::Ready(Some(Ok((7, CaptureEvent::Begin)))) => {}
+            other => panic!("unexpected poll result: {other:?}"),
+        }
+    }
 }

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -594,6 +594,10 @@ impl LanMouseInputCapture for LibeiInputCapture {
         Ok(())
     }
 
+    async fn set_enter_only(&mut self, _pos: Position, _enabled: bool) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
         self.notify_release.notify_waiters();
         Ok(())

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -38,6 +38,11 @@ use tokio::sync::{
     oneshot,
 };
 
+// Events synthesized by Lan Mouse are posted at the HID event tap and are
+// visible to our session event tap again. Marked motion may signal that an
+// incoming pointer wants to return, but must not start a new outgoing capture.
+const LAN_MOUSE_EVENT_MARKER: i64 = 0x4c41_4e4d_4f55_5345;
+
 #[derive(Debug, Default)]
 struct Bounds {
     xmin: f64,
@@ -50,8 +55,25 @@ struct Bounds {
 struct InputCaptureState {
     /// active capture positions
     active_clients: Lazy<HashSet<Position>>,
+    /// positions used to return an incoming emulated pointer
+    enter_only_clients: HashSet<Position>,
+    /// positions that physical local input may currently enter
+    ///
+    /// A position is disarmed after crossing and is only re-armed once a
+    /// physical pointer produces a separate inward motion.
+    /// This prevents macOS cursor warps at the edge from immediately starting
+    /// the opposite capture after an incoming pointer returns.
+    physical_armed_clients: HashSet<Position>,
+    /// positions that emulated input may currently use as a return signal
+    ///
+    /// Incoming emulation starts with a cursor warp at the entry edge. That
+    /// warp must not immediately signal a return. Emulated input is armed only
+    /// after it moves into the desktop and is disarmed after one return signal.
+    emulated_armed_clients: HashSet<Position>,
     /// the currently entered capture position, if any
     current_pos: Option<Position>,
+    /// provenance of events belonging to the active capture
+    current_source: Option<InputSource>,
     /// position where the cursor was captured
     enter_position: Option<CGPoint>,
     /// bounds of the input capture area
@@ -60,12 +82,19 @@ struct InputCaptureState {
     modifier_state: XMods,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputSource {
+    Physical,
+    Emulated,
+}
+
 #[derive(Debug)]
 enum ProducerEvent {
     Release,
     Create(Position),
     Destroy(Position),
-    Grab(Position),
+    SetEnterOnly(Position, bool),
+    Grab(Position, InputSource),
     EventTapDisabled,
     DisplayReconfigured,
 }
@@ -74,7 +103,11 @@ impl InputCaptureState {
     fn new() -> Result<Self, MacosCaptureCreationError> {
         let mut res = Self {
             active_clients: Lazy::new(HashSet::new),
+            enter_only_clients: HashSet::new(),
+            physical_armed_clients: HashSet::new(),
+            emulated_armed_clients: HashSet::new(),
             current_pos: None,
+            current_source: None,
             enter_position: None,
             bounds: Bounds::default(),
             modifier_state: Default::default(),
@@ -83,7 +116,22 @@ impl InputCaptureState {
         Ok(res)
     }
 
-    fn crossed(&mut self, event: &CGEvent) -> Option<Position> {
+    fn arm_clients_on_inward_motion(&mut self, event: &CGEvent, emulated: bool) {
+        let relative_x = event.get_double_value_field(EventField::MOUSE_EVENT_DELTA_X);
+        let relative_y = event.get_double_value_field(EventField::MOUSE_EVENT_DELTA_Y);
+
+        for &position in self.active_clients.iter() {
+            if is_inward_motion(position, relative_x, relative_y) {
+                if emulated {
+                    self.emulated_armed_clients.insert(position);
+                } else {
+                    self.physical_armed_clients.insert(position);
+                }
+            }
+        }
+    }
+
+    fn crossing_position(&self, event: &CGEvent) -> Option<Position> {
         let location = event.location();
         let relative_x = event.get_double_value_field(EventField::MOUSE_EVENT_DELTA_X);
         let relative_y = event.get_double_value_field(EventField::MOUSE_EVENT_DELTA_Y);
@@ -147,10 +195,7 @@ impl InputCaptureState {
         CGDisplay::show_cursor(&CGDisplay::main()).map_err(CaptureError::CoreGraphics)
     }
 
-    async fn handle_producer_event(
-        &mut self,
-        producer_event: ProducerEvent,
-    ) -> Result<(), CaptureError> {
+    fn handle_producer_event(&mut self, producer_event: ProducerEvent) -> Result<(), CaptureError> {
         log::debug!("handling event: {producer_event:?}");
         match producer_event {
             ProducerEvent::Release => {
@@ -158,24 +203,38 @@ impl InputCaptureState {
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
+                self.current_source = None;
             }
-            ProducerEvent::Grab(pos) => {
+            ProducerEvent::Grab(pos, source) => {
                 if self.current_pos.is_none() {
                     self.hide_cursor()?;
                     self.current_pos = Some(pos);
+                    self.current_source = Some(source);
                 }
             }
             ProducerEvent::Create(p) => {
                 self.active_clients.insert(p);
+                self.physical_armed_clients.insert(p);
             }
             ProducerEvent::Destroy(p) => {
+                self.physical_armed_clients.remove(&p);
+                self.emulated_armed_clients.remove(&p);
+                self.enter_only_clients.remove(&p);
                 if let Some(current) = self.current_pos {
                     if current == p {
                         self.show_cursor()?;
                         self.current_pos = None;
+                        self.current_source = None;
                     };
                 }
                 self.active_clients.remove(&p);
+            }
+            ProducerEvent::SetEnterOnly(p, enabled) => {
+                if enabled {
+                    self.enter_only_clients.insert(p);
+                } else {
+                    self.enter_only_clients.remove(&p);
+                }
             }
             ProducerEvent::EventTapDisabled => {
                 // Tap death can happen mid-capture (TCC Accessibility
@@ -186,6 +245,7 @@ impl InputCaptureState {
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
+                self.current_source = None;
                 return Err(CaptureError::EventTapDisabled);
             }
             ProducerEvent::DisplayReconfigured => {
@@ -205,6 +265,25 @@ impl InputCaptureState {
         };
         Ok(())
     }
+}
+
+fn is_inward_motion(position: Position, relative_x: f64, relative_y: f64) -> bool {
+    match position {
+        Position::Left => relative_x > 0.0,
+        Position::Right => relative_x < 0.0,
+        Position::Top => relative_y > 0.0,
+        Position::Bottom => relative_y < 0.0,
+    }
+}
+
+fn is_pointer_motion_event(event_type: CGEventType) -> bool {
+    matches!(
+        event_type,
+        CGEventType::MouseMoved
+            | CGEventType::LeftMouseDragged
+            | CGEventType::RightMouseDragged
+            | CGEventType::OtherMouseDragged
+    )
 }
 
 fn get_events(
@@ -408,7 +487,7 @@ fn get_events(
 fn create_event_tap<'a>(
     client_state: Arc<Mutex<InputCaptureState>>,
     notify_tx: Sender<ProducerEvent>,
-    event_tx: Sender<(Position, CaptureEvent)>,
+    event_tx: Sender<(Position, CaptureEvent, bool)>,
 ) -> Result<CGEventTap<'a>, MacosCaptureCreationError> {
     // Shared slot for the tap's mach port pointer. Stored as `usize`
     // because raw pointers aren't `Send`, but the integer
@@ -439,9 +518,22 @@ fn create_event_tap<'a>(
                                    event_type: CGEventType,
                                    cg_ev: &CGEvent| {
         log::trace!("Got event from tap: {event_type:?}");
+
         let mut state = client_state.blocking_lock();
         let mut capture_position = None;
         let mut res_events = vec![];
+        let mut drop_event = false;
+        let mut route_enter_only = false;
+        let source_user_data = cg_ev.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA);
+        let source_pid = cg_ev.get_integer_value_field(EventField::EVENT_SOURCE_UNIX_PROCESS_ID);
+        let own_pid = i64::from(std::process::id());
+        let is_lan_mouse_event =
+            source_user_data == LAN_MOUSE_EVENT_MARKER || source_pid == own_pid;
+        let input_source = if is_lan_mouse_event {
+            InputSource::Emulated
+        } else {
+            InputSource::Physical
+        };
 
         if matches!(event_type, CGEventType::TapDisabledByTimeout) {
             // The kernel disables the tap when our callback runs
@@ -484,6 +576,7 @@ fn create_event_tap<'a>(
                 let _ = CGDisplay::show_cursor(&CGDisplay::main());
                 state.current_pos = None;
             }
+            state.current_source = None;
             notify_tx
                 .blocking_send(ProducerEvent::EventTapDisabled)
                 .unwrap_or_else(|e| {
@@ -494,7 +587,15 @@ fn create_event_tap<'a>(
 
         // Are we in a client?
         if let Some(current_pos) = state.current_pos {
+            // Do not fold events from the other source into an active capture.
+            // Physical and remotely emulated pointers may both be producing
+            // events in the same session.
+            if state.current_source != Some(input_source) {
+                return CallbackResult::Keep;
+            }
+
             capture_position = Some(current_pos);
+            drop_event = true;
             get_events(
                 &event_type,
                 cg_ev,
@@ -506,39 +607,78 @@ fn create_event_tap<'a>(
             });
 
             // Keep (hidden) cursor at the edge of the screen
-            if matches!(
-                event_type,
-                CGEventType::MouseMoved
-                    | CGEventType::LeftMouseDragged
-                    | CGEventType::RightMouseDragged
-                    | CGEventType::OtherMouseDragged
-            ) {
+            if is_pointer_motion_event(event_type) {
                 state.reset_cursor().unwrap_or_else(|e| log::warn!("{e}"));
             }
-        } else if matches!(event_type, CGEventType::MouseMoved) {
+        } else if is_pointer_motion_event(event_type) {
             // Did we cross a barrier?
-            if let Some(new_pos) = state.crossed(cg_ev) {
-                capture_position = Some(new_pos);
-                state
-                    .start_capture(cg_ev, new_pos)
-                    .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin);
-                notify_tx
-                    .blocking_send(ProducerEvent::Grab(new_pos))
-                    .expect("Failed to send notification");
+            if let Some(new_pos) = state.crossing_position(cg_ev) {
+                let crossing_is_armed = if input_source == InputSource::Emulated {
+                    state.emulated_armed_clients.remove(&new_pos)
+                } else {
+                    state.physical_armed_clients.remove(&new_pos)
+                };
+                if crossing_is_armed {
+                    log::debug!(
+                        "pointer crossed {new_pos}: source_pid={source_pid}, own_pid={own_pid}, \
+                         source_user_data={source_user_data}, synthesized={is_lan_mouse_event}"
+                    );
+                    capture_position = Some(new_pos);
+                    if input_source == InputSource::Emulated
+                        && state.enter_only_clients.contains(&new_pos)
+                    {
+                        // Let only the EnterOnly handle notify the remote sender
+                        // that its pointer crossed back. Do not grab/hide the
+                        // local cursor and do not drop the synthesized event.
+                        route_enter_only = true;
+                        res_events.push(CaptureEvent::Begin);
+                    } else {
+                        drop_event = true;
+                        state
+                            .start_capture(cg_ev, new_pos)
+                            .unwrap_or_else(|e| log::warn!("{e}"));
+                        res_events.push(CaptureEvent::Begin);
+                        state
+                            .handle_producer_event(ProducerEvent::Grab(new_pos, input_source))
+                            .unwrap_or_else(|e| log::warn!("failed to grab pointer: {e}"));
+                    }
+                } else {
+                    log::debug!(
+                        "ignoring disarmed {} crossing at {new_pos}",
+                        if is_lan_mouse_event {
+                            "emulated"
+                        } else {
+                            "physical"
+                        }
+                    );
+                }
+            } else {
+                // Rearm on the first separate inward motion. The initial
+                // outward crossing stays disarmed while even a short
+                // inward-then-return gesture works.
+                state.arm_clients_on_inward_motion(cg_ev, input_source == InputSource::Emulated);
             }
         }
+
+        // Do not hold the capture-state mutex while waiting for space in the
+        // bounded event channel. The consumer may need this same mutex to
+        // release or reconfigure capture before it can receive another event.
+        drop(state);
 
         if let Some(pos) = capture_position {
             res_events.iter().for_each(|e| {
                 // error must be ignored, since the event channel
                 // may already be closed when the InputCapture instance is dropped.
-                let _ = event_tx.blocking_send((pos, *e));
+                let _ = event_tx.blocking_send((pos, *e, route_enter_only));
             });
-            // Returning Drop should stop the event from being processed
-            // but core fundation still returns the event
-            cg_ev.set_type(CGEventType::Null);
-            CallbackResult::Drop
+            if drop_event {
+                // Returning Drop should stop the event from being processed,
+                // but Core Foundation still returns the event.
+                cg_ev.set_type(CGEventType::Null);
+                CallbackResult::Drop
+            } else {
+                CallbackResult::Keep
+            }
         } else {
             CallbackResult::Keep
         }
@@ -574,7 +714,7 @@ fn create_event_tap<'a>(
 
 fn event_tap_thread(
     client_state: Arc<Mutex<InputCaptureState>>,
-    event_tx: Sender<(Position, CaptureEvent)>,
+    event_tx: Sender<(Position, CaptureEvent, bool)>,
     notify_tx: Sender<ProducerEvent>,
     ready: std::sync::mpsc::Sender<Result<CFRunLoop, MacosCaptureCreationError>>,
     exit: oneshot::Sender<()>,
@@ -650,9 +790,10 @@ extern "C" fn display_reconfiguration_callback(_display: u32, flags: u32, user_i
 }
 
 pub struct MacOSInputCapture {
-    event_rx: Receiver<(Position, CaptureEvent)>,
-    notify_tx: Sender<ProducerEvent>,
+    event_rx: Receiver<(Position, CaptureEvent, bool)>,
+    last_event_requires_enter_only: bool,
     run_loop: CFRunLoop,
+    state: Arc<Mutex<InputCaptureState>>,
 }
 
 impl MacOSInputCapture {
@@ -685,6 +826,7 @@ impl MacOSInputCapture {
         // wait for event tap creation result
         let run_loop = ready_rx.recv().expect("channel closed")?;
 
+        let control_state = state.clone();
         let _tap_task: tokio::task::JoinHandle<()> = tokio::task::spawn_local(async move {
             loop {
                 tokio::select! {
@@ -693,7 +835,7 @@ impl MacOSInputCapture {
                             break;
                         };
                         let mut state = state.lock().await;
-                        state.handle_producer_event(producer_event).await.unwrap_or_else(|e| {
+                        state.handle_producer_event(producer_event).unwrap_or_else(|e| {
                             log::error!("Failed to handle producer event: {e}");
                         })
                     }
@@ -706,8 +848,9 @@ impl MacOSInputCapture {
 
         Ok(Self {
             event_rx,
-            notify_tx,
+            last_event_requires_enter_only: false,
             run_loop,
+            state: control_state,
         })
     }
 }
@@ -753,32 +896,42 @@ impl Drop for MacOSInputCapture {
 #[async_trait]
 impl Capture for MacOSInputCapture {
     async fn create(&mut self, pos: Position) -> Result<(), CaptureError> {
-        let notify_tx = self.notify_tx.clone();
-        tokio::task::spawn_local(async move {
-            log::debug!("creating capture, {pos}");
-            let _ = notify_tx.send(ProducerEvent::Create(pos)).await;
-            log::debug!("done !");
-        });
+        log::debug!("creating capture, {pos}");
+        self.state
+            .lock()
+            .await
+            .handle_producer_event(ProducerEvent::Create(pos))?;
+        log::debug!("done !");
         Ok(())
     }
 
     async fn destroy(&mut self, pos: Position) -> Result<(), CaptureError> {
-        let notify_tx = self.notify_tx.clone();
-        tokio::task::spawn_local(async move {
-            log::debug!("destroying capture {pos}");
-            let _ = notify_tx.send(ProducerEvent::Destroy(pos)).await;
-            log::debug!("done !");
-        });
+        log::debug!("destroying capture {pos}");
+        self.state
+            .lock()
+            .await
+            .handle_producer_event(ProducerEvent::Destroy(pos))?;
+        log::debug!("done !");
         Ok(())
     }
 
+    async fn set_enter_only(&mut self, pos: Position, enabled: bool) -> Result<(), CaptureError> {
+        self.state
+            .lock()
+            .await
+            .handle_producer_event(ProducerEvent::SetEnterOnly(pos, enabled))
+    }
+
+    fn last_event_requires_enter_only(&self) -> bool {
+        self.last_event_requires_enter_only
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
-        let notify_tx = self.notify_tx.clone();
-        tokio::task::spawn_local(async move {
-            log::debug!("notifying Release");
-            let _ = notify_tx.send(ProducerEvent::Release).await;
-        });
-        Ok(())
+        log::debug!("notifying Release");
+        self.state
+            .lock()
+            .await
+            .handle_producer_event(ProducerEvent::Release)
     }
 
     async fn terminate(&mut self) -> Result<(), CaptureError> {
@@ -792,8 +945,39 @@ impl Stream for MacOSInputCapture {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match ready!(self.event_rx.poll_recv(cx)) {
             None => Poll::Ready(None),
-            Some(e) => Poll::Ready(Some(Ok(e))),
+            Some((pos, event, event_requires_enter_only)) => {
+                self.last_event_requires_enter_only = event_requires_enter_only;
+                Poll::Ready(Some(Ok((pos, event))))
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CGEventType, Position, is_inward_motion, is_pointer_motion_event};
+
+    #[test]
+    fn even_short_inward_motion_rearms_each_edge() {
+        assert!(is_inward_motion(Position::Left, 0.5, 0.0));
+        assert!(is_inward_motion(Position::Right, -0.5, 0.0));
+        assert!(is_inward_motion(Position::Top, 0.0, 0.5));
+        assert!(is_inward_motion(Position::Bottom, 0.0, -0.5));
+
+        assert!(!is_inward_motion(Position::Left, -1.0, 0.0));
+        assert!(!is_inward_motion(Position::Right, 1.0, 0.0));
+        assert!(!is_inward_motion(Position::Top, 0.0, -1.0));
+        assert!(!is_inward_motion(Position::Bottom, 0.0, 1.0));
+        assert!(!is_inward_motion(Position::Left, 0.0, 0.0));
+    }
+
+    #[test]
+    fn dragged_pointer_events_are_motion_events() {
+        assert!(is_pointer_motion_event(CGEventType::MouseMoved));
+        assert!(is_pointer_motion_event(CGEventType::LeftMouseDragged));
+        assert!(is_pointer_motion_event(CGEventType::RightMouseDragged));
+        assert!(is_pointer_motion_event(CGEventType::OtherMouseDragged));
+        assert!(!is_pointer_motion_event(CGEventType::LeftMouseDown));
     }
 }
 

--- a/input-capture/src/windows.rs
+++ b/input-capture/src/windows.rs
@@ -29,6 +29,10 @@ impl Capture for WindowsInputCapture {
         Ok(())
     }
 
+    async fn set_enter_only(&mut self, _pos: Position, _enabled: bool) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
         self.event_thread.release_capture();
         Ok(())

--- a/input-capture/src/x11.rs
+++ b/input-capture/src/x11.rs
@@ -23,6 +23,10 @@ impl Capture for X11InputCapture {
         Ok(())
     }
 
+    async fn set_enter_only(&mut self, _pos: Position, _enabled: bool) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn release(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -27,6 +27,9 @@ use super::error::MacOSEmulationCreationError;
 const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
 const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
+// Tag events posted by Lan Mouse so the capture backend in this process can
+// distinguish them from physical input and avoid bidirectional capture loops.
+const LAN_MOUSE_EVENT_MARKER: i64 = 0x4c41_4e4d_4f55_5345;
 
 pub(crate) struct MacOSEmulation {
     /// global event source for all events
@@ -198,6 +201,7 @@ fn key_event(event_source: CGEventSource, key: u16, state: u8, modifiers: XMods)
         flags |= CGEventFlags::CGEventFlagNumericPad | CGEventFlags::CGEventFlagSecondaryFn;
     }
     event.set_flags(flags);
+    event.set_integer_value_field(EventField::EVENT_SOURCE_USER_DATA, LAN_MOUSE_EVENT_MARKER);
     event.post(CGEventTapLocation::HID);
     log::trace!("key event: {key} {state}");
 }
@@ -210,6 +214,7 @@ fn modifier_event(event_source: CGEventSource, depressed: XMods) {
     let flags = to_cgevent_flags(depressed);
     event.set_type(CGEventType::FlagsChanged);
     event.set_flags(flags);
+    event.set_integer_value_field(EventField::EVENT_SOURCE_USER_DATA, LAN_MOUSE_EVENT_MARKER);
     event.post(CGEventTapLocation::HID);
     log::trace!("modifiers updated: {depressed:?}");
 }
@@ -333,6 +338,10 @@ impl Emulation for MacOSEmulation {
                         };
                         event.set_integer_value_field(EventField::MOUSE_EVENT_DELTA_X, dx as i64);
                         event.set_integer_value_field(EventField::MOUSE_EVENT_DELTA_Y, dy as i64);
+                        event.set_integer_value_field(
+                            EventField::EVENT_SOURCE_USER_DATA,
+                            LAN_MOUSE_EVENT_MARKER,
+                        );
                         event.post(CGEventTapLocation::HID);
                     }
                     PointerEvent::Button {
@@ -413,6 +422,10 @@ impl Emulation for MacOSEmulation {
                                 btn_num,
                             );
                         }
+                        event.set_integer_value_field(
+                            EventField::EVENT_SOURCE_USER_DATA,
+                            LAN_MOUSE_EVENT_MARKER,
+                        );
                         event.post(CGEventTapLocation::HID);
                     }
                     PointerEvent::Axis {
@@ -443,6 +456,10 @@ impl Emulation for MacOSEmulation {
                                 return Ok(());
                             }
                         };
+                        event.set_integer_value_field(
+                            EventField::EVENT_SOURCE_USER_DATA,
+                            LAN_MOUSE_EVENT_MARKER,
+                        );
                         event.post(CGEventTapLocation::HID);
                     }
                     PointerEvent::AxisDiscrete120 { axis, value } => {
@@ -469,6 +486,10 @@ impl Emulation for MacOSEmulation {
                                 return Ok(());
                             }
                         };
+                        event.set_integer_value_field(
+                            EventField::EVENT_SOURCE_USER_DATA,
+                            LAN_MOUSE_EVENT_MARKER,
+                        );
                         event.post(CGEventTapLocation::HID);
                     }
                 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -43,7 +43,7 @@ pub(crate) enum ICaptureEvent {
 pub(crate) enum CaptureType {
     /// a normal input capture
     Default,
-    /// A capture only interested in [`CaptureEvent::Begin`] events.
+    /// A capture interested only in begin/return events.
     /// The capture is released immediately, if there is no
     /// Default capture at the same position.
     EnterOnly,
@@ -199,6 +199,18 @@ impl CaptureTask {
             .2
     }
 
+    async fn create_backend_capture(
+        capture: &mut InputCapture,
+        handle: CaptureHandle,
+        pos: Position,
+        capture_type: CaptureType,
+    ) -> Result<(), CaptureError> {
+        match capture_type {
+            CaptureType::Default => capture.create(handle, pos).await,
+            CaptureType::EnterOnly => capture.create_enter_only(handle, pos).await,
+        }
+    }
+
     async fn run(mut self) {
         loop {
             if let Err(e) = self.do_capture().await {
@@ -251,9 +263,9 @@ impl CaptureTask {
 
     async fn create_captures(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
         let captures = self.captures.clone();
-        for (handle, pos, _type) in captures {
+        for (handle, pos, capture_type) in captures {
             tokio::select! {
-                r = capture.create(handle, pos) => r?,
+                r = Self::create_backend_capture(capture, handle, pos, capture_type) => r?,
                 _ = self.cancellation_token.cancelled() => return Ok(()),
             }
         }
@@ -298,7 +310,7 @@ impl CaptureTask {
                     CaptureRequest::Release => self.release_capture(capture).await?,
                     CaptureRequest::Create(h, p, t) => {
                         self.add_capture(h, p, t);
-                        capture.create(h, p).await?;
+                        Self::create_backend_capture(capture, h, p, t).await?;
                     }
                     CaptureRequest::Destroy(h) => {
                         self.remove_capture(h);
@@ -327,6 +339,9 @@ impl CaptureTask {
             return self.release_capture(capture).await;
         }
 
+        let capture_type = self.get_type(handle);
+        let pos = self.get_pos(handle);
+
         if event == CaptureEvent::Begin {
             self.event_tx
                 .send(ICaptureEvent::CaptureBegin(handle))
@@ -334,10 +349,10 @@ impl CaptureTask {
         }
 
         // enter only capture (for incoming connections)
-        if self.get_type(handle) == CaptureType::EnterOnly {
+        if capture_type == CaptureType::EnterOnly {
             // if there is no active outgoing connection at the current capture,
             // we release the capture
-            if !self.is_default_capture_at(self.get_pos(handle)) {
+            if !self.is_default_capture_at(pos) {
                 log::info!("releasing capture: no active client at this position");
                 capture.release().await?;
             }


### PR DESCRIPTION
## Problem

On a bidirectional Linux/Wayland ↔ macOS setup, Lan Mouse's macOS event tap
observes the pointer events posted by its own emulation backend. A synthesized
edge event can therefore be mistaken for a new local capture and immediately
send the pointer back, producing an Arch → macOS → Arch capture loop.

## Changes

- tag every macOS event posted by the emulation backend and retain a process-ID
  fallback when CoreGraphics does not preserve the tag
- keep separate physical and emulated edge-arm state
- ignore the initial outward crossing, then re-arm on the first inward motion
  so short reversals work
- send a synthesized return crossing only to the matching `EnterOnly` capture
  while preserving normal default capture for chained topologies
- handle dragged-pointer crossings as motion
- make capture state updates synchronous and release the state lock before
  bounded event delivery
- add routing, short-reversal, drag, and stream-progress regression tests

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features --locked`
- `cargo clippy -p input-capture --all-targets --all-features --locked -- -D warnings`
- macOS app bundle launches at commit `3d202975`
- recursive `@rpath` dependency closure and `codesign --verify --deep --strict`
  pass locally

Physical Arch → macOS → Arch verification is still running against the Arch
binary from #471 (`83e66bc`), so this is a draft.

## Scope

- the unsuccessful layer-shell re-entry experiment is not included
- macOS dylib packaging changes are not included
- this patch targets one active incoming peer; carrying peer identity through
  CoreGraphics event provenance is left for a follow-up

This is independent of #471, which contains the input post-processing changes.
