### PR TITLE
feat: enter a client with a key bind instead of a screen edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ release_bind = [ "KeyA", "KeyS", "KeyD", "KeyF" ]
 # optional port (defaults to 4242)
 port = 4242
 
+# optional key binds that enter the client(s) at a position without
+# the pointer having to cross that screen edge (see "Entering a client
+# with a key bind" below)
+[enter_binds]
+right = [ "KeyLeftCtrl", "KeyLeftAlt", "KeyRight" ]
+
 # list of authorized tls certificate fingerprints that
 # are accepted for incoming traffic
 [authorized_fingerprints]
@@ -414,6 +420,39 @@ port = 4242
 ```
 
 Where `left` can be either `left`, `right`, `top` or `bottom`.
+
+### Entering a client with a key bind
+
+An `[enter_binds]` entry makes a position reachable by holding a
+combination of keys, so the pointer no longer has to be moved into the
+corresponding screen edge:
+
+```toml
+[enter_binds]
+right = [ "KeyLeftCtrl", "KeyLeftAlt", "KeyRight" ]
+top = [ "KeyLeftCtrl", "KeyLeftAlt", "KeyUp" ]
+```
+
+Binds are keyed by position rather than by client because entering is
+position-based: crossing an edge enters *every* client at that edge,
+and a bind is deliberately no different.
+
+The bind takes effect on the machine that *sends* input and behaves
+exactly like the matching edge crossing: capture begins, the pointer is
+warped to that edge and the usual `release_bind` returns control to the
+local machine. Consequently a bind only fires while capture is
+inactive, and only for a position that currently has an active client.
+
+The key combination itself is consumed locally and is not forwarded, so
+the remote machine starts with no keys held — mirroring `release_bind`,
+which releases everything before handing control back. Keep holding the
+bind's modifiers after switching and the remote will not see them as
+held; release and press them again for that.
+
+> [!NOTE]
+> Supported on the macOS and Windows capture backends. The Linux
+> backends observe no input while capture is inactive, so binds are
+> ignored there (see [#260](https://github.com/feschber/lan-mouse/issues/260)).
 
 ## Roadmap
 - [x] Graphical frontend (gtk + libadwaita)

--- a/input-capture/src/enter_bind.rs
+++ b/input-capture/src/enter_bind.rs
@@ -1,0 +1,231 @@
+use std::collections::{HashMap, HashSet};
+
+use input_event::scancode;
+
+use crate::Position;
+
+/// Tracks the keys held down while capture is inactive and reports
+/// when the bind configured for a position becomes fully held.
+///
+/// Backends that can observe key events outside of an active capture
+/// (a global keyboard hook or event tap) feed every such key into
+/// [`Self::key_event`] and begin capture at the returned position,
+/// exactly as they would for a pointer crossing the screen edge.
+#[derive(Debug, Default)]
+pub(crate) struct EnterBindTracker {
+    binds: HashMap<Position, Vec<scancode::Linux>>,
+    pressed: HashSet<scancode::Linux>,
+}
+
+impl EnterBindTracker {
+    pub(crate) fn set_binds(&mut self, binds: HashMap<Position, Vec<scancode::Linux>>) {
+        self.binds = binds;
+        // A bind that is removed while its keys are held must not fire
+        // once a *different* bind completes, so start from a clean slate.
+        self.pressed.clear();
+    }
+
+    /// whether any bind is configured — lets a backend skip the
+    /// bookkeeping entirely in the common case
+    pub(crate) fn is_empty(&self) -> bool {
+        self.binds.is_empty()
+    }
+
+    /// Forget every held key.
+    ///
+    /// Called once a bind has fired: its keys are still physically
+    /// down, and without this the *next* key release would leave a
+    /// subset of the bind held, letting a single further keypress
+    /// re-trigger it.
+    pub(crate) fn clear(&mut self) {
+        self.pressed.clear();
+    }
+
+    /// Record a key event and report the position to enter, if the
+    /// bind for one just completed.
+    ///
+    /// `active` is the set of positions that currently have a client;
+    /// binds for any other position are ignored, so a bind can never
+    /// enter a client an edge crossing could not.
+    pub(crate) fn key_event(
+        &mut self,
+        key: scancode::Linux,
+        pressed: bool,
+        active: &HashSet<Position>,
+    ) -> Option<Position> {
+        if !pressed {
+            self.pressed.remove(&key);
+            // binds fire on the last key going *down*, never on release
+            return None;
+        }
+        self.pressed.insert(key);
+        self.binds
+            .iter()
+            .filter(|(pos, bind)| !bind.is_empty() && active.contains(pos))
+            .find(|(_, bind)| bind.iter().all(|k| self.pressed.contains(k)))
+            .map(|(&pos, _)| pos)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use input_event::scancode::Linux::{
+        KeyA, KeyB, KeyLeftAlt, KeyLeftCtrl, KeyLeftShift, KeyRight, KeyUp,
+    };
+
+    fn tracker(binds: &[(Position, &[scancode::Linux])]) -> EnterBindTracker {
+        let mut tracker = EnterBindTracker::default();
+        tracker.set_binds(
+            binds
+                .iter()
+                .map(|(pos, keys)| (*pos, keys.to_vec()))
+                .collect(),
+        );
+        tracker
+    }
+
+    fn active(positions: &[Position]) -> HashSet<Position> {
+        positions.iter().copied().collect()
+    }
+
+    #[test]
+    fn fires_once_every_key_is_held() {
+        let mut t = tracker(&[(Position::Right, &[KeyLeftCtrl, KeyLeftAlt, KeyRight])]);
+        let active = active(&[Position::Right]);
+
+        assert_eq!(t.key_event(KeyLeftCtrl, true, &active), None);
+        assert_eq!(t.key_event(KeyLeftAlt, true, &active), None);
+        assert_eq!(
+            t.key_event(KeyRight, true, &active),
+            Some(Position::Right),
+            "bind completes on the last key"
+        );
+    }
+
+    #[test]
+    fn order_of_the_keys_does_not_matter() {
+        let mut t = tracker(&[(Position::Top, &[KeyLeftCtrl, KeyUp])]);
+        let active = active(&[Position::Top]);
+
+        assert_eq!(t.key_event(KeyUp, true, &active), None);
+        assert_eq!(t.key_event(KeyLeftCtrl, true, &active), Some(Position::Top));
+    }
+
+    #[test]
+    fn does_not_fire_on_release() {
+        let mut t = tracker(&[(Position::Top, &[KeyLeftCtrl, KeyUp])]);
+        let active = active(&[Position::Top]);
+
+        t.key_event(KeyLeftCtrl, true, &active);
+        t.key_event(KeyUp, true, &active);
+        assert_eq!(
+            t.key_event(KeyUp, false, &active),
+            None,
+            "releasing a key must never enter a client"
+        );
+    }
+
+    #[test]
+    fn ignores_positions_without_a_client() {
+        let mut t = tracker(&[(Position::Right, &[KeyLeftCtrl, KeyRight])]);
+        let nothing_active = active(&[]);
+
+        t.key_event(KeyLeftCtrl, true, &nothing_active);
+        assert_eq!(
+            t.key_event(KeyRight, true, &nothing_active),
+            None,
+            "a bind must not enter a position that has no client"
+        );
+    }
+
+    #[test]
+    fn a_superset_of_the_bind_still_fires() {
+        // holding an extra key must not block the bind: users hold
+        // modifiers in whatever order and combination they like
+        let mut t = tracker(&[(Position::Left, &[KeyLeftCtrl])]);
+        let active = active(&[Position::Left]);
+
+        t.key_event(KeyLeftShift, true, &active);
+        assert_eq!(
+            t.key_event(KeyLeftCtrl, true, &active),
+            Some(Position::Left)
+        );
+    }
+
+    #[test]
+    fn unrelated_keys_do_not_fire() {
+        let mut t = tracker(&[(Position::Left, &[KeyLeftCtrl, KeyA])]);
+        let active = active(&[Position::Left]);
+
+        assert_eq!(t.key_event(KeyB, true, &active), None);
+        assert_eq!(t.key_event(KeyLeftCtrl, true, &active), None);
+    }
+
+    #[test]
+    fn clear_prevents_a_held_bind_from_retriggering() {
+        let mut t = tracker(&[(Position::Top, &[KeyLeftCtrl, KeyUp])]);
+        let active = active(&[Position::Top]);
+
+        t.key_event(KeyLeftCtrl, true, &active);
+        assert_eq!(t.key_event(KeyUp, true, &active), Some(Position::Top));
+
+        // capture has begun; the keys are still physically down
+        t.clear();
+        assert_eq!(
+            t.key_event(KeyUp, true, &active),
+            None,
+            "the whole bind has to be pressed again"
+        );
+        t.key_event(KeyLeftCtrl, true, &active);
+        assert_eq!(
+            t.key_event(KeyUp, false, &active),
+            None,
+            "and it still may not fire on release"
+        );
+    }
+
+    #[test]
+    fn keys_released_out_of_sight_do_not_stay_held() {
+        // Capture can also begin by crossing an edge, with part of a
+        // bind already held. Key events then go to the remote client
+        // instead of here, so the release of those keys is never
+        // seen — the backend clears for exactly this reason.
+        let mut t = tracker(&[(Position::Top, &[KeyLeftCtrl, KeyUp])]);
+        let active = active(&[Position::Top]);
+
+        t.key_event(KeyLeftCtrl, true, &active);
+        t.clear(); // capture began; ctrl is released unobserved
+
+        assert_eq!(
+            t.key_event(KeyUp, true, &active),
+            None,
+            "ctrl is not actually held anymore"
+        );
+    }
+
+    #[test]
+    fn empty_bind_never_fires() {
+        let mut t = tracker(&[(Position::Left, &[])]);
+        let active = active(&[Position::Left]);
+        assert_eq!(t.key_event(KeyA, true, &active), None);
+    }
+
+    #[test]
+    fn setting_binds_forgets_held_keys() {
+        let mut t = tracker(&[(Position::Left, &[KeyLeftCtrl, KeyA])]);
+        let active = active(&[Position::Left, Position::Right]);
+        t.key_event(KeyLeftCtrl, true, &active);
+
+        // reconfigured while ctrl is still held
+        t.set_binds(HashMap::from([(
+            Position::Right,
+            vec![KeyLeftCtrl, KeyRight],
+        )]));
+        assert_eq!(
+            t.key_event(KeyRight, true, &active),
+            None,
+            "ctrl was held before the new bind existed"
+        );
+    }
+}

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -15,6 +15,8 @@ pub use error::{CaptureCreationError, CaptureError, InputCaptureError};
 
 pub mod error;
 
+mod enter_bind;
+
 #[cfg(libei)]
 mod libei;
 
@@ -206,6 +208,20 @@ impl InputCapture {
         keys.iter().all(|k| self.pressed_keys.contains(k))
     }
 
+    /// Set the key binds that begin capture at the given position
+    /// without the pointer having to cross the corresponding screen
+    /// edge.
+    ///
+    /// A bind only takes effect while capture is inactive and while a
+    /// client exists at that position — the resulting capture is
+    /// indistinguishable from one started by an edge crossing.
+    ///
+    /// Backends that cannot observe key events while capture is
+    /// inactive ignore this.
+    pub fn set_enter_binds(&mut self, binds: HashMap<Position, Vec<scancode::Linux>>) {
+        self.capture.set_enter_binds(binds);
+    }
+
     fn update_pressed_keys(&mut self, key: u32, state: u8) {
         if let Ok(scancode) = scancode::Linux::try_from(key) {
             log::debug!("key: {key}, state: {state}, scancode: {scancode:?}");
@@ -289,6 +305,14 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;
+
+    /// see [`InputCapture::set_enter_binds`]
+    ///
+    /// Implementing this is optional: a backend that cannot observe
+    /// key events while capture is inactive (e.g. the input capture
+    /// portal) keeps the default no-op, which leaves entering a
+    /// client to edge crossings only.
+    fn set_enter_binds(&mut self, _binds: HashMap<Position, Vec<scancode::Linux>>) {}
 }
 
 async fn create_backend(

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -1,4 +1,7 @@
-use super::{Capture, CaptureError, CaptureEvent, Position, error::MacosCaptureCreationError};
+use super::{
+    Capture, CaptureError, CaptureEvent, Position, enter_bind::EnterBindTracker,
+    error::MacosCaptureCreationError,
+};
 use async_trait::async_trait;
 use bitflags::bitflags;
 use core_foundation::{
@@ -20,12 +23,13 @@ use core_graphics::{
 use futures_core::Stream;
 use input_event::{
     BTN_BACK, BTN_FORWARD, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT, Event, KeyboardEvent, PointerEvent,
+    scancode,
 };
 use keycode::{KeyMap, KeyMapping};
 use libc::c_void;
 use once_cell::unsync::Lazy;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     ffi::{CString, c_char},
     pin::Pin,
     sync::{Arc, OnceLock},
@@ -58,6 +62,10 @@ struct InputCaptureState {
     bounds: Bounds,
     /// current state of modifier keys
     modifier_state: XMods,
+    /// binds that begin capture without an edge crossing, fed from
+    /// the passthrough branch of the tap callback (keys pressed
+    /// *during* capture are tracked by `InputCapture` instead)
+    enter_binds: EnterBindTracker,
 }
 
 #[derive(Debug)]
@@ -68,6 +76,7 @@ enum ProducerEvent {
     Grab(Position),
     EventTapDisabled,
     DisplayReconfigured,
+    SetEnterBinds(HashMap<Position, Vec<scancode::Linux>>),
 }
 
 impl InputCaptureState {
@@ -78,6 +87,7 @@ impl InputCaptureState {
             enter_position: None,
             bounds: Bounds::default(),
             modifier_state: Default::default(),
+            enter_binds: Default::default(),
         };
         res.update_bounds()?;
         Ok(res)
@@ -118,8 +128,16 @@ impl InputCaptureState {
     }
 
     /// start the input capture by
-    fn start_capture(&mut self, event: &CGEvent, position: Position) -> Result<(), CaptureError> {
-        let mut location = event.location();
+    ///
+    /// `location` is where the pointer currently is: for an edge
+    /// crossing that is the triggering mouse event's location, for an
+    /// enter-bind it has to be queried separately since a key event
+    /// carries no meaningful pointer location.
+    fn start_capture(
+        &mut self,
+        mut location: CGPoint,
+        position: Position,
+    ) -> Result<(), CaptureError> {
         let edge_offset = 1.0;
         // move cursor location to display bounds
         match position {
@@ -164,6 +182,12 @@ impl InputCaptureState {
                     self.hide_cursor()?;
                     self.current_pos = Some(pos);
                 }
+                // Key events stop reaching the passthrough branch for
+                // the duration of the capture, so anything held right
+                // now would otherwise still count as held once we
+                // return to it — including after entering by crossing
+                // an edge, where nothing else clears the set.
+                self.enter_binds.clear();
             }
             ProducerEvent::Create(p) => {
                 self.active_clients.insert(p);
@@ -188,6 +212,7 @@ impl InputCaptureState {
                 }
                 return Err(CaptureError::EventTapDisabled);
             }
+            ProducerEvent::SetEnterBinds(binds) => self.enter_binds.set_binds(binds),
             ProducerEvent::DisplayReconfigured => {
                 // The macOS display configuration changed — a monitor
                 // was plugged in/out, the resolution changed, the
@@ -520,11 +545,73 @@ fn create_event_tap<'a>(
             if let Some(new_pos) = state.crossed(cg_ev) {
                 capture_position = Some(new_pos);
                 state
-                    .start_capture(cg_ev, new_pos)
+                    .start_capture(cg_ev.location(), new_pos)
                     .unwrap_or_else(|e| log::warn!("{e}"));
                 res_events.push(CaptureEvent::Begin);
                 notify_tx
                     .blocking_send(ProducerEvent::Grab(new_pos))
+                    .expect("Failed to send notification");
+            }
+        } else if matches!(
+            event_type,
+            CGEventType::KeyDown | CGEventType::KeyUp | CGEventType::FlagsChanged
+        ) && !state.enter_binds.is_empty()
+        {
+            // Capture is inactive, so these keys belong to the local
+            // machine and are passed through untouched — we only look
+            // at them to see whether an enter-bind became complete.
+            //
+            // `get_events` is reused rather than decoding the event
+            // here so that modifier bookkeeping stays identical to
+            // (and continuous with) the capturing branch: a modifier
+            // held down while capture begins must not be re-reported
+            // as a fresh press afterwards.
+            let mut observed = vec![];
+            let mut entered = None;
+            if let Err(e) = get_events(&event_type, cg_ev, &mut observed, &mut state.modifier_state)
+            {
+                // same as the capturing branch: a key we cannot map is
+                // worth a line, or an enter-bind containing it would
+                // silently never fire
+                log::error!("Failed to get events: {e}");
+            } else {
+                for event in &observed {
+                    let CaptureEvent::Input(Event::Keyboard(KeyboardEvent::Key {
+                        key,
+                        state: key_state,
+                        ..
+                    })) = event
+                    else {
+                        continue;
+                    };
+                    let Ok(key) = scancode::Linux::try_from(*key) else {
+                        continue;
+                    };
+                    let InputCaptureState {
+                        enter_binds,
+                        active_clients,
+                        ..
+                    } = &mut *state;
+                    if let Some(pos) = enter_binds.key_event(key, *key_state == 1, active_clients) {
+                        entered = Some(pos);
+                        break;
+                    }
+                }
+            }
+
+            if let Some(pos) = entered {
+                log::info!("entering client @ {pos}: enter-bind pressed");
+                // A key event carries no useful pointer location, so
+                // ask the window server where the cursor actually is.
+                let location = current_cursor_location().unwrap_or_else(|| cg_ev.location());
+                capture_position = Some(pos);
+                state
+                    .start_capture(location, pos)
+                    .unwrap_or_else(|e| log::warn!("{e}"));
+                state.enter_binds.clear();
+                res_events.push(CaptureEvent::Begin);
+                notify_tx
+                    .blocking_send(ProducerEvent::Grab(pos))
                     .expect("Failed to send notification");
             }
         }
@@ -712,6 +799,16 @@ impl MacOSInputCapture {
     }
 }
 
+/// Current pointer location according to the window server.
+///
+/// Keyboard events report a pointer location of their own, but it is
+/// only meaningful for pointer events, so an enter-bind has to ask
+/// for the real one instead of reading it off the triggering event.
+fn current_cursor_location() -> Option<CGPoint> {
+    let source = CGEventSource::new(CGEventSourceStateID::CombinedSessionState).ok()?;
+    Some(CGEvent::new(source).ok()?.location())
+}
+
 fn request_macos_capture_permissions() -> Result<(), MacosCaptureCreationError> {
     // Call both request functions unconditionally so macOS surfaces both
     // TCC prompts on the very first launch. TCC always returns `false` the
@@ -770,6 +867,13 @@ impl Capture for MacOSInputCapture {
             log::debug!("done !");
         });
         Ok(())
+    }
+
+    fn set_enter_binds(&mut self, binds: HashMap<Position, Vec<scancode::Linux>>) {
+        let notify_tx = self.notify_tx.clone();
+        tokio::task::spawn_local(async move {
+            let _ = notify_tx.send(ProducerEvent::SetEnterBinds(binds)).await;
+        });
     }
 
     async fn release(&mut self) -> Result<(), CaptureError> {

--- a/input-capture/src/windows.rs
+++ b/input-capture/src/windows.rs
@@ -2,6 +2,8 @@ use async_trait::async_trait;
 use core::task::{Context, Poll};
 use event_thread::EventThread;
 use futures::Stream;
+use input_event::scancode;
+use std::collections::HashMap;
 use std::pin::Pin;
 
 use std::task::ready;
@@ -36,6 +38,10 @@ impl Capture for WindowsInputCapture {
 
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
+    }
+
+    fn set_enter_binds(&mut self, binds: HashMap<Position, Vec<scancode::Linux>>) {
+        self.event_thread.set_enter_binds(binds);
     }
 }
 

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -1,5 +1,5 @@
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ptr::addr_of_mut;
 
 use std::default::Default;
@@ -18,12 +18,13 @@ use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::core::{PCWSTR, w};
 
 use windows::Win32::UI::WindowsAndMessaging::{
-    CallNextHookEx, CreateWindowExW, DispatchMessageW, EDD_GET_DEVICE_INTERFACE_NAME, GetMessageW,
-    HOOKPROC, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG, MSLLHOOKSTRUCT, PostThreadMessageW,
-    RegisterClassW, SetWindowsHookExW, TranslateMessage, WH_KEYBOARD_LL, WH_MOUSE_LL, WINDOW_STYLE,
-    WM_DISPLAYCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
-    WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_RBUTTONDOWN, WM_RBUTTONUP,
-    WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WNDPROC,
+    CallNextHookEx, CreateWindowExW, DispatchMessageW, EDD_GET_DEVICE_INTERFACE_NAME, GetCursorPos,
+    GetMessageW, HOOKPROC, KBDLLHOOKSTRUCT, LLKHF_EXTENDED, MSG, MSLLHOOKSTRUCT,
+    PostThreadMessageW, RegisterClassW, SetWindowsHookExW, TranslateMessage, WH_KEYBOARD_LL,
+    WH_MOUSE_LL, WINDOW_STYLE, WM_DISPLAYCHANGE, WM_KEYDOWN, WM_KEYUP, WM_LBUTTONDOWN,
+    WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL,
+    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_USER, WM_XBUTTONDOWN,
+    WM_XBUTTONUP, WNDCLASSW, WNDPROC,
 };
 
 use input_event::{
@@ -32,6 +33,7 @@ use input_event::{
 };
 
 use super::{CaptureEvent, Position, display_util};
+use crate::enter_bind::EnterBindTracker;
 
 pub(crate) struct EventThread {
     request_buffer: Arc<Mutex<Vec<ClientUpdate>>>,
@@ -60,6 +62,10 @@ impl EventThread {
 
     pub(crate) fn destroy(&self, pos: Position) {
         self.client_update(ClientUpdate::Destroy(pos));
+    }
+
+    pub(crate) fn set_enter_binds(&self, binds: HashMap<Position, Vec<scancode::Linux>>) {
+        self.client_update(ClientUpdate::SetEnterBinds(binds));
     }
 
     fn exit(&self) {
@@ -96,6 +102,7 @@ enum RequestType {
 enum ClientUpdate {
     Create(Position),
     Destroy(Position),
+    SetEnterBinds(HashMap<Position, Vec<scancode::Linux>>),
 }
 
 fn blocking_send_event(pos: Position, event: CaptureEvent) {
@@ -122,6 +129,8 @@ thread_local! {
     static PREV_POS: Cell<Option<(i32, i32)>> = const { Cell::new(None) };
     /// displays and generation counter
     static DISPLAYS: RefCell<(Vec<RECT>, i32)> = const { RefCell::new((Vec::new(), 0)) };
+    /// binds that enter a client without crossing a screen edge
+    static ENTER_BINDS: RefCell<EnterBindTracker> = RefCell::new(EnterBindTracker::default());
 }
 
 fn get_msg() -> Option<MSG> {
@@ -295,6 +304,9 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
         display_util::clamp_to_display_bounds(displays, prev_pos, curr_pos)
     });
     ENTRY_POINT.replace(entry_point);
+    /* keys held now stop being observed for the duration of the
+     * capture, so they must not still count as held afterwards */
+    ENTER_BINDS.with_borrow_mut(|binds| binds.clear());
 
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
@@ -331,9 +343,62 @@ unsafe extern "system" fn mouse_proc(ncode: i32, wparam: WPARAM, lparam: LPARAM)
     LRESULT(1)
 }
 
+/// Enter a client because its enter-bind was pressed rather than
+/// because the pointer crossed a screen edge.
+///
+/// The pointer is left where it is and simply becomes the reference
+/// for relative motion, the same role [`ENTRY_POINT`] plays after a
+/// barrier crossing.
+fn enter_via_bind(pos: Position) {
+    let mut point = Default::default();
+    let entry_point = match unsafe { GetCursorPos(&mut point) } {
+        Ok(()) => (point.x, point.y),
+        Err(e) => {
+            log::warn!("failed to query cursor position: {e}");
+            PREV_POS.get().unwrap_or((0, 0))
+        }
+    };
+    ACTIVE_CLIENT.replace(Some(pos));
+    ENTRY_POINT.replace(entry_point);
+    PREV_POS.replace(Some(entry_point));
+    log::info!("entering client @ {pos}: enter-bind pressed");
+    blocking_send_event(pos, CaptureEvent::Begin);
+}
+
+/// Feed a key event seen while no client is active into the
+/// enter-bind tracker, entering a client if one of the binds just
+/// completed. Returns whether the key was consumed.
+fn check_enter_bind(wparam: WPARAM, lparam: LPARAM) -> bool {
+    if ENTER_BINDS.with_borrow(|binds| binds.is_empty()) {
+        return false;
+    }
+    let Some(KeyboardEvent::Key { key, state, .. }) = to_key_event(wparam, lparam) else {
+        return false;
+    };
+    let Ok(key) = Linux::try_from(key) else {
+        return false;
+    };
+    let entered = CLIENTS.with_borrow(|clients| {
+        ENTER_BINDS.with_borrow_mut(|binds| binds.key_event(key, state == 1, clients))
+    });
+    let Some(pos) = entered else {
+        return false;
+    };
+    enter_via_bind(pos);
+    // The bind keys stay physically held — see EnterBindTracker::clear
+    ENTER_BINDS.with_borrow_mut(|binds| binds.clear());
+    true
+}
+
 unsafe extern "system" fn kybrd_proc(ncode: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     /* get active client if any */
     let Some(client) = ACTIVE_CLIENT.get() else {
+        /* no client active: the keys belong to this machine, unless
+         * they complete an enter-bind */
+        if check_enter_bind(wparam, lparam) {
+            /* swallow the key that triggered the switch */
+            return LRESULT(1);
+        }
         return CallNextHookEx(None, ncode, wparam, lparam);
     };
 
@@ -430,6 +495,9 @@ fn update_clients(request: ClientUpdate) {
                 }
             }
             CLIENTS.with_borrow_mut(|clients| clients.remove(&pos));
+        }
+        ClientUpdate::SetEnterBinds(binds) => {
+            ENTER_BINDS.with_borrow_mut(|tracker| tracker.set_binds(binds));
         }
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
+    collections::HashMap,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -61,6 +62,8 @@ enum CaptureRequest {
     Reenable,
     /// set release bind
     SetReleaseBind(Vec<scancode::Linux>),
+    /// set the binds that enter a client without an edge crossing
+    SetEnterBinds(HashMap<lan_mouse_ipc::Position, Vec<scancode::Linux>>),
 }
 
 impl Capture {
@@ -68,6 +71,7 @@ impl Capture {
         backend: Option<input_capture::Backend>,
         conn: LanMouseConnection,
         release_bind: Vec<scancode::Linux>,
+        enter_binds: HashMap<lan_mouse_ipc::Position, Vec<scancode::Linux>>,
     ) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
@@ -81,6 +85,7 @@ impl Capture {
             event_tx,
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
+            enter_binds,
             state: Default::default(),
         };
         let task = spawn_local(capture_task.run());
@@ -137,6 +142,13 @@ impl Capture {
     pub(crate) fn set_release_bind(&mut self, bind: Vec<scancode::Linux>) {
         let _ = self.request_tx.send(CaptureRequest::SetReleaseBind(bind));
     }
+
+    pub(crate) fn set_enter_binds(
+        &mut self,
+        binds: HashMap<lan_mouse_ipc::Position, Vec<scancode::Linux>>,
+    ) {
+        let _ = self.request_tx.send(CaptureRequest::SetEnterBinds(binds));
+    }
 }
 
 /// debounce a statement `$st`, i.e. the statement is executed only if the
@@ -164,6 +176,7 @@ struct CaptureTask {
     conn: LanMouseConnection,
     event_tx: Sender<ICaptureEvent>,
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
+    enter_binds: HashMap<lan_mouse_ipc::Position, Vec<scancode::Linux>>,
     request_rx: Receiver<CaptureRequest>,
     state: State,
 }
@@ -191,6 +204,13 @@ impl CaptureTask {
             .1
     }
 
+    fn capture_enter_binds(&self) -> HashMap<Position, Vec<scancode::Linux>> {
+        self.enter_binds
+            .iter()
+            .map(|(&pos, bind)| (to_capture_pos(pos), bind.clone()))
+            .collect()
+    }
+
     fn get_type(&self, handle: CaptureHandle) -> CaptureType {
         self.captures
             .iter()
@@ -214,6 +234,7 @@ impl CaptureTask {
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
+                        CaptureRequest::SetEnterBinds(binds) => self.enter_binds = binds,
                     },
                     _ = self.cancellation_token.cancelled() => return,
                 }
@@ -227,6 +248,11 @@ impl CaptureTask {
             r = InputCapture::new(self.backend) => r?,
             _ = self.cancellation_token.cancelled() => return Ok(()),
         };
+
+        // the backend is recreated whenever a capture session
+        // restarts, so the binds have to be re-applied here rather
+        // than only when they change
+        capture.set_enter_binds(self.capture_enter_binds());
 
         let _capture_guard = DropGuard::new(
             self.event_tx.clone(),
@@ -306,6 +332,10 @@ impl CaptureTask {
                     }
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);
+                    }
+                    CaptureRequest::SetEnterBinds(binds) => {
+                        self.enter_binds = binds;
+                        capture.set_enter_binds(self.capture_enter_binds());
                     }
                 },
                 _ = self.cancellation_token.cancelled() => break,

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,13 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    /// key binds that enter the client(s) at a position without the
+    /// pointer having to cross the corresponding screen edge
+    ///
+    /// Keyed by position rather than by client because entering is
+    /// position-based: crossing an edge enters every client at that
+    /// edge, and a bind is deliberately no different.
+    enter_binds: Option<HashMap<Position, Vec<scancode::Linux>>>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
@@ -492,6 +499,18 @@ impl Config {
             .as_ref()
             .and_then(|c| c.release_bind.clone())
             .unwrap_or(Vec::from_iter(DEFAULT_RELEASE_KEYS.iter().cloned()))
+    }
+
+    /// key binds that enter a client without an edge crossing,
+    /// binds that enter a position without an edge crossing
+    pub fn enter_binds(&self) -> HashMap<Position, Vec<scancode::Linux>> {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.enter_binds.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|(_, bind)| !bind.is_empty())
+            .collect()
     }
 
     /// set configured clients

--- a/src/service.rs
+++ b/src/service.rs
@@ -98,7 +98,12 @@ impl Service {
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
-        let capture = Capture::new(capture_backend, conn, config.release_bind());
+        let capture = Capture::new(
+            capture_backend,
+            conn,
+            config.release_bind(),
+            config.enter_binds(),
+        );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
 
@@ -255,6 +260,8 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
+        let enter_binds = self.config.enter_binds();
+        self.capture.set_enter_binds(enter_binds);
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()


### PR DESCRIPTION
Closes #260.

Adds optional `[enter_binds]`: key combinations that begin capture at a position
without the pointer having to travel into the corresponding screen edge.

```toml
[enter_binds]
right = [ "KeyLeftCtrl", "KeyLeftAlt", "KeyRight" ]
top = [ "KeyLeftCtrl", "KeyLeftAlt", "KeyUp" ]
```

Motivation from the issue: people who navigate by keyboard don't want to reach for
the mouse just to change machines, edges get crossed by accident, and games that
capture the pointer make the edge unreachable.

## Approach

A bind produces *exactly* the capture an edge crossing produces — the backend calls
the same `start_capture()` and emits the same `CaptureEvent::Begin` — so everything
downstream (`CaptureTask`, service, `enter_hook`, `release_bind`) works unchanged and
there is no second notion of "entered".

Consequences that fall out of that, rather than being special-cased:

- a bind only fires while capture is inactive; `release_bind` is still what returns
  control to the local machine
- a bind only fires for a position that currently has an active client, so it can
  never enter a client an edge crossing could not

Binds are keyed by **position**, not by client, for the same reason: crossing an edge
enters every client at that edge, so a per-client bind would have been a per-position
bind wearing a disguise — with the added problem that the frontend's `save_config`
round-trip has no representation for it and would have had to reconstruct it.

The matching itself lives in one small, backend-independent type
(`input-capture/src/enter_bind.rs`) that both backends drive, with unit tests
covering: firing on the last key down, key order independence, never firing on
release, ignoring positions without a client, extra held keys not blocking the bind,
and the two ways stale held-keys could otherwise fire a bind (below).

`Capture::set_enter_binds` has a default no-op implementation, so the Linux backends
are untouched and keep entering by edge only — the input capture portal doesn't
deliver input while capture is inactive, as noted in #260.

## Notes for review

- Held keys are forgotten whenever capture begins, by *either* route. Keys stop being
  observed for the duration of a capture, so without this a key held when capture
  began (and released during it, unseen) would still count as held afterwards, and
  could complete a bind on its own later.
- The bind chord is consumed locally and not forwarded, so the remote starts with no
  keys held. That mirrors `release_capture`, which deliberately releases everything
  before handing control back — clean slate in both directions. Carrying held
  modifiers across the switch instead would be a separate change.
- On macOS the idle branch decodes keys through the existing `get_events()` rather
  than reading the `CGEvent` separately, so modifier bookkeeping stays continuous
  across the idle → capturing transition instead of a modifier held at capture start
  being re-reported as a fresh press.
- A key event carries no meaningful pointer location, so the macOS path queries the
  window server for the real cursor position instead of reading it off the triggering
  event; `start_capture` now takes a `CGPoint` for that reason. Windows uses
  `GetCursorPos` and seeds both `ENTRY_POINT` and `PREV_POS` so the first motion
  delta after entering is ~0 rather than a jump.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`
  and `cargo test --workspace --all-features` are clean on macOS, and `cargo check` /
  `cargo clippy` are clean for `x86_64-pc-windows-msvc`.
