### PR TITLE
fix(libei): only restart the capture session on device change under GNOME

### DIFF
--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -18,12 +18,12 @@ use reis::{
 use std::{
     cell::Cell,
     collections::HashMap,
-    io,
+    env, io,
     num::NonZeroU32,
     os::unix::net::UnixStream,
     pin::Pin,
     rc::Rc,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     task::{Context, Poll},
 };
 use tokio::{
@@ -49,6 +49,25 @@ use super::{
 /* there is a bug in xdg-remote-desktop-portal-gnome / mutter that
  * prevents receiving further events after a session has been disabled once.
  * Therefore the session needs to be recreated when the barriers are updated */
+
+/* mutter also kills the session whenever ei devices come and go, so there the
+ * whole session has to be torn down and recreated on every device change.
+ * Elsewhere that is pure overhead: each restart costs a CreateSession +
+ * ConnectToEIS round trip, and compositors that keep per-session state around
+ * (hyprland leaks a keymap fd per eis session, see hyprwm/Hyprland) can be
+ * driven out of file descriptors by the churn.
+ * Set LM_RESTART_SESSION_ON_DEVICE_CHANGE=1/0 to override the default. */
+static RESTART_SESSION_ON_DEVICE_CHANGE: LazyLock<bool> =
+    LazyLock::new(restart_session_on_device_change);
+
+fn restart_session_on_device_change() -> bool {
+    match env::var("LM_RESTART_SESSION_ON_DEVICE_CHANGE").as_deref() {
+        Ok("1") => true,
+        Ok("0") => false,
+        _ => env::var("XDG_CURRENT_DESKTOP")
+            .is_ok_and(|desktops| desktops.to_uppercase().split(':').any(|d| d == "GNOME")),
+    }
+}
 
 /// events that necessitate restarting the capture session
 #[derive(Clone, Copy, Debug)]
@@ -555,20 +574,32 @@ async fn handle_ei_event(
             s.seat.bind_capabilities(all_capabilities);
             context.flush().map_err(|e| io::Error::new(e.kind(), e))?;
         }
-        EiEvent::SeatRemoved(_) | /* EiEvent::DeviceAdded(_) | */ EiEvent::DeviceRemoved(_) => {
+        EiEvent::SeatRemoved(_) => {
             log::debug!("releasing session: {ei_event:?}");
             release_session.notify_waiters();
+        }
+        /* EiEvent::DeviceAdded(_) | */
+        EiEvent::DeviceRemoved(_) => {
+            if *RESTART_SESSION_ON_DEVICE_CHANGE {
+                log::debug!("releasing session: {ei_event:?}");
+                release_session.notify_waiters();
+            } else {
+                log::debug!("ignoring device change: {ei_event:?}");
+            }
         }
         EiEvent::DevicePaused(_) | EiEvent::DeviceResumed(_) => {}
         EiEvent::DeviceStartEmulating(_) => log::debug!("START EMULATING"),
         EiEvent::DeviceStopEmulating(_) => log::debug!("STOP EMULATING"),
         EiEvent::Disconnected(d) => {
-            return Err(CaptureError::Disconnected(format!("{:?}", d.reason)))
+            return Err(CaptureError::Disconnected(format!("{:?}", d.reason)));
         }
         _ => {
             if let Some(pos) = current_client {
                 for event in Event::from_ei_event(ei_event) {
-                    event_tx.send((pos, CaptureEvent::Input(event))).await.expect("no channel");
+                    event_tx
+                        .send((pos, CaptureEvent::Input(event)))
+                        .await
+                        .expect("no channel");
                 }
             }
         }


### PR DESCRIPTION
## Problem

`handle_ei_event` treats `EiEvent::DeviceRemoved` as a reason to release and recreate the entire input-capture session:

```rust
EiEvent::SeatRemoved(_) | /* EiEvent::DeviceAdded(_) | */ EiEvent::DeviceRemoved(_) => {
    log::debug!("releasing session: {ei_event:?}");
    release_session.notify_waiters();
}
```

That is a workaround for mutter, which stops delivering events after a device change — the same class of bug the comment above already documents for barrier updates. But it runs on every compositor.

On everything else the restart is pure overhead: each one costs a `CreateSession` + `ConnectToEIS` round trip, and devices come and go often enough that the session is rebuilt continuously during normal use.

On compositors that keep per-session state around it is actively harmful. Hyprland allocates a keymap fd per EIS session and only reaps a session when the portal client destroys the resource, which does not happen when we drop a session this way. Sessions accumulate, and `CInputCaptureProtocol::updateKeymap()` walks all of them on every focus change, so the leak grows quadratically. On my machine Hyprland reached 45k open fds and crashed (`xkb_keymap_new_from_names()` returns NULL under EMFILE and is dereferenced unchecked). That is a Hyprland bug and I am reporting it there separately, but lan-mouse is what drives the churn: ~35 `ConnectToEIS` per 38 minutes of ordinary use.

## Change

Gate the device-change restart on GNOME. `SeatRemoved` still releases unconditionally — a seat disappearing genuinely invalidates the session.

The default comes from `XDG_CURRENT_DESKTOP`; `LM_RESTART_SESSION_ON_DEVICE_CHANGE=1/0` overrides it, for compositors that need the mutter behaviour without advertising themselves as GNOME.

## Testing

- Hyprland 0.56.1: `ConnectToEIS` churn went from ~35 per 38 min to 0, capture/release across the barrier unchanged over a multi-hour session.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.

Note: splitting the match arm makes rustfmt format that block for the first time (it previously bailed on the inline comment inside the multi-pattern arm), so the commit also carries two one-line reformats it demanded in adjacent arms. Happy to drop them into a separate commit if you'd rather keep the diff to the behaviour change.

I do not have a GNOME setup to verify the mutter path still behaves — it should be unchanged, since `XDG_CURRENT_DESKTOP` contains GNOME there, but a second pair of eyes on that would be good.