### PR TITLE
feat: remap keys on their way to other devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,22 @@ KeyLeftCtrl = "KeyLeftMeta"
 Remapping happens on the *sending* side, so the local machine is unaffected:
 `release_bind` and the host's own shortcuts keep seeing the physical keys.
 
+### Inverting scroll direction for other operating systems
+
+`invert_scroll_vertical` and `invert_scroll_horizontal` flip the direction of
+scroll events on their way to other devices. This is mostly useful when
+macOS' "natural scrolling" reaches a Windows or Linux peer that scrolls the
+traditional way, making the wheel feel backwards on the remote machine:
+
+```toml
+[input_pre_processing]
+invert_scroll_vertical = true
+invert_scroll_horizontal = false
+```
+
+Like `remap_keys`, this happens on the *sending* side only, so scrolling on
+the local machine itself is unaffected.
+
 ## Roadmap
 - [x] Graphical frontend (gtk + libadwaita)
 - [x] respect xdg-config-home for config file location.

--- a/README.md
+++ b/README.md
@@ -415,6 +415,25 @@ port = 4242
 
 Where `left` can be either `left`, `right`, `top` or `bottom`.
 
+Crossing an edge carries the cursor's position along that edge over to the
+peer — leaving near the top of the right edge enters the peer near the top
+of its left edge, scaled to the peer's own display size if the two differ.
+This also applies when handing control back without a matching `[[clients]]`
+entry on the other side (moving the cursor further past the edge it just
+entered at): the side you're leaving reports the spot it saw you reach, so
+the cursor reappears there instead of back at the original entry point.
+
+Support so far:
+
+| | reports its own crossings (sending) | applies an incoming position (receiving) |
+|---|---|---|
+| macOS | yes | yes |
+| Windows | yes | not yet — falls back to the edge's midpoint |
+| X11 / Wayland | not yet — falls back to the edge's midpoint | not yet — falls back to the edge's midpoint |
+
+Falling back just means that side behaves as before this existed; nothing
+breaks, the position simply isn't preserved on that leg of the crossing.
+
 ### Remapping keys for other operating systems
 
 `[input_pre_processing]` rewrites events on their way to other devices.

--- a/README.md
+++ b/README.md
@@ -415,6 +415,22 @@ port = 4242
 
 Where `left` can be either `left`, `right`, `top` or `bottom`.
 
+### Remapping keys for other operating systems
+
+`[input_pre_processing]` rewrites events on their way to other devices.
+`remap_keys` swaps individual keys, which is mostly useful for reconciling
+modifier layouts — sending Command from a Mac as Control, and Control as
+Super, so that Cmd+C keeps copying on a Windows or Linux peer:
+
+```toml
+[input_pre_processing.remap_keys]
+KeyLeftMeta = "KeyLeftCtrl"
+KeyLeftCtrl = "KeyLeftMeta"
+```
+
+Remapping happens on the *sending* side, so the local machine is unaffected:
+`release_bind` and the host's own shortcuts keep seeing the physical keys.
+
 ## Roadmap
 - [x] Graphical frontend (gtk + libadwaita)
 - [x] respect xdg-config-home for config file location.

--- a/README.md
+++ b/README.md
@@ -450,6 +450,28 @@ KeyLeftCtrl = "KeyLeftMeta"
 Remapping happens on the *sending* side, so the local machine is unaffected:
 `release_bind` and the host's own shortcuts keep seeing the physical keys.
 
+`remap_keys` is a plain per-key substitution — it can't tell "Command alone"
+from "Command as part of a chord", so it always sends a given key as the
+same thing. `remap_chords` covers that case: a modifier is sent as
+something *else* specifically when a given trigger key is pressed while
+it's held, without changing what it sends as the rest of the time. The
+motivating case is `Cmd+Tab` reaching a Windows peer as `Alt+Tab` (its app
+switcher) instead of `Ctrl+Tab`, while `Cmd+C` still becomes `Ctrl+C`:
+
+```toml
+[[input_pre_processing.remap_chords]]
+modifier = "KeyLeftMeta"
+trigger = "KeyTab"
+to = "KeyLeftAlt"
+```
+
+Holding the modifier and pressing anything *other* than `trigger` — another
+regular key, a click, a scroll — falls back to `remap_keys` as usual.
+Pressing another modifier first (e.g. Shift, for `Cmd+Shift+Tab` to cycle
+backwards) doesn't cancel the chord; only plain cursor motion is ignored
+entirely, so an incidental mouse twitch while holding the modifier can't
+break it either.
+
 ### Inverting scroll direction for other operating systems
 
 `invert_scroll_vertical` and `invert_scroll_horizontal` flip the direction of

--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -46,6 +46,10 @@ impl Capture for DummyInputCapture {
         Ok(())
     }
 
