### PR TITLE
fix(wlroots): share one virtual keyboard across clients

### DIFF
--- a/input-emulation/examples/keymap_fd_churn.rs
+++ b/input-emulation/examples/keymap_fd_churn.rs
@@ -1,0 +1,123 @@
+//! Reproduction for issue #478: "Too many references: cannot splice (os error 109)",
+//! which is ETOOMANYREFS, on a wlroots compositor.
+//!
+//! `State::add_client` creates a virtual keyboard per emulation client and hands the
+//! compositor a keymap file descriptor. It is the same descriptor every time, and
+//! Wayland caps descriptors per sendmsg (MAX_FDS_OUT), so under client churn they
+//! queue faster than the compositor drains them until the send is refused.
+//!
+//! Run under a wlroots compositor:
+//!   cargo run --release -p input-emulation --example keymap_fd_churn
+//!   cargo run --release -p input-emulation --example keymap_fd_churn -- --control
+//!
+//! Churn mode creates one client per iteration. Control mode holds the client count
+//! at one and sends the same number of events, which is what distinguishes client
+//! creation from the event path.
+//!
+//! The descriptor limit matters. `too_many_unix_fds()` compares the USER's total
+//! in-flight SCM_RIGHTS count against the SENDER's RLIMIT_NOFILE, so a limit below
+//! the machine's ambient in-flight count fails at iteration 0 regardless of this bug,
+//! and a limit far above it never trips. On the machine this was written on, ambient
+//! sits near 1024 and `ulimit -n 2048` fails at about iteration 900 before the fix and
+//! runs clean after it.
+//!
+//! Motion events are sent with dx and dy of zero so the example never moves the real
+//! cursor.
+
+use input_emulation::{Backend, EmulationHandle, InputEmulation};
+use input_event::{Event, PointerEvent};
+
+/// number of simulated peer reconnects
+const ITERATIONS: u64 = 2000;
+
+/// how often to sample the descriptor count
+const SAMPLE_EVERY: u64 = 100;
+
+/// counts open descriptors of this process.
+/// returns None rather than 0 when the count itself fails for lack of a descriptor,
+/// so an exhausted process is never reported as using none.
+fn open_fds() -> Option<usize> {
+    std::fs::read_dir("/proc/self/fd").ok().map(|d| d.count())
+}
+
+fn fds_display(fds: Option<usize>) -> String {
+    match fds {
+        Some(n) => n.to_string(),
+        None => "unreadable (process out of descriptors)".to_string(),
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build runtime");
+
+    runtime.block_on(async {
+        let mut emulation = match InputEmulation::new(Some(Backend::Wlroots)).await {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("could not create wlroots emulation backend: {e}");
+                eprintln!("this example requires a running wlroots compositor");
+                std::process::exit(1);
+            }
+        };
+
+        // control mode reuses a single client, so only the event path runs.
+        // if descriptors stay flat here but climb in the default mode, client
+        // creation is the source and the event path is exonerated.
+        let control = std::env::args().any(|a| a == "--control");
+
+        let baseline = open_fds().unwrap_or(0);
+        println!("mode: {}", if control { "control (one client, N events)" } else { "churn (N clients)" });
+        println!("baseline open fds: {baseline}");
+        println!("running {ITERATIONS} iterations");
+
+        if control {
+            emulation.create(0).await;
+        }
+
+        for i in 0..ITERATIONS {
+            let handle = if control { 0 } else { i as EmulationHandle };
+
+            if !control {
+                // mirrors do_emulation_session: an unseen peer address creates a client
+                emulation.create(handle).await;
+            }
+
+            // a zero motion event is harmless but forces a flush of the queued keymap fd
+            let event = Event::Pointer(PointerEvent::Motion {
+                time: 0,
+                dx: 0.0,
+                dy: 0.0,
+            });
+
+            if let Err(e) = emulation.consume(event, handle).await {
+                println!();
+                println!("FAILED at iteration {i}");
+                println!("open fds: {} (baseline {baseline})", fds_display(open_fds()));
+                println!("error: {e}");
+                std::process::exit(1);
+            }
+
+            if i % SAMPLE_EVERY == 0 {
+                let now = open_fds();
+                let delta = now.map(|n| n.saturating_sub(baseline));
+                println!(
+                    "  iteration {i:>5}: open fds {:>6}{}",
+                    fds_display(now),
+                    delta.map(|d| format!(" (+{d} over baseline)")).unwrap_or_default(),
+                );
+            }
+        }
+
+        let final_fds = open_fds();
+        println!();
+        println!("completed {ITERATIONS} iterations without error");
+        println!(
+            "open fds: {} (baseline {baseline})",
+            fds_display(final_fds)
+        );
+        emulation.terminate().await;
+    });
+}

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -37,6 +37,8 @@ use super::error::WaylandBindError;
 
 struct State {
     keymap: Option<(u32, OwnedFd, u32)>,
+    /// shared by all clients, so the keymap fd is sent once instead of once per client
+    keyboard: Option<Vk>,
     input_for_client: HashMap<EmulationHandle, VirtualInput>,
     seat: wl_seat::WlSeat,
     qh: QueueHandle<Self>,
@@ -74,6 +76,7 @@ impl WlrootsEmulation {
             last_flush_failed: false,
             state: State {
                 keymap: None,
+                keyboard: None,
                 input_for_client,
                 seat,
                 vpm,
@@ -95,14 +98,20 @@ impl WlrootsEmulation {
 impl State {
     fn add_client(&mut self, client: EmulationHandle) {
         let pointer: Vp = self.vpm.create_virtual_pointer(None, &self.qh, ());
-        let keyboard: Vk = self.vkm.create_virtual_keyboard(&self.seat, &self.qh, ());
 
-        // TODO: use server side keymap
-        if let Some((format, fd, size)) = self.keymap.as_ref() {
-            keyboard.keymap(*format, fd.as_fd(), *size);
-        } else {
-            panic!("no keymap");
-        }
+        let keyboard = match self.keyboard.as_ref() {
+            Some(keyboard) => keyboard.clone(),
+            None => {
+                let keyboard: Vk = self.vkm.create_virtual_keyboard(&self.seat, &self.qh, ());
+                // TODO: use server side keymap
+                let Some((format, fd, size)) = self.keymap.as_ref() else {
+                    panic!("no keymap");
+                };
+                keyboard.keymap(*format, fd.as_fd(), *size);
+                self.keyboard = Some(keyboard.clone());
+                keyboard
+            }
+        };
 
         let vinput = VirtualInput {
             pointer,
@@ -114,9 +123,9 @@ impl State {
     }
 
     fn destroy_client(&mut self, handle: EmulationHandle) {
+        // the shared keyboard outlives every client; keys are released by InputEmulation::destroy
         if let Some(input) = self.input_for_client.remove(&handle) {
             input.pointer.destroy();
-            input.keyboard.destroy();
         }
     }
 }


### PR DESCRIPTION
Fixes the file descriptor exhaustion behind #478.

## Cause

`State::add_client` creates a virtual keyboard per emulation client and hands the compositor a keymap descriptor:

```rust
let keyboard: Vk = self.vkm.create_virtual_keyboard(&self.seat, &self.qh, ());
if let Some((format, fd, size)) = self.keymap.as_ref() {
    keyboard.keymap(*format, fd.as_fd(), *size);
```

It is the same descriptor on every call. Wayland caps descriptors per `sendmsg` (`MAX_FDS_OUT`), so under client-creation churn they queue faster than the compositor drains them, and the kernel eventually refuses the send. `too_many_unix_fds()` compares the user's total in-flight `SCM_RIGHTS` count against the sender's `RLIMIT_NOFILE`, which is why this shows up on an otherwise idle desktop: a distro with the traditional 1024 soft limit is already close to the ceiling before lan-mouse adds anything.

## Reproduction

Added as an example so it can be re-run: `cargo run --release -p input-emulation --example keymap_fd_churn`. It creates N emulation clients and samples `/proc/self/fd`. `--control` holds the client count at one and sends the same number of events instead.

On Arch, Hyprland 0.56.2, at `ulimit -n 2048`:

```
FAILED at iteration 896
error: wayland error: `Io error: Too many references: cannot splice (os error 109)`
```

That is `ETOOMANYREFS`, the error in #478. Control mode stays flat at 12 descriptors and completes clean, which is what identifies client creation rather than the event path as the source.

Note the threshold is environment dependent. The ambient in-flight count on this machine sits around 1024 to 1152, so a limit below that fails at iteration 0 regardless of this bug, and a limit far above it never trips. 1536 and 2048 both discriminate here.

## After

```
completed 2000 iterations without error
open fds: 12 (baseline 12)
```

Interleaved A/B at `ulimit -n 2048`, alternating binaries so ambient pressure is not mistaken for the effect:

| | before | after |
| --- | --- | --- |
| round 1 | FAILED at iteration 896, errno 109 | 2000 iterations, 12 fds |
| round 2 | FAILED at iteration 919, errno 109 | 2000 iterations, 12 fds |

`WAYLAND_DEBUG=1` over a 2000 client run confirms it at the protocol level: `create_virtual_keyboard` 1, `zwp_virtual_keyboard_v1.keymap` 1, `create_virtual_pointer` 2000.

## Why sharing the keyboard is safe

- Every virtual keyboard was already created on the same `wl_seat`, so wlroots merged their key and modifier streams into one focused surface. N objects never gave clients independent keyboard state, only independent handles onto the same seat.
- Per client modifier tracking is untouched. `XMods` stays in `VirtualInput`, one per client.
- Key release on destroy does not depend on `keyboard.destroy()`. `InputEmulation::destroy` calls `release_keys` first, which emits explicit releases and zeroed modifiers before the backend's `destroy` runs.
- Creation stays lazy rather than moving into `new()`, so the keyboard appears on the seat at the same moment as before, and never appears if no client is created.

## Testing

Verified end to end between two Arch machines running Hyprland over a LAN, layer-shell capture and wlroots emulation on both: cursor crossing, text entry, and Shift and Ctrl held while typing, with no stuck or dropped modifiers on either side.

## Adjacent, not addressed here

`Dispatch<WlSeat>` calls `seat.get_keyboard(...)` on every `Capabilities` event and never releases the `wl_keyboard`, so repeated capability announcements would leak keyboard objects and keymap descriptors. It looks unreachable today because nothing dispatches the queue after `new()`, so I have left it alone rather than change it without a reproduction.