- macOS verified end-to-end against a Windows peer over Tailscale: pressing the bind
  from the idle state enters the client exactly as an edge crossing does —

  ```
  input_capture::macos] entering client @ top: enter-bind pressed
  lan_mouse::service]   entering client 0 ...
  lan_mouse::connect]   client (0) connected @ …:4242
  lan_mouse::capture]   client 0 acknowledged the connection!
  lan_mouse::capture]   releasing capture: left remote client device region
  ```

  Confirmed on real hardware too: pressing the bind physically on the Mac hands input
  to the Windows machine — moving the trackpad afterwards moves the remote pointer.
  Entering by edge afterwards is unaffected and `release_bind` still hands control
  back.

  Note the pointer lands wherever it was left on the remote rather than at a matching
  position, since `Enter` carries no coordinates — same as an edge crossing, and
  orthogonal to this PR (cf. the `CursorPos` proposal in #429).
- Windows: implemented and compile/clippy-checked for `x86_64-pc-windows-msvc`, but
  not exercised at runtime — the hook path mirrors the macOS one and shares the tested
  matcher, so a confirmation from someone running the Windows capture backend would be
  welcome.

## Possible follow-ups (deliberately not in this PR)

- switching straight from one client to another while capture is already active
  (today: release, then bind)
- an option to disable edge crossings entirely and rely on binds only, which a couple
  of people asked for in #260
- entering at a position matching where the pointer was — that needs coordinates on
  the wire, which is its own discussion (#429), and binds inherit whatever edge
  crossings end up doing