+    async fn release_to(&mut self, _t: f64) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }
@@ -62,7 +66,7 @@ impl Stream for DummyInputCapture {
         let event = match self.start {
             None => {
                 self.start.replace(current);
-                CaptureEvent::Begin
+                CaptureEvent::Begin(0.5)
             }
             Some(start) => {
                 let elapsed = start.elapsed();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -635,6 +635,10 @@ impl Capture for LayerShellInputCapture {
         Ok(inner.flush_events()?)
     }
 
+    async fn release_to(&mut self, _t: f64) -> Result<(), CaptureError> {
+        self.release().await
+    }
+
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }
@@ -753,7 +757,8 @@ impl Dispatch<WlPointer, ()> for State {
                     .find(|w| w.surface == surface)
                     .map(|w| w.pos)
                     .unwrap();
-                app.pending_events.push_back((pos, CaptureEvent::Begin));
+                app.pending_events
+                    .push_back((pos, CaptureEvent::Begin(0.5)));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -37,8 +37,11 @@ pub type CaptureHandle = u64;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CaptureEvent {
-    /// capture on this capture handle is now active
-    Begin,
+    /// capture on this capture handle is now active. The `f64` is the
+    /// normalized (`0.0..=1.0`) position along the crossed edge, so the
+    /// receiving side can warp its cursor to the matching spot. Backends
+    /// that can't determine it report `0.5` (the edge's midpoint).
+    Begin(f64),
     /// input event coming from capture handle
     Input(Event),
 }
@@ -46,7 +49,7 @@ pub enum CaptureEvent {
 impl Display for CaptureEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CaptureEvent::Begin => write!(f, "begin capture"),
+            CaptureEvent::Begin(t) => write!(f, "begin capture ({t:.2})"),
             CaptureEvent::Input(e) => write!(f, "{e}"),
         }
     }
@@ -171,6 +174,15 @@ impl InputCapture {
         self.capture.release().await
     }
 
+    /// release mouse, first warping the cursor to the normalized
+    /// (`0.0..=1.0`) cross-axis position `t` along the edge it's
+    /// currently captured at — so a peer that detected its own local
+    /// crossing back can hand the cursor back at the matching spot.
+    pub async fn release_to(&mut self, t: f64) -> Result<(), CaptureError> {
+        self.pressed_keys.clear();
+        self.capture.release_to(t).await
+    }
+
     /// Drain and return every key the capture has forwarded as
     /// down-but-not-up. The caller is expected to synthesize key-up
     /// events to the remote peer for each — otherwise the peer
@@ -286,6 +298,12 @@ trait Capture: Stream<Item = Result<(Position, CaptureEvent), CaptureError>> + U
 
     /// release mouse
     async fn release(&mut self) -> Result<(), CaptureError>;
+
+    /// release, first warping the cursor to normalized cross-axis
+    /// position `t` along the edge currently captured at. Best-effort:
+    /// backends that can't warp just release, same as before this
+    /// existed — the cursor stays wherever it already was.
+    async fn release_to(&mut self, t: f64) -> Result<(), CaptureError>;
 
     /// destroy the input capture
     async fn terminate(&mut self) -> Result<(), CaptureError>;

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -425,7 +425,10 @@ async fn do_capture_session(
                     current_pos.replace(Some(pos));
 
                     // client entered => send event
-                    event_tx.send((pos, CaptureEvent::Begin)).await.expect("no channel");
+                    event_tx
+                        .send((pos, CaptureEvent::Begin(0.5)))
+                        .await
+                        .expect("no channel");
 
                     tokio::select! {
                         _ = notify_release.notified() => { /* capture release */
@@ -597,6 +600,10 @@ impl LanMouseInputCapture for LibeiInputCapture {
     async fn release(&mut self) -> Result<(), CaptureError> {
         self.notify_release.notify_waiters();
         Ok(())
+    }
+
+    async fn release_to(&mut self, _t: f64) -> Result<(), CaptureError> {
+        self.release().await
     }
 
     async fn terminate(&mut self) -> Result<(), CaptureError> {

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -46,6 +46,24 @@ struct Bounds {
     ymax: f64,
 }
 
+/// Normalizes `coord` to `0.0..=1.0` within `min..=max`, clamping if the
+/// raw crossing point briefly ended up just outside the bounds (e.g. a
+/// fast flick past the very corner). Falls back to the midpoint if the
+/// bounds are degenerate, which should not happen in practice — active
+/// displays always have positive size.
+fn normalized_cross_axis(coord: f64, min: f64, max: f64) -> f64 {
+    if max <= min {
+        return 0.5;
+    }
+    ((coord - min) / (max - min)).clamp(0.0, 1.0)
+}
+
+/// Absolute coordinate for a normalized (`0.0..=1.0`) cross-axis
+/// position within `min..=max`. Inverse of [`normalized_cross_axis`].
+fn denormalize(t: f64, min: f64, max: f64) -> f64 {
+    min + t.clamp(0.0, 1.0) * (max - min)
+}
+
 #[derive(Debug)]
 struct InputCaptureState {
     /// active capture positions
@@ -63,6 +81,9 @@ struct InputCaptureState {
 #[derive(Debug)]
 enum ProducerEvent {
     Release,
+    /// release, first warping the cursor to normalized cross-axis
+    /// position `t` along the edge currently captured at
+    ReleaseTo(f64),
     Create(Position),
     Destroy(Position),
     Grab(Position),
@@ -118,8 +139,21 @@ impl InputCaptureState {
     }
 
     /// start the input capture by
-    fn start_capture(&mut self, event: &CGEvent, position: Position) -> Result<(), CaptureError> {
+    ///
+    /// Returns the normalized (`0.0..=1.0`) position along the crossed
+    /// edge, computed from the raw crossing location *before* it gets
+    /// clamped to the edge below — so the peer can warp its cursor to
+    /// the matching spot instead of a fixed point on the edge.
+    fn start_capture(&mut self, event: &CGEvent, position: Position) -> Result<f64, CaptureError> {
         let mut location = event.location();
+        let t = match position {
+            Position::Left | Position::Right => {
+                normalized_cross_axis(location.y, self.bounds.ymin, self.bounds.ymax)
+            }
+            Position::Top | Position::Bottom => {
+                normalized_cross_axis(location.x, self.bounds.xmin, self.bounds.xmax)
+            }
+        };
         let edge_offset = 1.0;
         // move cursor location to display bounds
         match position {
@@ -129,7 +163,8 @@ impl InputCaptureState {
             Position::Bottom => location.y = self.bounds.ymax - edge_offset,
         };
         self.enter_position = Some(location);
-        self.reset_cursor()
+        self.reset_cursor()?;
+        Ok(t)
     }
 
     /// resets the cursor to the position, where the capture started
@@ -137,6 +172,31 @@ impl InputCaptureState {
         let pos = self.enter_position.expect("capture active");
         log::trace!("Resetting cursor position to: {}, {}", pos.x, pos.y);
         CGDisplay::warp_mouse_cursor_position(pos).map_err(CaptureError::WarpCursor)
+    }
+
+    /// point on the currently-captured edge for normalized cross-axis
+    /// position `t`, e.g. so a peer handing control back can place the
+    /// cursor at the spot matching where its own local crossing was.
+    fn release_point(&self, t: f64) -> Option<CGPoint> {
+        let edge_offset = 1.0;
+        Some(match self.current_pos? {
+            Position::Left => CGPoint::new(
+                self.bounds.xmin + edge_offset,
+                denormalize(t, self.bounds.ymin, self.bounds.ymax),
+            ),
+            Position::Right => CGPoint::new(
+                self.bounds.xmax - edge_offset,
+                denormalize(t, self.bounds.ymin, self.bounds.ymax),
+            ),
+            Position::Top => CGPoint::new(
+                denormalize(t, self.bounds.xmin, self.bounds.xmax),
+                self.bounds.ymin + edge_offset,
+            ),
+            Position::Bottom => CGPoint::new(
+                denormalize(t, self.bounds.xmin, self.bounds.xmax),
+                self.bounds.ymax - edge_offset,
+            ),
+        })
     }
 
     fn hide_cursor(&self) -> Result<(), CaptureError> {
@@ -155,6 +215,16 @@ impl InputCaptureState {
         match producer_event {
             ProducerEvent::Release => {
                 if self.current_pos.is_some() {
+                    self.show_cursor()?;
+                    self.current_pos = None;
+                }
+            }
+            ProducerEvent::ReleaseTo(t) => {
+                if self.current_pos.is_some() {
+                    if let Some(point) = self.release_point(t) {
+                        CGDisplay::warp_mouse_cursor_position(point)
+                            .map_err(CaptureError::WarpCursor)?;
+                    }
                     self.show_cursor()?;
                     self.current_pos = None;
                 }
@@ -519,10 +589,11 @@ fn create_event_tap<'a>(
             // Did we cross a barrier?
             if let Some(new_pos) = state.crossed(cg_ev) {
                 capture_position = Some(new_pos);
-                state
-                    .start_capture(cg_ev, new_pos)
-                    .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin);
+                let t = state.start_capture(cg_ev, new_pos).unwrap_or_else(|e| {
+                    log::warn!("{e}");
+                    0.5
+                });
+                res_events.push(CaptureEvent::Begin(t));
                 notify_tx
                     .blocking_send(ProducerEvent::Grab(new_pos))
                     .expect("Failed to send notification");
@@ -781,6 +852,15 @@ impl Capture for MacOSInputCapture {
         Ok(())
     }
 
+    async fn release_to(&mut self, t: f64) -> Result<(), CaptureError> {
+        let notify_tx = self.notify_tx.clone();
+        tokio::task::spawn_local(async move {
+            log::debug!("notifying ReleaseTo({t:.2})");
+            let _ = notify_tx.send(ProducerEvent::ReleaseTo(t)).await;
+        });
+        Ok(())
+    }
+
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }
@@ -884,5 +964,67 @@ bitflags! {
         const Mod3Mask = (1<<5);
         const Mod4Mask = (1<<6);
         const Mod5Mask = (1<<7);
+    }
+}
+
+#[cfg(test)]
+mod cross_axis_test {
+    use super::normalized_cross_axis;
+
+    #[test]
+    fn midpoint_of_range() {
+        assert_eq!(normalized_cross_axis(50.0, 0.0, 100.0), 0.5);
+    }
+
+    #[test]
+    fn start_and_end_of_range() {
+        assert_eq!(normalized_cross_axis(0.0, 0.0, 100.0), 0.0);
+        assert_eq!(normalized_cross_axis(100.0, 0.0, 100.0), 1.0);
+    }
+
+    #[test]
+    fn clamps_outside_bounds() {
+        assert_eq!(normalized_cross_axis(-10.0, 0.0, 100.0), 0.0);
+        assert_eq!(normalized_cross_axis(110.0, 0.0, 100.0), 1.0);
+    }
+
+    #[test]
+    fn offset_bounds() {
+        // a display union that doesn't start at the origin, e.g. a
+        // monitor placed to the left of (0, 0)
+        assert_eq!(normalized_cross_axis(-400.0, -500.0, -300.0), 0.5);
+    }
+
+    #[test]
+    fn degenerate_bounds_fall_back_to_midpoint() {
+        assert_eq!(normalized_cross_axis(5.0, 10.0, 10.0), 0.5);
+        assert_eq!(normalized_cross_axis(5.0, 10.0, 0.0), 0.5);
+    }
+}
+
+#[cfg(test)]
+mod denormalize_test {
+    use super::denormalize;
+
+    #[test]
+    fn midpoint() {
+        assert_eq!(denormalize(0.5, 0.0, 100.0), 50.0);
+    }
+
+    #[test]
+    fn extremes() {
+        assert_eq!(denormalize(0.0, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.0, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn clamps_out_of_range_t() {
+        assert_eq!(denormalize(-0.5, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.5, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn offset_bounds() {
+        assert_eq!(denormalize(0.5, -500.0, -300.0), -400.0);
     }
 }

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -277,6 +277,27 @@ impl InputCaptureState {
     }
 }
 
+/// Whether `event` came from real keyboard hardware, as opposed to
+/// being synthesized by another process.
+///
+/// Vietnamese (and other) input method engines implement diacritic
+/// composition by deleting the real keystroke from the event stream
+/// and re-injecting a correction: a synthetic Backspace plus a
+/// synthetic "letter" event that carries a placeholder keycode (the
+/// actual composed character rides along in a separate Unicode-string
+/// field this capture never reads). If our tap sees these before the
+/// IME's own tap — tap ordering between two unrelated processes isn't
+/// something either controls — we'd forward that placeholder keycode
+/// to the peer as if it were what the user typed, which is wrong more
+/// often than not. Genuine hardware input reports
+/// [`CGEventSourceStateID::HIDSystemState`]; synthetic events created
+/// via `CGEventSourceCreate` with some other state (IMEs typically use
+/// `Private`) don't.
+fn is_genuine_hardware_event(event: &CGEvent) -> bool {
+    event.get_integer_value_field(EventField::EVENT_SOURCE_STATE_ID)
+        == CGEventSourceStateID::HIDSystemState as i64
+}
+
 fn get_events(
     ev_type: &CGEventType,
     ev: &CGEvent,
@@ -565,15 +586,29 @@ fn create_event_tap<'a>(
         // Are we in a client?
         if let Some(current_pos) = state.current_pos {
             capture_position = Some(current_pos);
-            get_events(
-                &event_type,
-                cg_ev,
-                &mut res_events,
-                &mut state.modifier_state,
-            )
-            .unwrap_or_else(|e| {
-                log::error!("Failed to get events: {e}");
-            });
+
+            let is_keyboard_event = matches!(
+                event_type,
+                CGEventType::KeyDown | CGEventType::KeyUp | CGEventType::FlagsChanged
+            );
+            if is_keyboard_event && !is_genuine_hardware_event(cg_ev) {
+                // A synthetic correction from something like a
+                // Vietnamese IME composing diacritics — see
+                // `is_genuine_hardware_event`. Consumed below
+                // (CallbackResult::Drop) same as a real key, just never
+                // translated or forwarded to the peer.
+                log::trace!("dropping non-hardware keyboard event: {event_type:?}");
+            } else {
+                get_events(
+                    &event_type,
+                    cg_ev,
+                    &mut res_events,
+                    &mut state.modifier_state,
+                )
+                .unwrap_or_else(|e| {
+                    log::error!("Failed to get events: {e}");
+                });
+            }
 
             // Keep (hidden) cursor at the edge of the screen
             if matches!(
@@ -1026,5 +1061,36 @@ mod denormalize_test {
     #[test]
     fn offset_bounds() {
         assert_eq!(denormalize(0.5, -500.0, -300.0), -400.0);
+    }
+}
+
+#[cfg(test)]
+mod hardware_event_test {
+    use super::is_genuine_hardware_event;
+    use core_graphics::event::CGEvent;
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+    #[test]
+    fn real_hid_source_is_genuine() {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).expect("source");
+        let event = CGEvent::new_keyboard_event(source, 0, true).expect("event");
+        assert!(is_genuine_hardware_event(&event));
+    }
+
+    #[test]
+    fn private_source_is_not_genuine() {
+        // the state an IME's own `CGEventSourceCreate` typically uses
+        // for its synthetic composition/correction events
+        let source = CGEventSource::new(CGEventSourceStateID::Private).expect("source");
+        let event = CGEvent::new_keyboard_event(source, 0, true).expect("event");
+        assert!(!is_genuine_hardware_event(&event));
+    }
+
+    #[test]
+    fn combined_session_source_is_not_genuine() {
+        let source =
+            CGEventSource::new(CGEventSourceStateID::CombinedSessionState).expect("source");
+        let event = CGEvent::new_keyboard_event(source, 0, true).expect("event");
+        assert!(!is_genuine_hardware_event(&event));
     }
 }

--- a/input-capture/src/windows.rs
+++ b/input-capture/src/windows.rs
@@ -34,6 +34,13 @@ impl Capture for WindowsInputCapture {
         Ok(())
     }
 
+    async fn release_to(&mut self, _t: f64) -> Result<(), CaptureError> {
+        // TODO: warp the cursor before releasing, like the macOS
+        // backend does — needs the same per-display RECT math already
+        // used for the crossing position (see `display_util.rs`).
+        self.release().await
+    }
+
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }

--- a/input-capture/src/windows/display_util.rs
+++ b/input-capture/src/windows/display_util.rs
@@ -97,3 +97,88 @@ pub(crate) fn clamp_to_display_bounds(
     let (min_y, max_y) = (display.top, display.bottom - 1);
     (x.clamp(min_x, max_x), y.clamp(min_y, max_y))
 }
+
+/// Normalizes `coord` to `0.0..=1.0` within `min..=max`, clamping if the
+/// raw crossing point briefly ended up just outside the bounds. Falls
+/// back to the midpoint if the bounds are degenerate, which should not
+/// happen in practice — real display RECTs always have positive size.
+fn normalized_cross_axis(coord: i32, min: i32, max: i32) -> f64 {
+    if max <= min {
+        return 0.5;
+    }
+    ((coord - min) as f64 / (max - min) as f64).clamp(0.0, 1.0)
+}
+
+/// Normalized (`0.0..=1.0`) position along the edge `pos` was crossed
+/// at, within the bounds of the display `prev_point` was on — the same
+/// display [`clamp_to_display_bounds`] uses for this crossing. Falls
+/// back to the midpoint if that display can't be determined.
+pub(crate) fn cross_axis_position(
+    display_regions: &[RECT],
+    prev_point: (i32, i32),
+    point: (i32, i32),
+    pos: Position,
+) -> f64 {
+    let Some(display) = display_regions
+        .iter()
+        .find(|&d| is_within_dp_region(prev_point, d))
+    else {
+        return 0.5;
+    };
+    let (x, y) = point;
+    match pos {
+        Position::Left | Position::Right => normalized_cross_axis(y, display.top, display.bottom),
+        Position::Top | Position::Bottom => normalized_cross_axis(x, display.left, display.right),
+    }
+}
+
+#[cfg(test)]
+mod cross_axis_test {
+    use super::*;
+
+    fn rect(left: i32, top: i32, right: i32, bottom: i32) -> RECT {
+        RECT {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    #[test]
+    fn midpoint_of_top_edge() {
+        let displays = [rect(0, 0, 1000, 800)];
+        let t = cross_axis_position(&displays, (500, 400), (500, -5), Position::Top);
+        assert_eq!(t, 0.5);
+    }
+
+    #[test]
+    fn near_left_end_of_top_edge() {
+        let displays = [rect(0, 0, 1000, 800)];
+        let t = cross_axis_position(&displays, (10, 400), (10, -5), Position::Top);
+        assert_eq!(t, 0.01);
+    }
+
+    #[test]
+    fn cross_axis_for_left_right_edges_uses_y() {
+        let displays = [rect(0, 0, 1000, 800)];
+        let t = cross_axis_position(&displays, (5, 200), (-5, 200), Position::Left);
+        assert_eq!(t, 0.25);
+    }
+
+    #[test]
+    fn uses_bounds_of_the_display_movement_came_from() {
+        // two displays side by side; the crossing display is the
+        // second (offset) one, not the first
+        let displays = [rect(0, 0, 1000, 800), rect(1000, 0, 2000, 800)];
+        let t = cross_axis_position(&displays, (1500, 400), (1500, -5), Position::Top);
+        assert_eq!(t, 0.5);
+    }
+
+    #[test]
+    fn falls_back_to_midpoint_when_display_not_found() {
+        let displays = [rect(0, 0, 1000, 800)];
+        let t = cross_axis_position(&displays, (5000, 5000), (5000, -5), Position::Top);
+        assert_eq!(t, 0.5);
+    }
+}

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -291,15 +291,18 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
 
     /* update active client and entry point */
     ACTIVE_CLIENT.replace(Some(pos));
-    let entry_point = DISPLAYS.with_borrow(|(displays, _)| {
-        display_util::clamp_to_display_bounds(displays, prev_pos, curr_pos)
+    let (entry_point, t) = DISPLAYS.with_borrow(|(displays, _)| {
+        (
+            display_util::clamp_to_display_bounds(displays, prev_pos, curr_pos),
+            display_util::cross_axis_position(displays, prev_pos, curr_pos, pos),
+        )
     });
     ENTRY_POINT.replace(entry_point);
 
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
     let active = ACTIVE_CLIENT.get().expect("active client");
-    blocking_send_event(active, CaptureEvent::Begin);
+    blocking_send_event(active, CaptureEvent::Begin(t));
 
     ret
 }

--- a/input-capture/src/x11.rs
+++ b/input-capture/src/x11.rs
@@ -27,6 +27,10 @@ impl Capture for X11InputCapture {
         Ok(())
     }
 
+    async fn release_to(&mut self, _t: f64) -> Result<(), CaptureError> {
+        Ok(())
+    }
+
     async fn terminate(&mut self) -> Result<(), CaptureError> {
         Ok(())
     }

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -32,6 +32,16 @@ mod error;
 
 pub type EmulationHandle = u64;
 
+/// Edge a peer's cursor entered this device from, used by
+/// [`InputEmulation::warp`] to place the cursor on the matching edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Position {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Backend {
     #[cfg(wlroots)]
@@ -163,6 +173,15 @@ impl InputEmulation {
         }
     }
 
+    /// Warp the cursor to the normalized (`0.0..=1.0`) position `t`
+    /// along the given edge, so a cursor entering this device lands at
+    /// the same relative spot it left the peer's opposite edge at.
+    /// Backends that can't perform an absolute warp leave the cursor
+    /// wherever it already was, same as before this existed.
+    pub async fn warp(&mut self, handle: EmulationHandle, pos: Position, t: f64) {
+        self.emulation.warp(handle, pos, t).await
+    }
+
     pub async fn destroy(&mut self, handle: EmulationHandle) {
         let _ = self.release_keys(handle).await;
         if self.handles.remove(&handle) {
@@ -237,4 +256,8 @@ trait Emulation: Send {
     async fn create(&mut self, handle: EmulationHandle);
     async fn destroy(&mut self, handle: EmulationHandle);
     async fn terminate(&mut self);
+    /// Warp the cursor to the normalized cross-axis position `t` along
+    /// `pos`. Best-effort: a no-op default for backends that can't do
+    /// an absolute warp, or platforms not implemented yet.
+    async fn warp(&mut self, _handle: EmulationHandle, _pos: Position, _t: f64) {}
 }

--- a/input-emulation/src/macos.rs
+++ b/input-emulation/src/macos.rs
@@ -1,9 +1,9 @@
-use super::{Emulation, EmulationHandle, error::EmulationError};
+use super::{Emulation, EmulationHandle, Position, error::EmulationError};
 use async_trait::async_trait;
 use bitflags::bitflags;
 use core_graphics::base::CGFloat;
 use core_graphics::display::{
-    CGDirectDisplayID, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
+    CGDirectDisplayID, CGDisplay, CGDisplayBounds, CGGetDisplaysWithRect, CGPoint, CGRect, CGSize,
 };
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGKeyCode, CGMouseButton, EventField,
@@ -239,6 +239,44 @@ fn get_display_at_point(x: CGFloat, y: CGFloat) -> Option<CGDirectDisplayID> {
     }
 
     displays.first().copied()
+}
+
+/// Absolute coordinate for a normalized (`0.0..=1.0`) cross-axis
+/// position within `min..=max`. Inverse of the capture-side
+/// normalization in `input-capture`'s macOS backend.
+fn denormalize(t: f64, min: f64, max: f64) -> f64 {
+    min + t.clamp(0.0, 1.0) * (max - min)
+}
+
+/// The point to warp the cursor to when a peer's cursor enters this
+/// device from `pos` at normalized cross-axis position `t`, in the
+/// union bounds of all active displays. `None` if the bounds can't be
+/// determined (no active displays, or a degenerate union).
+fn warp_target(pos: Position, t: f64) -> Option<CGPoint> {
+    let ids = CGDisplay::active_displays().ok()?;
+    let (mut xmin, mut xmax, mut ymin, mut ymax) = (
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+        f64::INFINITY,
+        f64::NEG_INFINITY,
+    );
+    for id in ids {
+        let bounds = CGDisplay::new(id).bounds();
+        xmin = xmin.min(bounds.origin.x);
+        xmax = xmax.max(bounds.origin.x + bounds.size.width);
+        ymin = ymin.min(bounds.origin.y);
+        ymax = ymax.max(bounds.origin.y + bounds.size.height);
+    }
+    if xmax <= xmin || ymax <= ymin {
+        return None;
+    }
+    let edge_offset = 1.0;
+    Some(match pos {
+        Position::Left => CGPoint::new(xmin + edge_offset, denormalize(t, ymin, ymax)),
+        Position::Right => CGPoint::new(xmax - edge_offset, denormalize(t, ymin, ymax)),
+        Position::Top => CGPoint::new(denormalize(t, xmin, xmax), ymin + edge_offset),
+        Position::Bottom => CGPoint::new(denormalize(t, xmin, xmax), ymax - edge_offset),
+    })
 }
 
 fn get_display_bounds(display: CGDirectDisplayID) -> (CGFloat, CGFloat, CGFloat, CGFloat) {
@@ -521,6 +559,16 @@ impl Emulation for MacOSEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    async fn warp(&mut self, _handle: EmulationHandle, pos: Position, t: f64) {
+        let Some(point) = warp_target(pos, t) else {
+            log::warn!("could not determine display bounds for cursor warp");
+            return;
+        };
+        if let Err(e) = CGDisplay::warp_mouse_cursor_position(point) {
+            log::warn!("failed to warp cursor to {pos:?} @ {t:.2}: {e:?}");
+        }
+    }
 }
 
 fn update_modifiers(modifiers: &Cell<XMods>, key: u32, state: u8) -> bool {
@@ -598,5 +646,32 @@ bitflags! {
         const Mod3Mask = (1<<5);
         const Mod4Mask = (1<<6);
         const Mod5Mask = (1<<7);
+    }
+}
+
+#[cfg(test)]
+mod warp_test {
+    use super::denormalize;
+
+    #[test]
+    fn midpoint() {
+        assert_eq!(denormalize(0.5, 0.0, 100.0), 50.0);
+    }
+
+    #[test]
+    fn extremes() {
+        assert_eq!(denormalize(0.0, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.0, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn clamps_out_of_range_t() {
+        assert_eq!(denormalize(-0.5, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.5, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn offset_bounds() {
+        assert_eq!(denormalize(0.5, -500.0, -300.0), -400.0);
     }
 }

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -17,9 +17,12 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT_0, KEYEVENTF_EXTENDEDKEY, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, SendInput,
 };
-use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+    SetCursorPos, XBUTTON1, XBUTTON2,
+};
 
-use super::{Emulation, EmulationHandle};
+use super::{Emulation, EmulationHandle, Position};
 
 const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
 const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
@@ -80,6 +83,18 @@ impl Emulation for WindowsEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    async fn warp(&mut self, _handle: EmulationHandle, pos: Position, t: f64) {
+        let Some((x, y)) = warp_target(pos, t) else {
+            log::warn!("could not determine virtual screen bounds for cursor warp");
+            return;
+        };
+        // SAFETY: SetCursorPos with in-bounds screen coordinates is
+        // always safe to call.
+        if let Err(e) = unsafe { SetCursorPos(x, y) } {
+            log::warn!("failed to warp cursor to {pos:?} @ {t:.2}: {e:?}");
+        }
+    }
 }
 
 impl WindowsEmulation {
@@ -192,6 +207,43 @@ fn scroll(axis: u8, value: i32) {
     send_mouse_input(mi);
 }
 
+/// Absolute coordinate for a normalized (`0.0..=1.0`) cross-axis
+/// position within `min..=max`. Inverse of the capture-side
+/// normalization in `input-capture`'s macOS backend.
+fn denormalize(t: f64, min: f64, max: f64) -> f64 {
+    min + t.clamp(0.0, 1.0) * (max - min)
+}
+
+/// The point to warp the cursor to when a peer's cursor enters this
+/// device from `pos` at normalized cross-axis position `t`, in virtual
+/// screen coordinates. `None` if the virtual screen bounds can't be
+/// determined.
+fn warp_target(pos: Position, t: f64) -> Option<(i32, i32)> {
+    // SAFETY: GetSystemMetrics with a valid SYSTEM_METRICS_INDEX is
+    // always safe to call.
+    let (x0, y0, cx, cy) = unsafe {
+        (
+            GetSystemMetrics(SM_XVIRTUALSCREEN),
+            GetSystemMetrics(SM_YVIRTUALSCREEN),
+            GetSystemMetrics(SM_CXVIRTUALSCREEN),
+            GetSystemMetrics(SM_CYVIRTUALSCREEN),
+        )
+    };
+    if cx <= 0 || cy <= 0 {
+        return None;
+    }
+    let (xmin, xmax) = (x0 as f64, (x0 + cx) as f64);
+    let (ymin, ymax) = (y0 as f64, (y0 + cy) as f64);
+    let edge_offset = 1.0;
+    let (x, y) = match pos {
+        Position::Left => (xmin + edge_offset, denormalize(t, ymin, ymax)),
+        Position::Right => (xmax - edge_offset, denormalize(t, ymin, ymax)),
+        Position::Top => (denormalize(t, xmin, xmax), ymin + edge_offset),
+        Position::Bottom => (denormalize(t, xmin, xmax), ymax - edge_offset),
+    };
+    Some((x as i32, y as i32))
+}
+
 fn key_event(key: u32, state: u8) {
     let scancode = match linux_keycode_to_windows_scancode(key) {
         Some(code) => code,
@@ -234,4 +286,33 @@ fn linux_keycode_to_windows_scancode(linux_keycode: u32) -> Option<u16> {
     };
     log::trace!("windows code: {windows_scancode:?}");
     Some(windows_scancode as u16)
+}
+
+#[cfg(test)]
+mod warp_test {
+    use super::denormalize;
+
+    #[test]
+    fn midpoint() {
+        assert_eq!(denormalize(0.5, 0.0, 100.0), 50.0);
+    }
+
+    #[test]
+    fn extremes() {
+        assert_eq!(denormalize(0.0, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.0, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn clamps_out_of_range_t() {
+        assert_eq!(denormalize(-0.5, 0.0, 100.0), 0.0);
+        assert_eq!(denormalize(1.5, 0.0, 100.0), 100.0);
+    }
+
+    #[test]
+    fn offset_bounds() {
+        // a virtual screen that doesn't start at the origin, e.g. a
+        // monitor placed to the left of / above the primary display
+        assert_eq!(denormalize(0.5, -500.0, -300.0), -400.0);
+    }
 }

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -48,12 +48,21 @@ impl Display for Position {
 /// main lan-mouse protocol event type
 #[derive(Clone, Copy, Debug)]
 pub enum ProtoEvent {
-    /// notify a client that the cursor entered its region at the given position
+    /// notify a client that the cursor entered its region at the given position.
+    /// The `f64` is the normalized (`0.0..=1.0`) position along the crossed
+    /// edge, e.g. how far down a `Left`/`Right` edge or how far across a
+    /// `Top`/`Bottom` edge, so the receiving side can warp the cursor to
+    /// the matching spot instead of a fixed point on the edge.
     /// [`ProtoEvent::Ack`] with the same serial is used for synchronization between devices
-    Enter(Position),
-    /// notify a client that the cursor left its region
+    Enter(Position, f64),
+    /// notify a client that the cursor left its region. The `f64` is the
+    /// normalized (`0.0..=1.0`) position along the edge this side's
+    /// cursor should reappear at — set when the *other* side detected
+    /// its own local crossing back (see the `EnterOnly` capture in
+    /// `src/service.rs::add_incoming`), `0.5` for a plain release with
+    /// no such crossing (release-bind, explicit release request, etc).
     /// [`ProtoEvent::Ack`] with the same serial is used for synchronization between devices
-    Leave(u32),
+    Leave(u32, f64),
     /// acknowledge of an [`ProtoEvent::Enter`] or [`ProtoEvent::Leave`] event
     Ack(u32),
     /// Input event
@@ -77,8 +86,8 @@ pub enum ProtoEvent {
 impl Display for ProtoEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProtoEvent::Enter(s) => write!(f, "Enter({s})"),
-            ProtoEvent::Leave(s) => write!(f, "Leave({s})"),
+            ProtoEvent::Enter(s, t) => write!(f, "Enter({s}, {t:.2})"),
+            ProtoEvent::Leave(s, t) => write!(f, "Leave({s}, {t:.2})"),
             ProtoEvent::Ack(s) => write!(f, "Ack({s})"),
             ProtoEvent::Input(e) => write!(f, "{e}"),
             ProtoEvent::Ping => write!(f, "ping"),
@@ -131,8 +140,8 @@ impl ProtoEvent {
             },
             ProtoEvent::Ping => EventType::Ping,
             ProtoEvent::Pong(_) => EventType::Pong,
-            ProtoEvent::Enter(_) => EventType::Enter,
-            ProtoEvent::Leave(_) => EventType::Leave,
+            ProtoEvent::Enter(..) => EventType::Enter,
+            ProtoEvent::Leave(..) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Hello { .. } => EventType::Hello,
         }
@@ -186,8 +195,11 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
             ))),
             EventType::Ping => Ok(Self::Ping),
             EventType::Pong => Ok(Self::Pong(decode_u8(&mut buf)? != 0)),
-            EventType::Enter => Ok(Self::Enter(decode_u8(&mut buf)?.try_into()?)),
-            EventType::Leave => Ok(Self::Leave(decode_u32(&mut buf)?)),
+            EventType::Enter => Ok(Self::Enter(
+                decode_u8(&mut buf)?.try_into()?,
+                decode_f64(&mut buf)?,
+            )),
+            EventType::Leave => Ok(Self::Leave(decode_u32(&mut buf)?, decode_f64(&mut buf)?)),
             EventType::Ack => Ok(Self::Ack(decode_u32(&mut buf)?)),
             EventType::Hello => {
                 let mut commit = [0u8; 8];
@@ -257,8 +269,14 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                 },
                 ProtoEvent::Ping => {}
                 ProtoEvent::Pong(alive) => encode_u8(buf, len, alive as u8),
-                ProtoEvent::Enter(pos) => encode_u8(buf, len, pos as u8),
-                ProtoEvent::Leave(serial) => encode_u32(buf, len, serial),
+                ProtoEvent::Enter(pos, t) => {
+                    encode_u8(buf, len, pos as u8);
+                    encode_f64(buf, len, t);
+                }
+                ProtoEvent::Leave(serial, t) => {
+                    encode_u32(buf, len, serial);
+                    encode_f64(buf, len, t);
+                }
                 ProtoEvent::Ack(serial) => encode_u32(buf, len, serial),
                 ProtoEvent::Hello { commit } => {
                     for b in commit.iter() {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -15,6 +15,7 @@ use tokio::task::{JoinHandle, spawn_local};
 use tokio_util::sync::CancellationToken;
 
 use crate::connect::LanMouseConnection;
+use crate::remap::KeyRemap;
 
 pub(crate) struct Capture {
     cancellation_token: CancellationToken,
@@ -61,6 +62,8 @@ enum CaptureRequest {
     Reenable,
     /// set release bind
     SetReleaseBind(Vec<scancode::Linux>),
+    /// set the keys rewritten on their way to other devices
+    SetRemap(KeyRemap),
 }
 
 impl Capture {
@@ -68,6 +71,7 @@ impl Capture {
         backend: Option<input_capture::Backend>,
         conn: LanMouseConnection,
         release_bind: Vec<scancode::Linux>,
+        remap: KeyRemap,
     ) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
@@ -81,6 +85,7 @@ impl Capture {
             event_tx,
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
+            remap,
             state: Default::default(),
         };
         let task = spawn_local(capture_task.run());
@@ -137,6 +142,10 @@ impl Capture {
     pub(crate) fn set_release_bind(&mut self, bind: Vec<scancode::Linux>) {
         let _ = self.request_tx.send(CaptureRequest::SetReleaseBind(bind));
     }
+
+    pub(crate) fn set_remap(&mut self, remap: KeyRemap) {
+        let _ = self.request_tx.send(CaptureRequest::SetRemap(remap));
+    }
 }
 
 /// debounce a statement `$st`, i.e. the statement is executed only if the
@@ -164,6 +173,7 @@ struct CaptureTask {
     conn: LanMouseConnection,
     event_tx: Sender<ICaptureEvent>,
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
+    remap: KeyRemap,
     request_rx: Receiver<CaptureRequest>,
     state: State,
 }
@@ -214,6 +224,7 @@ impl CaptureTask {
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
+                        CaptureRequest::SetRemap(remap) => self.remap = remap,
                     },
                     _ = self.cancellation_token.cancelled() => return,
                 }
@@ -307,6 +318,7 @@ impl CaptureTask {
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);
                     }
+                    CaptureRequest::SetRemap(remap) => self.remap = remap,
                 },
                 _ = self.cancellation_token.cancelled() => break,
             }
@@ -361,7 +373,7 @@ impl CaptureTask {
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
-                State::Sending => ProtoEvent::Input(e),
+                State::Sending => ProtoEvent::Input(self.remap.apply(e)),
             },
         };
 
@@ -387,9 +399,14 @@ impl CaptureTask {
             // mods until its watchdog times out (1+ s) or our Leave
             // arrives — and Leave can be lost over UDP/DTLS.
             for key in capture.take_pressed_keys() {
+                // `pressed_keys` holds the *physical* keys, so these
+                // have to go through the same remap the down events
+                // did — otherwise the peer is released from a key it
+                // was never pressed with and keeps holding the one it
+                // actually got.
                 let key_up = ProtoEvent::Input(Event::Keyboard(KeyboardEvent::Key {
                     time: 0,
-                    key: key as u32,
+                    key: self.remap.key(key) as u32,
                     state: 0,
                 }));
                 if let Err(e) = self.conn.send(key_up, handle).await {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -26,8 +26,9 @@ pub(crate) struct Capture {
 }
 
 pub(crate) enum ICaptureEvent {
-    /// a client was entered
-    CaptureBegin(CaptureHandle),
+    /// a client was entered, at the given normalized cross-axis
+    /// position along the edge it was entered at
+    CaptureBegin(CaptureHandle, f64),
     /// capture disabled
     CaptureDisabled,
     /// capture disabled
@@ -92,6 +93,7 @@ impl Capture {
             remap,
             scroll_invert,
             state: Default::default(),
+            enter_t: 0.5,
         };
         let task = spawn_local(capture_task.run());
         Self {
@@ -188,6 +190,10 @@ struct CaptureTask {
     scroll_invert: ScrollInvert,
     request_rx: Receiver<CaptureRequest>,
     state: State,
+    /// normalized cross-axis position from the most recent
+    /// [`CaptureEvent::Begin`], reused when [`State::WaitingForAck`]
+    /// re-sends `Enter` — it's the same logical crossing, just retried.
+    enter_t: f64,
 }
 
 impl CaptureTask {
@@ -312,16 +318,16 @@ impl CaptureTask {
                             self.state = State::Sending;
                         }
                         // client disconnected
-                        ProtoEvent::Leave(_) => {
+                        ProtoEvent::Leave(_, t) => {
                             log::info!("releasing capture: left remote client device region");
-                            self.release_capture(capture).await?;
+                            self.release_capture(capture, Some(t)).await?;
                         },
                         _ => {}
                     }
                 },
                 e = self.request_rx.recv() => match e.expect("channel closed") {
                     CaptureRequest::Reenable => { /* already active */ },
-                    CaptureRequest::Release => self.release_capture(capture).await?,
+                    CaptureRequest::Release => self.release_capture(capture, None).await?,
                     CaptureRequest::Create(h, p, t) => {
                         self.add_capture(h, p, t);
                         capture.create(h, p).await?;
@@ -354,12 +360,12 @@ impl CaptureTask {
 
         if capture.keys_pressed(&self.release_bind.borrow()) {
             log::info!("releasing capture: release-bind pressed");
-            return self.release_capture(capture).await;
+            return self.release_capture(capture, None).await;
         }
 
-        if event == CaptureEvent::Begin {
+        if let CaptureEvent::Begin(t) = event {
             self.event_tx
-                .send(ICaptureEvent::CaptureBegin(handle))
+                .send(ICaptureEvent::CaptureBegin(handle, t))
                 .expect("channel closed");
         }
 
@@ -376,7 +382,7 @@ impl CaptureTask {
         }
 
         // activated a new client
-        if event == CaptureEvent::Begin && Some(handle) != self.active_client {
+        if matches!(event, CaptureEvent::Begin(_)) && Some(handle) != self.active_client {
             self.state = State::WaitingForAck;
             self.active_client.replace(handle);
             self.event_tx
@@ -387,10 +393,13 @@ impl CaptureTask {
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
         let event = match event {
-            CaptureEvent::Begin => ProtoEvent::Enter(opposite_pos),
+            CaptureEvent::Begin(t) => {
+                self.enter_t = t;
+                ProtoEvent::Enter(opposite_pos, t)
+            }
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
-                State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
+                State::WaitingForAck => ProtoEvent::Enter(opposite_pos, self.enter_t),
                 State::Sending => ProtoEvent::Input(self.scroll_invert.apply(self.remap.apply(e))),
             },
         };
@@ -403,7 +412,16 @@ impl CaptureTask {
         Ok(())
     }
 
-    async fn release_capture(&mut self, capture: &mut InputCapture) -> Result<(), CaptureError> {
+    /// releases the capture, optionally warping the cursor to a
+    /// normalized cross-axis position `warp_to` along the edge it was
+    /// captured at first — set when the peer told us to leave with a
+    /// specific hand-back spot (see [`ProtoEvent::Leave`]), `None` for
+    /// a plain release (release-bind, explicit release request, ...)
+    async fn release_capture(
+        &mut self,
+        capture: &mut InputCapture,
+        warp_to: Option<f64>,
+    ) -> Result<(), CaptureError> {
         // If we have an active client, notify them we're leaving
         if let Some(handle) = self.active_client.take() {
             // Synthesize key-up events for every key still held in the
@@ -447,11 +465,16 @@ impl CaptureTask {
             }
 
             log::info!("sending Leave event to client {handle}");
-            if let Err(e) = self.conn.send(ProtoEvent::Leave(0), handle).await {
+            // the peer doesn't act on this `t` — it's *our* Leave,
+            // stopping capture towards them, not a hand-back to us
+            if let Err(e) = self.conn.send(ProtoEvent::Leave(0, 0.5), handle).await {
                 log::warn!("failed to send Leave to client {handle}: {e}");
             }
         }
-        capture.release().await
+        match warp_to {
+            Some(t) => capture.release_to(t).await,
+            None => capture.release().await,
+        }
     }
 }
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -65,7 +65,7 @@ enum CaptureRequest {
     /// set release bind
     SetReleaseBind(Vec<scancode::Linux>),
     /// set the keys rewritten on their way to other devices
-    SetRemap(KeyRemap),
+    SetRemap(Box<KeyRemap>),
     /// set the scroll axes inverted on their way to other devices
     SetScrollInvert(ScrollInvert),
 }
@@ -151,7 +151,9 @@ impl Capture {
     }
 
     pub(crate) fn set_remap(&mut self, remap: KeyRemap) {
-        let _ = self.request_tx.send(CaptureRequest::SetRemap(remap));
+        let _ = self
+            .request_tx
+            .send(CaptureRequest::SetRemap(Box::new(remap)));
     }
 
     pub(crate) fn set_scroll_invert(&mut self, scroll_invert: ScrollInvert) {
@@ -242,7 +244,7 @@ impl CaptureTask {
                         CaptureRequest::SetReleaseBind(bind) => {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
-                        CaptureRequest::SetRemap(remap) => self.remap = remap,
+                        CaptureRequest::SetRemap(remap) => self.remap = *remap,
                         CaptureRequest::SetScrollInvert(scroll_invert) => {
                             self.scroll_invert = scroll_invert
                         }
@@ -339,7 +341,7 @@ impl CaptureTask {
                     CaptureRequest::SetReleaseBind(bind) => {
                         self.release_bind.borrow_mut().clone_from(&bind);
                     }
-                    CaptureRequest::SetRemap(remap) => self.remap = remap,
+                    CaptureRequest::SetRemap(remap) => self.remap = *remap,
                     CaptureRequest::SetScrollInvert(scroll_invert) => {
                         self.scroll_invert = scroll_invert
                     }
@@ -392,22 +394,33 @@ impl CaptureTask {
 
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
-        let event = match event {
+        let events: Vec<ProtoEvent> = match event {
             CaptureEvent::Begin(t) => {
                 self.enter_t = t;
-                ProtoEvent::Enter(opposite_pos, t)
+                vec![ProtoEvent::Enter(opposite_pos, t)]
             }
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
-                State::WaitingForAck => ProtoEvent::Enter(opposite_pos, self.enter_t),
-                State::Sending => ProtoEvent::Input(self.scroll_invert.apply(self.remap.apply(e))),
+                State::WaitingForAck => vec![ProtoEvent::Enter(opposite_pos, self.enter_t)],
+                // a single physical event can resolve into 0-2 outgoing
+                // events once chord remapping buffers/replays a
+                // modifier (see `KeyRemap::apply`)
+                State::Sending => self
+                    .remap
+                    .apply(e)
+                    .into_iter()
+                    .map(|e| ProtoEvent::Input(self.scroll_invert.apply(e)))
+                    .collect(),
             },
         };
 
-        if let Err(e) = self.conn.send(event, handle).await {
-            const DUR: Duration = Duration::from_millis(500);
-            debounce!(PREV_LOG, DUR, log::warn!("releasing capture: {e}"));
-            capture.release().await?;
+        for event in events {
+            if let Err(e) = self.conn.send(event, handle).await {
+                const DUR: Duration = Duration::from_millis(500);
+                debounce!(PREV_LOG, DUR, log::warn!("releasing capture: {e}"));
+                capture.release().await?;
+                break;
+            }
         }
         Ok(())
     }
@@ -439,10 +452,16 @@ impl CaptureTask {
                 // have to go through the same remap the down events
                 // did — otherwise the peer is released from a key it
                 // was never pressed with and keeps holding the one it
-                // actually got.
+                // actually got. A key still `pending` on an unresolved
+                // chord never had a down event sent for it at all —
+                // `release_key` reports `None` for those, and no
+                // key-up should be synthesized either.
+                let Some(target) = self.remap.release_key(key) else {
+                    continue;
+                };
                 let key_up = ProtoEvent::Input(Event::Keyboard(KeyboardEvent::Key {
                     time: 0,
-                    key: self.remap.key(key) as u32,
+                    key: target as u32,
                     state: 0,
                 }));
                 if let Err(e) = self.conn.send(key_up, handle).await {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -16,6 +16,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::connect::LanMouseConnection;
 use crate::remap::KeyRemap;
+use crate::scroll::ScrollInvert;
 
 pub(crate) struct Capture {
     cancellation_token: CancellationToken,
@@ -64,6 +65,8 @@ enum CaptureRequest {
     SetReleaseBind(Vec<scancode::Linux>),
     /// set the keys rewritten on their way to other devices
     SetRemap(KeyRemap),
+    /// set the scroll axes inverted on their way to other devices
+    SetScrollInvert(ScrollInvert),
 }
 
 impl Capture {
@@ -72,6 +75,7 @@ impl Capture {
         conn: LanMouseConnection,
         release_bind: Vec<scancode::Linux>,
         remap: KeyRemap,
+        scroll_invert: ScrollInvert,
     ) -> Self {
         let (request_tx, request_rx) = channel();
         let (event_tx, event_rx) = channel();
@@ -86,6 +90,7 @@ impl Capture {
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
             remap,
+            scroll_invert,
             state: Default::default(),
         };
         let task = spawn_local(capture_task.run());
@@ -146,6 +151,12 @@ impl Capture {
     pub(crate) fn set_remap(&mut self, remap: KeyRemap) {
         let _ = self.request_tx.send(CaptureRequest::SetRemap(remap));
     }
+
+    pub(crate) fn set_scroll_invert(&mut self, scroll_invert: ScrollInvert) {
+        let _ = self
+            .request_tx
+            .send(CaptureRequest::SetScrollInvert(scroll_invert));
+    }
 }
 
 /// debounce a statement `$st`, i.e. the statement is executed only if the
@@ -174,6 +185,7 @@ struct CaptureTask {
     event_tx: Sender<ICaptureEvent>,
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
     remap: KeyRemap,
+    scroll_invert: ScrollInvert,
     request_rx: Receiver<CaptureRequest>,
     state: State,
 }
@@ -225,6 +237,9 @@ impl CaptureTask {
                             self.release_bind.borrow_mut().clone_from(&bind);
                         }
                         CaptureRequest::SetRemap(remap) => self.remap = remap,
+                        CaptureRequest::SetScrollInvert(scroll_invert) => {
+                            self.scroll_invert = scroll_invert
+                        }
                     },
                     _ = self.cancellation_token.cancelled() => return,
                 }
@@ -319,6 +334,9 @@ impl CaptureTask {
                         self.release_bind.borrow_mut().clone_from(&bind);
                     }
                     CaptureRequest::SetRemap(remap) => self.remap = remap,
+                    CaptureRequest::SetScrollInvert(scroll_invert) => {
+                        self.scroll_invert = scroll_invert
+                    }
                 },
                 _ = self.cancellation_token.cancelled() => break,
             }
@@ -373,7 +391,7 @@ impl CaptureTask {
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
                 State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
-                State::Sending => ProtoEvent::Input(self.remap.apply(e)),
+                State::Sending => ProtoEvent::Input(self.scroll_invert.apply(self.remap.apply(e))),
             },
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,9 +66,19 @@ struct ConfigToml {
     emulation_backend: Option<EmulationBackend>,
     port: Option<u16>,
     release_bind: Option<Vec<scancode::Linux>>,
+    /// transformations applied to input events on their way to other
+    /// devices (the counterpart of receive-side post-processing)
+    input_pre_processing: Option<InputPreProcessing>,
     cert_path: Option<PathBuf>,
     clients: Option<Vec<TomlClient>>,
     authorized_fingerprints: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+struct InputPreProcessing {
+    /// keys to send as a different key, e.g. to reconcile modifier
+    /// layouts between operating systems
+    remap_keys: Option<HashMap<scancode::Linux, scancode::Linux>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -492,6 +502,15 @@ impl Config {
             .as_ref()
             .and_then(|c| c.release_bind.clone())
             .unwrap_or(Vec::from_iter(DEFAULT_RELEASE_KEYS.iter().cloned()))
+    }
+
+    /// keys rewritten on their way to other devices
+    pub fn remap_keys(&self) -> HashMap<scancode::Linux, scancode::Linux> {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_pre_processing.as_ref())
+            .and_then(|p| p.remap_keys.clone())
+            .unwrap_or_default()
     }
 
     /// set configured clients

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,10 @@ struct InputPreProcessing {
     invert_scroll_vertical: Option<bool>,
     /// invert the direction of horizontal scroll events
     invert_scroll_horizontal: Option<bool>,
+    /// chord-specific key overrides, e.g. sending Command as Alt only
+    /// when Tab is pressed while it's held (Cmd+Tab → Alt+Tab), without
+    /// disturbing what Command sends as on its own or with anything else
+    remap_chords: Option<Vec<crate::remap::ChordRemap>>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -515,6 +519,15 @@ impl Config {
             .as_ref()
             .and_then(|c| c.input_pre_processing.as_ref())
             .and_then(|p| p.remap_keys.clone())
+            .unwrap_or_default()
+    }
+
+    /// chord-specific key overrides applied on their way to other devices
+    pub fn remap_chords(&self) -> Vec<crate::ChordRemap> {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_pre_processing.as_ref())
+            .and_then(|p| p.remap_chords.clone())
             .unwrap_or_default()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,11 @@ struct InputPreProcessing {
     /// keys to send as a different key, e.g. to reconcile modifier
     /// layouts between operating systems
     remap_keys: Option<HashMap<scancode::Linux, scancode::Linux>>,
+    /// invert the direction of vertical scroll events, e.g. to
+    /// reconcile "natural" macOS scrolling with a Windows or Linux peer
+    invert_scroll_vertical: Option<bool>,
+    /// invert the direction of horizontal scroll events
+    invert_scroll_horizontal: Option<bool>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -511,6 +516,24 @@ impl Config {
             .and_then(|c| c.input_pre_processing.as_ref())
             .and_then(|p| p.remap_keys.clone())
             .unwrap_or_default()
+    }
+
+    /// whether vertical scroll events are inverted on their way to other devices
+    pub fn invert_scroll_vertical(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_pre_processing.as_ref())
+            .and_then(|p| p.invert_scroll_vertical)
+            .unwrap_or(false)
+    }
+
+    /// whether horizontal scroll events are inverted on their way to other devices
+    pub fn invert_scroll_horizontal(&self) -> bool {
+        self.config_toml
+            .as_ref()
+            .and_then(|c| c.input_pre_processing.as_ref())
+            .and_then(|p| p.invert_scroll_horizontal)
+            .unwrap_or(false)
     }
 
     /// set configured clients

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -68,7 +68,9 @@ pub(crate) enum EmulationEvent {
 
 enum EmulationRequest {
     Reenable,
-    Release(SocketAddr),
+    /// release the peer's capture, handing the cursor back at the
+    /// given normalized cross-axis position
+    Release(SocketAddr, f64),
     ChangePort(u16),
     Terminate,
 }
@@ -95,9 +97,9 @@ impl Emulation {
         }
     }
 
-    pub(crate) fn send_leave_event(&self, addr: SocketAddr) {
+    pub(crate) fn send_leave_event(&self, addr: SocketAddr, t: f64) {
         self.request_tx
-            .send(EmulationRequest::Release(addr))
+            .send(EmulationRequest::Release(addr, t))
             .expect("channel closed");
     }
 
@@ -148,15 +150,16 @@ impl ListenTask {
                         log::trace!("{event} <-<-<-<-<- {addr}");
                         last_response.insert(addr, Instant::now());
                         match event {
-                            ProtoEvent::Enter(pos) => {
+                            ProtoEvent::Enter(pos, t) => {
                                 if let Some(fingerprint) = self.listener.get_certificate_fingerprint(addr).await {
                                     log::info!("releasing capture: {addr} entered this device");
                                     self.event_tx.send(EmulationEvent::ReleaseNotify).expect("channel closed");
                                     self.listener.reply(addr, ProtoEvent::Ack(0)).await;
+                                    self.emulation_proxy.warp(addr, to_emulation_pos(pos), t);
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
                                 }
                             }
-                            ProtoEvent::Leave(_) => {
+                            ProtoEvent::Leave(..) => {
                                 self.emulation_proxy.remove(addr);
                                 self.listener.reply(addr, ProtoEvent::Ack(0)).await;
                             }
@@ -198,7 +201,7 @@ impl ListenTask {
                     // reenable emulation
                     EmulationRequest::Reenable => self.emulation_proxy.reenable(),
                     // notify the other end that we hit a barrier (should release capture)
-                    EmulationRequest::Release(addr) => self.listener.reply(addr, ProtoEvent::Leave(0)).await,
+                    EmulationRequest::Release(addr, t) => self.listener.reply(addr, ProtoEvent::Leave(0, t)).await,
                     EmulationRequest::ChangePort(port) => {
                         self.listener.request_port_change(port);
                         let result = self.listener.port_changed().await;
@@ -237,6 +240,8 @@ pub(crate) struct EmulationProxy {
 
 enum ProxyRequest {
     Input(Event, SocketAddr),
+    /// warp the cursor to a normalized cross-axis position along an edge
+    Warp(SocketAddr, input_emulation::Position, f64),
     Remove(SocketAddr),
     Terminate,
     Reenable,
@@ -286,6 +291,15 @@ impl EmulationProxy {
         }
     }
 
+    fn warp(&self, addr: SocketAddr, pos: input_emulation::Position, t: f64) {
+        // ignore if emulation is currently disabled
+        if self.emulation_active.get() {
+            self.request_tx
+                .send(ProxyRequest::Warp(addr, pos, t))
+                .expect("channel closed");
+        }
+    }
+
     fn remove(&self, addr: SocketAddr) {
         self.request_tx
             .send(ProxyRequest::Remove(addr))
@@ -331,6 +345,7 @@ impl EmulationTask {
                     ProxyRequest::Reenable => break,
                     ProxyRequest::Terminate => return,
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::Warp(..) => { /* emulation inactive => ignore */ }
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
                 }
             }
@@ -385,17 +400,12 @@ impl EmulationTask {
             tokio::select! {
                 e = self.request_rx.recv() => match e.expect("channel closed") {
                     ProxyRequest::Input(event, addr) => {
-                        let handle = match self.handles.get(&addr) {
-                            Some(&handle) => handle,
-                            None => {
-                                let handle = self.next_id;
-                                self.next_id += 1;
-                                emulation.create(handle).await;
-                                self.handles.insert(addr, handle);
-                                handle
-                            }
-                        };
+                        let handle = self.handle_for(emulation, addr).await;
                         emulation.consume(event, handle).await?;
+                    },
+                    ProxyRequest::Warp(addr, pos, t) => {
+                        let handle = self.handle_for(emulation, addr).await;
+                        emulation.warp(handle, pos, t).await;
                     },
                     ProxyRequest::Remove(addr) => {
                         if let Some(handle) = self.handles.remove(&addr) {
@@ -408,6 +418,22 @@ impl EmulationTask {
             }
         }
     }
+
+    /// the emulation handle for `addr`, creating one on first use
+    async fn handle_for(
+        &mut self,
+        emulation: &mut InputEmulation,
+        addr: SocketAddr,
+    ) -> EmulationHandle {
+        if let Some(&handle) = self.handles.get(&addr) {
+            return handle;
+        }
+        let handle = self.next_id;
+        self.next_id += 1;
+        emulation.create(handle).await;
+        self.handles.insert(addr, handle);
+        handle
+    }
 }
 
 fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
@@ -419,11 +445,21 @@ fn to_ipc_pos(pos: Position) -> lan_mouse_ipc::Position {
     }
 }
 
+fn to_emulation_pos(pos: Position) -> input_emulation::Position {
+    match pos {
+        Position::Left => input_emulation::Position::Left,
+        Position::Right => input_emulation::Position::Right,
+        Position::Top => input_emulation::Position::Top,
+        Position::Bottom => input_emulation::Position::Bottom,
+    }
+}
+
 async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
     loop {
         match rx.recv().await.expect("channel closed") {
             ProxyRequest::Terminate => return,
             ProxyRequest::Input(_, _) => continue,
+            ProxyRequest::Warp(_, _, _) => continue,
             ProxyRequest::Remove(_) => continue,
             ProxyRequest::Reenable => continue,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ mod dns;
 mod emulation;
 pub mod emulation_test;
 mod listen;
+mod remap;
 pub mod service;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,5 @@ mod listen;
 mod remap;
 mod scroll;
 pub mod service;
+
+pub use remap::ChordRemap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ mod emulation;
 pub mod emulation_test;
 mod listen;
 mod remap;
+mod scroll;
 pub mod service;

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,10 +128,14 @@ fn start_service() -> Result<Child, io::Error> {
 
 async fn run_service(config: Config) -> Result<(), ServiceError> {
     let release_bind = config.release_bind();
+    let remap_keys = config.remap_keys();
     let config_path = config.config_path().to_owned();
     let mut service = Service::new(config).await?;
     log::info!("using config: {config_path:?}");
     log::info!("Press {release_bind:?} to release the mouse");
+    for (from, to) in &remap_keys {
+        log::info!("sending {from:?} to other devices as {to:?}");
+    }
     service.run().await?;
     log::info!("service exited!");
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ fn start_service() -> Result<Child, io::Error> {
 async fn run_service(config: Config) -> Result<(), ServiceError> {
     let release_bind = config.release_bind();
     let remap_keys = config.remap_keys();
+    let remap_chords = config.remap_chords();
     let invert_scroll_vertical = config.invert_scroll_vertical();
     let invert_scroll_horizontal = config.invert_scroll_horizontal();
     let config_path = config.config_path().to_owned();
@@ -137,6 +138,14 @@ async fn run_service(config: Config) -> Result<(), ServiceError> {
     log::info!("Press {release_bind:?} to release the mouse");
     for (from, to) in &remap_keys {
         log::info!("sending {from:?} to other devices as {to:?}");
+    }
+    for chord in &remap_chords {
+        log::info!(
+            "sending {:?} to other devices as {:?} while {:?} is pressed",
+            chord.modifier,
+            chord.to,
+            chord.trigger
+        );
     }
     if invert_scroll_vertical {
         log::info!("inverting vertical scroll direction on its way to other devices");

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,12 +129,20 @@ fn start_service() -> Result<Child, io::Error> {
 async fn run_service(config: Config) -> Result<(), ServiceError> {
     let release_bind = config.release_bind();
     let remap_keys = config.remap_keys();
+    let invert_scroll_vertical = config.invert_scroll_vertical();
+    let invert_scroll_horizontal = config.invert_scroll_horizontal();
     let config_path = config.config_path().to_owned();
     let mut service = Service::new(config).await?;
     log::info!("using config: {config_path:?}");
     log::info!("Press {release_bind:?} to release the mouse");
     for (from, to) in &remap_keys {
         log::info!("sending {from:?} to other devices as {to:?}");
+    }
+    if invert_scroll_vertical {
+        log::info!("inverting vertical scroll direction on its way to other devices");
+    }
+    if invert_scroll_horizontal {
+        log::info!("inverting horizontal scroll direction on its way to other devices");
     }
     service.run().await?;
     log::info!("service exited!");

--- a/src/remap.rs
+++ b/src/remap.rs
@@ -1,0 +1,228 @@
+use std::collections::HashMap;
+
+use input_event::{Event, KeyboardEvent, scancode};
+
+/// X11-style modifier mask bits, as carried by
+/// [`KeyboardEvent::Modifiers`].
+mod mask {
+    pub(super) const SHIFT: u32 = 1 << 0;
+    pub(super) const LOCK: u32 = 1 << 1;
+    pub(super) const CONTROL: u32 = 1 << 2;
+    pub(super) const MOD1: u32 = 1 << 3; // Alt
+    pub(super) const MOD4: u32 = 1 << 6; // Super / Command
+}
+
+/// The modifier bit a key contributes to the mask, if any.
+fn modifier_bit(key: scancode::Linux) -> Option<u32> {
+    use scancode::Linux::*;
+    Some(match key {
+        KeyLeftShift | KeyRightShift => mask::SHIFT,
+        KeyCapsLock => mask::LOCK,
+        KeyLeftCtrl | KeyRightCtrl => mask::CONTROL,
+        KeyLeftAlt | KeyRightalt => mask::MOD1,
+        KeyLeftMeta | KeyRightmeta => mask::MOD4,
+        _ => return None,
+    })
+}
+
+/// Rewrites keys on their way to another device.
+///
+/// The typical use is reconciling modifier layouts between operating
+/// systems — sending Command from a Mac as Control, and Control as
+/// Super, so muscle memory keeps working on a Windows or Linux peer.
+///
+/// Remapping deliberately happens on the *sending* side, right before
+/// events go on the wire: everything local (the release bind, enter
+/// binds, the host's own shortcuts) keeps seeing the physical keys.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct KeyRemap {
+    keys: HashMap<scancode::Linux, scancode::Linux>,
+    /// Bit rewrites derived from `keys`, as (from, to) pairs.
+    ///
+    /// A modifier press arrives twice — once as a key and once as a
+    /// mask update — and the two have to stay consistent, or the peer
+    /// ends up holding one modifier while its mask claims another.
+    bits: Vec<(u32, u32)>,
+}
+
+impl KeyRemap {
+    pub(crate) fn new(keys: HashMap<scancode::Linux, scancode::Linux>) -> Self {
+        let bits = keys
+            .iter()
+            .filter(|(from, to)| from != to)
+            .filter_map(|(&from, &to)| Some((modifier_bit(from)?, modifier_bit(to)?)))
+            .filter(|(from, to)| from != to)
+            .collect();
+        Self { keys, bits }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// the key this one is sent as
+    pub(crate) fn key(&self, key: scancode::Linux) -> scancode::Linux {
+        self.keys.get(&key).copied().unwrap_or(key)
+    }
+
+    fn remap_mask(&self, m: u32) -> u32 {
+        if self.bits.is_empty() {
+            return m;
+        }
+        // Clear every source bit before setting any target bit, so a
+        // swap (A→B together with B→A) doesn't lose one of the two.
+        let mut out = m;
+        for (from, _) in &self.bits {
+            out &= !from;
+        }
+        for (from, to) in &self.bits {
+            if m & from != 0 {
+                out |= to;
+            }
+        }
+        out
+    }
+
+    /// Rewrite an outgoing event. Anything that isn't a key or a
+    /// modifier update passes through untouched.
+    pub(crate) fn apply(&self, event: Event) -> Event {
+        if self.is_empty() {
+            return event;
+        }
+        match event {
+            Event::Keyboard(KeyboardEvent::Key { time, key, state }) => {
+                let key = match scancode::Linux::try_from(key) {
+                    Ok(k) => self.key(k) as u32,
+                    Err(_) => key,
+                };
+                Event::Keyboard(KeyboardEvent::Key { time, key, state })
+            }
+            Event::Keyboard(KeyboardEvent::Modifiers {
+                depressed,
+                latched,
+                locked,
+                group,
+            }) => Event::Keyboard(KeyboardEvent::Modifiers {
+                depressed: self.remap_mask(depressed),
+                latched: self.remap_mask(latched),
+                locked: self.remap_mask(locked),
+                group,
+            }),
+            e => e,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use input_event::scancode::Linux::{KeyA, KeyLeftAlt, KeyLeftCtrl, KeyLeftMeta};
+
+    /// the swap this exists for: Command ⇄ Control
+    fn swap() -> KeyRemap {
+        KeyRemap::new(HashMap::from([
+            (KeyLeftMeta, KeyLeftCtrl),
+            (KeyLeftCtrl, KeyLeftMeta),
+        ]))
+    }
+
+    fn key_event(key: scancode::Linux, state: u8) -> Event {
+        Event::Keyboard(KeyboardEvent::Key {
+            time: 0,
+            key: key as u32,
+            state,
+        })
+    }
+
+    fn mods(depressed: u32) -> Event {
+        Event::Keyboard(KeyboardEvent::Modifiers {
+            depressed,
+            latched: 0,
+            locked: 0,
+            group: 0,
+        })
+    }
+
+    #[test]
+    fn swaps_both_directions() {
+        let r = swap();
+        assert_eq!(
+            r.apply(key_event(KeyLeftMeta, 1)),
+            key_event(KeyLeftCtrl, 1)
+        );
+        assert_eq!(
+            r.apply(key_event(KeyLeftCtrl, 1)),
+            key_event(KeyLeftMeta, 1)
+        );
+    }
+
+    #[test]
+    fn leaves_unmapped_keys_alone() {
+        let r = swap();
+        assert_eq!(r.apply(key_event(KeyA, 1)), key_event(KeyA, 1));
+        assert_eq!(r.apply(key_event(KeyLeftAlt, 1)), key_event(KeyLeftAlt, 1));
+    }
+
+    #[test]
+    fn key_state_is_preserved() {
+        let r = swap();
+        assert_eq!(
+            r.apply(key_event(KeyLeftMeta, 0)),
+            key_event(KeyLeftCtrl, 0)
+        );
+    }
+
+    #[test]
+    fn modifier_mask_swaps_with_the_keys() {
+        // the whole point: the mask must agree with the key events,
+        // or the peer holds Control while its mask says Super
+        let r = swap();
+        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::CONTROL));
+        assert_eq!(r.apply(mods(mask::CONTROL)), mods(mask::MOD4));
+    }
+
+    #[test]
+    fn both_modifiers_held_survives_the_swap() {
+        // a plain "clear then set" that forgot to clear first would
+        // drop one of the two bits here
+        let r = swap();
+        assert_eq!(
+            r.apply(mods(mask::CONTROL | mask::MOD4)),
+            mods(mask::CONTROL | mask::MOD4)
+        );
+    }
+
+    #[test]
+    fn untouched_modifier_bits_are_kept() {
+        let r = swap();
+        assert_eq!(
+            r.apply(mods(mask::SHIFT | mask::MOD1 | mask::MOD4)),
+            mods(mask::SHIFT | mask::MOD1 | mask::CONTROL)
+        );
+    }
+
+    #[test]
+    fn one_way_remap_does_not_resurrect_the_source_bit() {
+        // Command → Control only: nothing should still claim Super
+        let r = KeyRemap::new(HashMap::from([(KeyLeftMeta, KeyLeftCtrl)]));
+        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::CONTROL));
+    }
+
+    #[test]
+    fn empty_remap_is_a_passthrough() {
+        let r = KeyRemap::default();
+        assert!(r.is_empty());
+        assert_eq!(
+            r.apply(key_event(KeyLeftMeta, 1)),
+            key_event(KeyLeftMeta, 1)
+        );
+        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::MOD4));
+    }
+
+    #[test]
+    fn remapping_a_non_modifier_leaves_masks_alone() {
+        let r = KeyRemap::new(HashMap::from([(KeyA, KeyLeftCtrl)]));
+        assert_eq!(r.apply(key_event(KeyA, 1)), key_event(KeyLeftCtrl, 1));
+        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::MOD4));
+    }
+}

--- a/src/remap.rs
+++ b/src/remap.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use input_event::{Event, KeyboardEvent, scancode};
+use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
+use serde::{Deserialize, Serialize};
 
 /// X11-style modifier mask bits, as carried by
 /// [`KeyboardEvent::Modifiers`].
@@ -25,11 +26,44 @@ fn modifier_bit(key: scancode::Linux) -> Option<u32> {
     })
 }
 
+fn key_event(time: u32, key: scancode::Linux, state: u8) -> Event {
+    Event::Keyboard(KeyboardEvent::Key {
+        time,
+        key: key as u32,
+        state,
+    })
+}
+
+/// A chord-specific override: while `modifier` is held, pressing
+/// `trigger` sends `modifier` as `to` instead of its plain
+/// [`KeyRemap`] mapping, for the rest of that hold. The motivating
+/// case is `Cmd+Tab` on a Mac reaching a Windows peer as `Alt+Tab`
+/// (app switcher) rather than `Ctrl+Tab` (which a plain Command→Control
+/// mapping would otherwise produce, since `remap_keys` can't tell
+/// `Cmd` alone from `Cmd+Tab`).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChordRemap {
+    pub modifier: scancode::Linux,
+    pub trigger: scancode::Linux,
+    pub to: scancode::Linux,
+}
+
+/// Resolution state of a chord-eligible modifier that's currently held.
+#[derive(Debug, Clone, Copy)]
+struct ChordEntry {
+    trigger: scancode::Linux,
+    to: scancode::Linux,
+}
+
 /// Rewrites keys on their way to another device.
 ///
 /// The typical use is reconciling modifier layouts between operating
 /// systems — sending Command from a Mac as Control, and Control as
 /// Super, so muscle memory keeps working on a Windows or Linux peer.
+/// `remap_chords` layers a second, narrower rewrite on top: a modifier
+/// can be sent as something *else* specifically when a given trigger
+/// key is pressed while it's held (`Cmd+Tab` → `Alt+Tab`), without
+/// disturbing what it sends as on its own (`Cmd+C` → `Ctrl+C`).
 ///
 /// Remapping deliberately happens on the *sending* side, right before
 /// events go on the wire: everything local (the release bind, enter
@@ -43,26 +77,79 @@ pub(crate) struct KeyRemap {
     /// mask update — and the two have to stay consistent, or the peer
     /// ends up holding one modifier while its mask claims another.
     bits: Vec<(u32, u32)>,
+    /// chord rules, keyed by the physical modifier they apply to. Only
+    /// one rule per modifier is supported — a later duplicate in config
+    /// silently wins, like any other `HashMap` collision.
+    chords: HashMap<scancode::Linux, ChordEntry>,
+    /// chord modifiers currently held whose fate isn't decided yet — no
+    /// down event has been sent to the peer for these at all
+    pending: HashSet<scancode::Linux>,
+    /// chord modifiers currently held that resolved to an override,
+    /// and what they're being sent as
+    active: HashMap<scancode::Linux, scancode::Linux>,
+    /// last raw `Modifiers` mask seen, used to emit a corrected
+    /// snapshot once a pending chord resolves (the original event for
+    /// that hold was suppressed, since its outcome wasn't known yet)
+    raw_mask: (u32, u32, u32, u32),
 }
 
 impl KeyRemap {
-    pub(crate) fn new(keys: HashMap<scancode::Linux, scancode::Linux>) -> Self {
+    pub(crate) fn new(
+        keys: HashMap<scancode::Linux, scancode::Linux>,
+        chords: Vec<ChordRemap>,
+    ) -> Self {
         let bits = keys
             .iter()
             .filter(|(from, to)| from != to)
             .filter_map(|(&from, &to)| Some((modifier_bit(from)?, modifier_bit(to)?)))
             .filter(|(from, to)| from != to)
             .collect();
-        Self { keys, bits }
+        let chords = chords
+            .into_iter()
+            .map(|c| {
+                (
+                    c.modifier,
+                    ChordEntry {
+                        trigger: c.trigger,
+                        to: c.to,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            keys,
+            bits,
+            chords,
+            pending: HashSet::new(),
+            active: HashMap::new(),
+            raw_mask: (0, 0, 0, 0),
+        }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.keys.is_empty()
+        self.keys.is_empty() && self.chords.is_empty()
     }
 
-    /// the key this one is sent as
-    pub(crate) fn key(&self, key: scancode::Linux) -> scancode::Linux {
+    /// the key `key` is sent as outside of any chord resolution
+    fn plain_key(&self, key: scancode::Linux) -> scancode::Linux {
         self.keys.get(&key).copied().unwrap_or(key)
+    }
+
+    /// The key a currently-held physical key should be released as, or
+    /// `None` if no matching down was ever actually sent (it was still
+    /// `pending` on an unresolved chord) — synthesizing a key-up in
+    /// that case would release a key the peer was never told was
+    /// pressed. Clears any chord bookkeeping for `key` as a side
+    /// effect, matching the one-shot "drain and release everything"
+    /// use at [`crate::capture::CaptureTask::release_capture`].
+    pub(crate) fn release_key(&mut self, key: scancode::Linux) -> Option<scancode::Linux> {
+        if let Some(to) = self.active.remove(&key) {
+            return Some(to);
+        }
+        if self.pending.remove(&key) {
+            return None;
+        }
+        Some(self.plain_key(key))
     }
 
     fn remap_mask(&self, m: u32) -> u32 {
@@ -83,32 +170,151 @@ impl KeyRemap {
         out
     }
 
-    /// Rewrite an outgoing event. Anything that isn't a key or a
-    /// modifier update passes through untouched.
-    pub(crate) fn apply(&self, event: Event) -> Event {
+    /// [`Self::remap_mask`], further corrected for chord-eligible
+    /// modifiers currently `pending` (bit omitted — no down sent yet)
+    /// or `active` (bit swapped to the override's, not the plain
+    /// mapping's).
+    fn remap_mask_dynamic(&self, m: u32) -> u32 {
+        let mut out = self.remap_mask(m);
+        for &phys in self.chords.keys() {
+            let Some(phys_bit) = modifier_bit(phys) else {
+                continue;
+            };
+            if m & phys_bit == 0 {
+                continue;
+            }
+            let static_target = self.plain_key(phys);
+            if let Some(b) = modifier_bit(static_target) {
+                out &= !b;
+            }
+            match self.active.get(&phys) {
+                Some(&to) => {
+                    if let Some(b) = modifier_bit(to) {
+                        out |= b;
+                    }
+                }
+                None if self.pending.contains(&phys) => { /* omit: no down sent yet */ }
+                None => {
+                    if let Some(b) = modifier_bit(static_target) {
+                        out |= b;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// a fresh `Modifiers` event from the last raw mask seen, reflecting
+    /// the current chord resolution — sent whenever that resolution
+    /// changes, since the original event (if any) for this state may
+    /// have been suppressed while the outcome was still undecided
+    fn remapped_modifiers_event(&self) -> Event {
+        let (depressed, latched, locked, group) = self.raw_mask;
+        Event::Keyboard(KeyboardEvent::Modifiers {
+            depressed: self.remap_mask_dynamic(depressed),
+            latched: self.remap_mask_dynamic(latched),
+            locked: self.remap_mask_dynamic(locked),
+            group,
+        })
+    }
+
+    /// resolves every still-pending chord modifier as "plain" — its
+    /// static mapping, same as if no chord rule applied this hold —
+    /// and emits the Key + Modifiers events that were held back
+    fn flush_pending(&mut self, time: u32) -> Vec<Event> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        let mut out: Vec<Event> = std::mem::take(&mut self.pending)
+            .into_iter()
+            .map(|k| key_event(time, self.plain_key(k), 1))
+            .collect();
+        out.push(self.remapped_modifiers_event());
+        out
+    }
+
+    fn apply_key(&mut self, time: u32, k: scancode::Linux, state: u8) -> Vec<Event> {
+        if state == 1 {
+            if self.chords.contains_key(&k) {
+                self.pending.insert(k);
+                return Vec::new();
+            }
+            if let Some(&modifier) = self.pending.iter().find(|&&m| self.chords[&m].trigger == k) {
+                self.pending.remove(&modifier);
+                let to = self.chords[&modifier].to;
+                self.active.insert(modifier, to);
+                return vec![
+                    key_event(time, to, 1),
+                    self.remapped_modifiers_event(),
+                    key_event(time, self.plain_key(k), 1),
+                ];
+            }
+            if modifier_bit(k).is_some() {
+                // an unrelated modifier (e.g. Shift for Cmd+Shift+Tab)
+                // — pass through, leave any pending chord waiting
+                return vec![key_event(time, self.plain_key(k), 1)];
+            }
+            // a regular key that isn't our trigger: the chord
+            // opportunity is over
+            let mut out = self.flush_pending(time);
+            out.push(key_event(time, self.plain_key(k), 1));
+            out
+        } else {
+            if let Some(to) = self.active.remove(&k) {
+                return vec![key_event(time, to, 0)];
+            }
+            if self.pending.remove(&k) {
+                // tapped alone and released before it resolved either way
+                return vec![
+                    key_event(time, self.plain_key(k), 1),
+                    key_event(time, self.plain_key(k), 0),
+                ];
+            }
+            if modifier_bit(k).is_some() {
+                return vec![key_event(time, self.plain_key(k), 0)];
+            }
+            let mut out = self.flush_pending(time);
+            out.push(key_event(time, self.plain_key(k), 0));
+            out
+        }
+    }
+
+    /// Rewrite an outgoing event. Anything that isn't a key, a
+    /// modifier update, or a deliberate pointer action (button, scroll)
+    /// passes through untouched; plain cursor motion never disturbs an
+    /// in-progress chord decision.
+    pub(crate) fn apply(&mut self, event: Event) -> Vec<Event> {
         if self.is_empty() {
-            return event;
+            return vec![event];
         }
         match event {
             Event::Keyboard(KeyboardEvent::Key { time, key, state }) => {
-                let key = match scancode::Linux::try_from(key) {
-                    Ok(k) => self.key(k) as u32,
-                    Err(_) => key,
-                };
-                Event::Keyboard(KeyboardEvent::Key { time, key, state })
+                match scancode::Linux::try_from(key) {
+                    Ok(k) => self.apply_key(time, k, state),
+                    Err(_) => vec![Event::Keyboard(KeyboardEvent::Key { time, key, state })],
+                }
             }
             Event::Keyboard(KeyboardEvent::Modifiers {
                 depressed,
                 latched,
                 locked,
                 group,
-            }) => Event::Keyboard(KeyboardEvent::Modifiers {
-                depressed: self.remap_mask(depressed),
-                latched: self.remap_mask(latched),
-                locked: self.remap_mask(locked),
-                group,
-            }),
-            e => e,
+            }) => {
+                self.raw_mask = (depressed, latched, locked, group);
+                if self.pending.is_empty() {
+                    vec![self.remapped_modifiers_event()]
+                } else {
+                    Vec::new()
+                }
+            }
+            Event::Pointer(PointerEvent::Motion { .. }) => vec![event],
+            e => {
+                // a click or a scroll is a deliberate action, not a
+                // chord in progress — resolve any pending chord first
+                let mut out = self.flush_pending(0);
+                out.push(e);
+                out
+            }
         }
     }
 }
@@ -116,17 +322,31 @@ impl KeyRemap {
 #[cfg(test)]
 mod test {
     use super::*;
-    use input_event::scancode::Linux::{KeyA, KeyLeftAlt, KeyLeftCtrl, KeyLeftMeta};
+    use input_event::scancode::Linux::{
+        KeyA, KeyC, KeyLeftAlt, KeyLeftCtrl, KeyLeftMeta, KeyLeftShift, KeyTab,
+    };
 
     /// the swap this exists for: Command ⇄ Control
     fn swap() -> KeyRemap {
-        KeyRemap::new(HashMap::from([
-            (KeyLeftMeta, KeyLeftCtrl),
-            (KeyLeftCtrl, KeyLeftMeta),
-        ]))
+        KeyRemap::new(
+            HashMap::from([(KeyLeftMeta, KeyLeftCtrl), (KeyLeftCtrl, KeyLeftMeta)]),
+            Vec::new(),
+        )
     }
 
-    fn key_event(key: scancode::Linux, state: u8) -> Event {
+    /// Command→Control, plus Cmd+Tab → Alt+Tab
+    fn swap_with_chord() -> KeyRemap {
+        KeyRemap::new(
+            HashMap::from([(KeyLeftMeta, KeyLeftCtrl), (KeyLeftCtrl, KeyLeftMeta)]),
+            vec![ChordRemap {
+                modifier: KeyLeftMeta,
+                trigger: KeyTab,
+                to: KeyLeftAlt,
+            }],
+        )
+    }
+
+    fn key_ev(key: scancode::Linux, state: u8) -> Event {
         Event::Keyboard(KeyboardEvent::Key {
             time: 0,
             key: key as u32,
@@ -145,30 +365,30 @@ mod test {
 
     #[test]
     fn swaps_both_directions() {
-        let r = swap();
+        let mut r = swap();
         assert_eq!(
-            r.apply(key_event(KeyLeftMeta, 1)),
-            key_event(KeyLeftCtrl, 1)
+            r.apply(key_ev(KeyLeftMeta, 1)),
+            vec![key_ev(KeyLeftCtrl, 1)]
         );
         assert_eq!(
-            r.apply(key_event(KeyLeftCtrl, 1)),
-            key_event(KeyLeftMeta, 1)
+            r.apply(key_ev(KeyLeftCtrl, 1)),
+            vec![key_ev(KeyLeftMeta, 1)]
         );
     }
 
     #[test]
     fn leaves_unmapped_keys_alone() {
-        let r = swap();
-        assert_eq!(r.apply(key_event(KeyA, 1)), key_event(KeyA, 1));
-        assert_eq!(r.apply(key_event(KeyLeftAlt, 1)), key_event(KeyLeftAlt, 1));
+        let mut r = swap();
+        assert_eq!(r.apply(key_ev(KeyA, 1)), vec![key_ev(KeyA, 1)]);
+        assert_eq!(r.apply(key_ev(KeyLeftAlt, 1)), vec![key_ev(KeyLeftAlt, 1)]);
     }
 
     #[test]
     fn key_state_is_preserved() {
-        let r = swap();
+        let mut r = swap();
         assert_eq!(
-            r.apply(key_event(KeyLeftMeta, 0)),
-            key_event(KeyLeftCtrl, 0)
+            r.apply(key_ev(KeyLeftMeta, 0)),
+            vec![key_ev(KeyLeftCtrl, 0)]
         );
     }
 
@@ -176,53 +396,174 @@ mod test {
     fn modifier_mask_swaps_with_the_keys() {
         // the whole point: the mask must agree with the key events,
         // or the peer holds Control while its mask says Super
-        let r = swap();
-        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::CONTROL));
-        assert_eq!(r.apply(mods(mask::CONTROL)), mods(mask::MOD4));
+        let mut r = swap();
+        assert_eq!(r.apply(mods(mask::MOD4)), vec![mods(mask::CONTROL)]);
+        let mut r = swap();
+        assert_eq!(r.apply(mods(mask::CONTROL)), vec![mods(mask::MOD4)]);
     }
 
     #[test]
     fn both_modifiers_held_survives_the_swap() {
         // a plain "clear then set" that forgot to clear first would
         // drop one of the two bits here
-        let r = swap();
+        let mut r = swap();
         assert_eq!(
             r.apply(mods(mask::CONTROL | mask::MOD4)),
-            mods(mask::CONTROL | mask::MOD4)
+            vec![mods(mask::CONTROL | mask::MOD4)]
         );
     }
 
     #[test]
     fn untouched_modifier_bits_are_kept() {
-        let r = swap();
+        let mut r = swap();
         assert_eq!(
             r.apply(mods(mask::SHIFT | mask::MOD1 | mask::MOD4)),
-            mods(mask::SHIFT | mask::MOD1 | mask::CONTROL)
+            vec![mods(mask::SHIFT | mask::MOD1 | mask::CONTROL)]
         );
     }
 
     #[test]
     fn one_way_remap_does_not_resurrect_the_source_bit() {
         // Command → Control only: nothing should still claim Super
-        let r = KeyRemap::new(HashMap::from([(KeyLeftMeta, KeyLeftCtrl)]));
-        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::CONTROL));
+        let mut r = KeyRemap::new(HashMap::from([(KeyLeftMeta, KeyLeftCtrl)]), Vec::new());
+        assert_eq!(r.apply(mods(mask::MOD4)), vec![mods(mask::CONTROL)]);
     }
 
     #[test]
     fn empty_remap_is_a_passthrough() {
-        let r = KeyRemap::default();
+        let mut r = KeyRemap::default();
         assert!(r.is_empty());
         assert_eq!(
-            r.apply(key_event(KeyLeftMeta, 1)),
-            key_event(KeyLeftMeta, 1)
+            r.apply(key_ev(KeyLeftMeta, 1)),
+            vec![key_ev(KeyLeftMeta, 1)]
         );
-        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::MOD4));
+        assert_eq!(r.apply(mods(mask::MOD4)), vec![mods(mask::MOD4)]);
     }
 
     #[test]
     fn remapping_a_non_modifier_leaves_masks_alone() {
-        let r = KeyRemap::new(HashMap::from([(KeyA, KeyLeftCtrl)]));
-        assert_eq!(r.apply(key_event(KeyA, 1)), key_event(KeyLeftCtrl, 1));
-        assert_eq!(r.apply(mods(mask::MOD4)), mods(mask::MOD4));
+        let mut r = KeyRemap::new(HashMap::from([(KeyA, KeyLeftCtrl)]), Vec::new());
+        assert_eq!(r.apply(key_ev(KeyA, 1)), vec![key_ev(KeyLeftCtrl, 1)]);
+        assert_eq!(r.apply(mods(mask::MOD4)), vec![mods(mask::MOD4)]);
+    }
+
+    #[test]
+    fn chord_trigger_sends_override_instead_of_plain() {
+        let mut r = swap_with_chord();
+        // macOS pairs a modifier key event with a `Modifiers` update;
+        // the latter is suppressed until the chord resolves
+        assert_eq!(r.apply(key_ev(KeyLeftMeta, 1)), Vec::<Event>::new());
+        assert_eq!(r.apply(mods(mask::MOD4)), Vec::<Event>::new());
+        assert_eq!(
+            r.apply(key_ev(KeyTab, 1)),
+            vec![key_ev(KeyLeftAlt, 1), mods(mask::MOD1), key_ev(KeyTab, 1)]
+        );
+    }
+
+    #[test]
+    fn chord_release_sends_override_up() {
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        r.apply(key_ev(KeyTab, 1));
+        r.apply(key_ev(KeyTab, 0));
+        assert_eq!(r.apply(key_ev(KeyLeftMeta, 0)), vec![key_ev(KeyLeftAlt, 0)]);
+    }
+
+    #[test]
+    fn repeated_tab_taps_pass_through_unchanged_once_chord_is_active() {
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        r.apply(key_ev(KeyTab, 1));
+        assert_eq!(r.apply(key_ev(KeyTab, 0)), vec![key_ev(KeyTab, 0)]);
+        assert_eq!(r.apply(key_ev(KeyTab, 1)), vec![key_ev(KeyTab, 1)]);
+    }
+
+    #[test]
+    fn non_trigger_key_falls_back_to_plain_mapping() {
+        // Cmd+C: not a chord, must still become Ctrl+C
+        let mut r = swap_with_chord();
+        assert_eq!(r.apply(key_ev(KeyLeftMeta, 1)), Vec::<Event>::new());
+        assert_eq!(
+            r.apply(key_ev(KeyC, 1)),
+            vec![key_ev(KeyLeftCtrl, 1), mods(0), key_ev(KeyC, 1)]
+        );
+    }
+
+    #[test]
+    fn tapping_the_chord_modifier_alone_resolves_as_plain_on_release() {
+        let mut r = swap_with_chord();
+        assert_eq!(r.apply(key_ev(KeyLeftMeta, 1)), Vec::<Event>::new());
+        assert_eq!(
+            r.apply(key_ev(KeyLeftMeta, 0)),
+            vec![key_ev(KeyLeftCtrl, 1), key_ev(KeyLeftCtrl, 0)]
+        );
+    }
+
+    #[test]
+    fn other_modifier_held_alongside_does_not_force_resolution() {
+        // Cmd+Shift+Tab (cycle backwards) must still become Alt+Shift+Tab
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        assert_eq!(
+            r.apply(key_ev(KeyLeftShift, 1)),
+            vec![key_ev(KeyLeftShift, 1)]
+        );
+        assert_eq!(
+            r.apply(key_ev(KeyTab, 1)),
+            vec![key_ev(KeyLeftAlt, 1), mods(0), key_ev(KeyTab, 1)]
+        );
+    }
+
+    #[test]
+    fn mouse_motion_does_not_disturb_a_pending_chord() {
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        let motion = Event::Pointer(PointerEvent::Motion {
+            time: 0,
+            dx: 1.0,
+            dy: 1.0,
+        });
+        assert_eq!(r.apply(motion), vec![motion]);
+        assert_eq!(
+            r.apply(key_ev(KeyTab, 1)),
+            vec![key_ev(KeyLeftAlt, 1), mods(0), key_ev(KeyTab, 1)]
+        );
+    }
+
+    #[test]
+    fn mouse_click_resolves_a_pending_chord_as_plain() {
+        // Cmd+Click must still become Ctrl+Click
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        let click = Event::Pointer(PointerEvent::Button {
+            time: 0,
+            button: input_event::BTN_LEFT,
+            state: 1,
+        });
+        assert_eq!(r.apply(click), vec![key_ev(KeyLeftCtrl, 1), mods(0), click]);
+    }
+
+    #[test]
+    fn release_key_reports_the_override_while_a_chord_is_active() {
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        r.apply(key_ev(KeyTab, 1));
+        assert_eq!(r.release_key(KeyLeftMeta), Some(KeyLeftAlt));
+    }
+
+    #[test]
+    fn release_key_reports_nothing_for_a_still_pending_modifier() {
+        // no down was ever sent for it — a synthesized key-up would
+        // release a key the peer was never told was pressed
+        let mut r = swap_with_chord();
+        r.apply(key_ev(KeyLeftMeta, 1));
+        assert_eq!(r.release_key(KeyLeftMeta), None);
+    }
+
+    #[test]
+    fn release_key_falls_back_to_the_plain_mapping_otherwise() {
+        let mut r = swap_with_chord();
+        assert_eq!(r.release_key(KeyLeftMeta), Some(KeyLeftCtrl));
+        assert_eq!(r.release_key(KeyA), Some(KeyA));
     }
 }

--- a/src/scroll.rs
+++ b/src/scroll.rs
@@ -1,0 +1,136 @@
+use input_event::{Event, PointerEvent};
+
+/// axis id carried by [`PointerEvent::Axis`] / [`PointerEvent::AxisDiscrete120`]
+/// for vertical scrolling; anything else is horizontal.
+const VERTICAL: u8 = 0;
+
+/// Inverts scroll direction on its way to another device.
+///
+/// The motivating case is macOS' "natural scrolling" reaching a Windows
+/// or Linux peer that scrolls the traditional way: the two disagree on
+/// which way the wheel should move the content, so scrolling feels
+/// backwards on the peer even though both machines are working as
+/// designed.
+///
+/// Like [`crate::remap::KeyRemap`], this happens on the *sending* side,
+/// right before events go on the wire, so the local machine's own
+/// scrolling is unaffected.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub(crate) struct ScrollInvert {
+    vertical: bool,
+    horizontal: bool,
+}
+
+impl ScrollInvert {
+    pub(crate) fn new(vertical: bool, horizontal: bool) -> Self {
+        Self {
+            vertical,
+            horizontal,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        !self.vertical && !self.horizontal
+    }
+
+    fn inverts(&self, axis: u8) -> bool {
+        if axis == VERTICAL {
+            self.vertical
+        } else {
+            self.horizontal
+        }
+    }
+
+    /// Invert an outgoing event. Anything that isn't a scroll axis
+    /// passes through untouched.
+    pub(crate) fn apply(&self, event: Event) -> Event {
+        if self.is_empty() {
+            return event;
+        }
+        match event {
+            Event::Pointer(PointerEvent::Axis { time, axis, value }) if self.inverts(axis) => {
+                Event::Pointer(PointerEvent::Axis {
+                    time,
+                    axis,
+                    value: -value,
+                })
+            }
+            Event::Pointer(PointerEvent::AxisDiscrete120 { axis, value }) if self.inverts(axis) => {
+                Event::Pointer(PointerEvent::AxisDiscrete120 {
+                    axis,
+                    value: -value,
+                })
+            }
+            e => e,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const HORIZONTAL: u8 = 1;
+
+    fn axis(axis: u8, value: f64) -> Event {
+        Event::Pointer(PointerEvent::Axis {
+            time: 0,
+            axis,
+            value,
+        })
+    }
+
+    fn axis120(axis: u8, value: i32) -> Event {
+        Event::Pointer(PointerEvent::AxisDiscrete120 { axis, value })
+    }
+
+    #[test]
+    fn inverts_vertical_scroll() {
+        let s = ScrollInvert::new(true, false);
+        assert_eq!(s.apply(axis(VERTICAL, 1.5)), axis(VERTICAL, -1.5));
+        assert_eq!(s.apply(axis120(VERTICAL, 120)), axis120(VERTICAL, -120));
+    }
+
+    #[test]
+    fn leaves_horizontal_alone_when_only_vertical_is_inverted() {
+        let s = ScrollInvert::new(true, false);
+        assert_eq!(s.apply(axis(HORIZONTAL, 1.5)), axis(HORIZONTAL, 1.5));
+    }
+
+    #[test]
+    fn inverts_horizontal_scroll() {
+        let s = ScrollInvert::new(false, true);
+        assert_eq!(s.apply(axis(HORIZONTAL, 1.5)), axis(HORIZONTAL, -1.5));
+    }
+
+    #[test]
+    fn leaves_vertical_alone_when_only_horizontal_is_inverted() {
+        let s = ScrollInvert::new(false, true);
+        assert_eq!(s.apply(axis(VERTICAL, 1.5)), axis(VERTICAL, 1.5));
+    }
+
+    #[test]
+    fn inverts_both_axes() {
+        let s = ScrollInvert::new(true, true);
+        assert_eq!(s.apply(axis(VERTICAL, 1.0)), axis(VERTICAL, -1.0));
+        assert_eq!(s.apply(axis(HORIZONTAL, 1.0)), axis(HORIZONTAL, -1.0));
+    }
+
+    #[test]
+    fn empty_invert_is_a_passthrough() {
+        let s = ScrollInvert::default();
+        assert!(s.is_empty());
+        assert_eq!(s.apply(axis(VERTICAL, 1.0)), axis(VERTICAL, 1.0));
+    }
+
+    #[test]
+    fn leaves_non_scroll_events_alone() {
+        let s = ScrollInvert::new(true, true);
+        let motion = Event::Pointer(PointerEvent::Motion {
+            time: 0,
+            dx: 1.0,
+            dy: 1.0,
+        });
+        assert_eq!(s.apply(motion), motion);
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -104,7 +104,7 @@ impl Service {
             capture_backend,
             conn,
             config.release_bind(),
-            KeyRemap::new(config.remap_keys()),
+            KeyRemap::new(config.remap_keys(), config.remap_chords()),
             ScrollInvert::new(
                 config.invert_scroll_vertical(),
                 config.invert_scroll_horizontal(),
@@ -266,8 +266,10 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
-        self.capture
-            .set_remap(KeyRemap::new(self.config.remap_keys()));
+        self.capture.set_remap(KeyRemap::new(
+            self.config.remap_keys(),
+            self.config.remap_chords(),
+        ));
         self.capture.set_scroll_invert(ScrollInvert::new(
             self.config.invert_scroll_vertical(),
             self.config.invert_scroll_horizontal(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -349,11 +349,11 @@ impl Service {
 
     fn handle_capture_event(&mut self, event: ICaptureEvent) {
         match event {
-            ICaptureEvent::CaptureBegin(handle) => {
+            ICaptureEvent::CaptureBegin(handle, t) => {
                 // we entered the capture zone for an incoming connection
                 // => notify it that its capture should be released
                 if let Some(incoming) = self.incoming_conn_info.get(&handle) {
-                    self.emulation.send_leave_event(incoming.addr);
+                    self.emulation.send_leave_event(incoming.addr, t);
                 }
             }
             ICaptureEvent::CaptureDisabled => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -8,6 +8,7 @@ use crate::{
     emulation::{Emulation, EmulationEvent},
     listen::{LanMouseListener, ListenerCreationError},
     remap::KeyRemap,
+    scroll::ScrollInvert,
 };
 use futures::StreamExt;
 use lan_mouse_ipc::{
@@ -104,6 +105,10 @@ impl Service {
             conn,
             config.release_bind(),
             KeyRemap::new(config.remap_keys()),
+            ScrollInvert::new(
+                config.invert_scroll_vertical(),
+                config.invert_scroll_horizontal(),
+            ),
         );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
@@ -263,6 +268,10 @@ impl Service {
         self.capture.set_release_bind(release_bind);
         self.capture
             .set_remap(KeyRemap::new(self.config.remap_keys()));
+        self.capture.set_scroll_invert(ScrollInvert::new(
+            self.config.invert_scroll_vertical(),
+            self.config.invert_scroll_horizontal(),
+        ));
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()

--- a/src/service.rs
+++ b/src/service.rs
@@ -7,6 +7,7 @@ use crate::{
     dns::{DnsEvent, DnsResolver},
     emulation::{Emulation, EmulationEvent},
     listen::{LanMouseListener, ListenerCreationError},
+    remap::KeyRemap,
 };
 use futures::StreamExt;
 use lan_mouse_ipc::{
@@ -98,7 +99,12 @@ impl Service {
 
         // input capture + emulation
         let capture_backend = config.capture_backend().map(|b| b.into());
-        let capture = Capture::new(capture_backend, conn, config.release_bind());
+        let capture = Capture::new(
+            capture_backend,
+            conn,
+            config.release_bind(),
+            KeyRemap::new(config.remap_keys()),
+        );
         let emulation_backend = config.emulation_backend().map(|b| b.into());
         let emulation = Emulation::new(emulation_backend, listener);
 
@@ -255,6 +261,8 @@ impl Service {
         }
         let release_bind = self.config.release_bind();
         self.capture.set_release_bind(release_bind);
+        self.capture
+            .set_remap(KeyRemap::new(self.config.remap_keys()));
         let authorized_keys = self.config.authorized_fingerprints();
         self.authorized_keys
             .write()


### PR DESCRIPTION
Related to #361.

Adds `[input_pre_processing.remap_keys]`, rewriting individual keys just before
they go on the wire:

```toml
[input_pre_processing.remap_keys]
KeyLeftMeta = "KeyLeftCtrl"
KeyLeftCtrl = "KeyLeftMeta"
```

The motivating case is the one from #361 — modifier layouts differing across
operating systems. Sending Command from a Mac as Control (and Control as Super)
keeps `Cmd+C` copying on a Windows or Linux peer instead of firing whatever
Super+C happens to be bound to.

## Approach

Remapping is deliberately **send-side only**, applied right before events go on
the wire. Everything local — the release bind, enter binds, the host's own
shortcuts — keeps seeing the physical keys, so the remap cannot lock the user
out of their own machine.

The section name follows the direction set in #347: `input_post_processing` for
transformations on events *received* from other devices, `input_pre_processing`
for events *sent* to them. If #471 lands first I am happy to rebase onto
whatever shape it settles on.

## Two things a naive remap gets wrong

Both are covered by tests:

- **A modifier arrives twice** — once as a key event and once as a mask update.
  Rewriting only the key leaves the peer holding one modifier while its
  `KeyboardEvent::Modifiers` mask claims another. A swap also needs every source
  bit cleared *before* any target bit is set, or `A→B` together with `B→A` drops
  one of the two.
- **`release_capture` synthesizes key-up events** from the physical keys it
  recorded, so those have to go through the same remap — otherwise the peer is
  released from a key it was never pressed with and keeps holding the one it
  actually got.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`
  and `cargo test --workspace --all-features` clean on macOS; `cargo check` /
  `cargo clippy` clean for `x86_64-pc-windows-msvc`.
- 9 unit tests on the remap itself, including the mask/key consistency above.
- Verified end-to-end macOS → Windows over Tailscale: with the swap configured,
  `Cmd+C` and `Cmd+X` arrive as `Ctrl+C` / `Ctrl+X` on the Windows peer.

## Not in this PR

Per-client remaps. #361 asks for it per client/server pair; this is global
because that is the smaller change and matches the section being about the
sending side as a whole. Happy to extend it if you would rather have it keyed
per client.
