### PR TITLE
docs: correct the log level env var in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ cargo build --workspace                                    # full build
 cargo build -p <crate>                                     # single crate
 cargo test --workspace                                     # all tests
 cargo fmt && cargo clippy --workspace --all-targets --all-features  # lint
-RUST_LOG=lan_mouse=debug cargo run                         # debug logging
+LAN_MOUSE_LOG_LEVEL=debug cargo run                        # debug logging
 ```
 
 Run from repo root—no `cd` in scripts.


### PR DESCRIPTION
AGENTS.md tells contributors to use `RUST_LOG=lan_mouse=debug` for debug logging, but `src/main.rs:45` reads a different variable:

```rust
let env = Env::default().filter_or("LAN_MOUSE_LOG_LEVEL", "info");
```

`Env::default().filter_or(name, default)` uses `name` as the filter variable, so `RUST_LOG` is never consulted. Setting it has no effect and the level stays at `info`, silently.

Noticed while debugging a connection issue, where the missing trace output cost some time before I checked `main.rs`.