### PR TITLE
Preserve cross-edge cursor position when switching machines

### DIFF
--- a/input-capture/src/dummy.rs
+++ b/input-capture/src/dummy.rs
@@ -62,7 +62,7 @@ impl Stream for DummyInputCapture {
         let event = match self.start {
             None => {
                 self.start.replace(current);
-                CaptureEvent::Begin
+                CaptureEvent::Begin { cross_axis: None }
             }
             Some(start) => {
                 let elapsed = start.elapsed();

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -61,7 +61,10 @@ use wayland_client::{
     },
 };
 
-use input_event::{Event, KeyboardEvent, PointerEvent};
+use input_event::{
+    Event, KeyboardEvent, PointerEvent,
+    screen::{Edge, EdgeSegment, EdgeSegments, Rect},
+};
 
 use crate::{CaptureError, CaptureEvent};
 
@@ -148,6 +151,7 @@ struct Window {
     surface: WlSurface,
     layer_surface: ZwlrLayerSurfaceV1,
     pos: Position,
+    rect: Rect,
 }
 
 impl Window {
@@ -156,14 +160,15 @@ impl Window {
         qh: &QueueHandle<State>,
         output: &WlOutput,
         pos: Position,
-        size: (i32, i32),
+        output_rect: Rect,
+        rect: Rect,
     ) -> Window {
-        log::debug!("creating window output: {output:?}, size: {size:?}");
+        log::debug!("creating window output: {output:?}, rect: {rect:?}");
         let g = &state.globals;
 
         let (width, height) = match pos {
-            Position::Left | Position::Right => (1, size.1 as u32),
-            Position::Top | Position::Bottom => (size.0 as u32, 1),
+            Position::Left | Position::Right => (1, rect.height as u32),
+            Position::Top | Position::Bottom => (rect.width as u32, 1),
         };
         let mut file = tempfile::tempfile().unwrap();
         draw(&mut file, (width, height));
@@ -189,17 +194,29 @@ impl Window {
             qh,
             (),
         );
-        let anchor = match pos {
-            Position::Left => Anchor::Left,
-            Position::Right => Anchor::Right,
-            Position::Top => Anchor::Top,
-            Position::Bottom => Anchor::Bottom,
+        let (anchor, margin) = match pos {
+            Position::Left => (
+                Anchor::Left | Anchor::Top,
+                (rect.y - output_rect.y, 0, 0, 0),
+            ),
+            Position::Right => (
+                Anchor::Right | Anchor::Top,
+                (rect.y - output_rect.y, 0, 0, 0),
+            ),
+            Position::Top => (
+                Anchor::Top | Anchor::Left,
+                (0, 0, 0, rect.x - output_rect.x),
+            ),
+            Position::Bottom => (
+                Anchor::Bottom | Anchor::Left,
+                (0, 0, 0, rect.x - output_rect.x),
+            ),
         };
 
         layer_surface.set_anchor(anchor);
         layer_surface.set_size(width, height);
         layer_surface.set_exclusive_zone(-1);
-        layer_surface.set_margin(0, 0, 0, 0);
+        layer_surface.set_margin(margin.0, margin.1, margin.2, margin.3);
         surface.set_input_region(None);
         surface.commit();
         Window {
@@ -207,6 +224,7 @@ impl Window {
             buffer,
             surface,
             layer_surface,
+            rect,
         }
     }
 }
@@ -220,36 +238,124 @@ impl Drop for Window {
     }
 }
 
-fn get_edges(outputs: &[Output], pos: Position) -> Vec<(Output, i32)> {
-    outputs
-        .iter()
-        .filter_map(|output| {
-            output.info.as_ref().map(|info| {
-                (
-                    output.clone(),
-                    match pos {
-                        Position::Left => info.position.0,
-                        Position::Right => info.position.0 + info.size.0,
-                        Position::Top => info.position.1,
-                        Position::Bottom => info.position.1 + info.size.1,
-                    },
-                )
-            })
-        })
-        .collect()
+fn edge(pos: Position) -> Edge {
+    match pos {
+        Position::Left => Edge::Left,
+        Position::Right => Edge::Right,
+        Position::Top => Edge::Top,
+        Position::Bottom => Edge::Bottom,
+    }
 }
 
-fn get_output_configuration(state: &State, pos: Position) -> Vec<Output> {
-    // get all output edges corresponding to the position
-    let edges = get_edges(&state.outputs, pos);
-    let opposite_edges = get_edges(&state.outputs, pos.opposite());
+fn cursor_cross_axis(
+    window: &Window,
+    rectangles: &[Rect],
+    surface_x: f64,
+    surface_y: f64,
+) -> Option<f32> {
+    let edge = edge(window.pos);
+    let (edge_coordinate, cross_coordinate) = match edge {
+        Edge::Left => (window.rect.x, window.rect.y + surface_y.floor() as i32),
+        Edge::Right => (
+            window.rect.x + window.rect.width - 1,
+            window.rect.y + surface_y.floor() as i32,
+        ),
+        Edge::Top => (window.rect.y, window.rect.x + surface_x.floor() as i32),
+        Edge::Bottom => (
+            window.rect.y + window.rect.height - 1,
+            window.rect.x + surface_x.floor() as i32,
+        ),
+    };
+    EdgeSegments::from_rectangles(edge, rectangles.iter().copied())
+        .normalize(edge_coordinate, cross_coordinate)
+}
 
-    // remove those edges that are at the same position
-    // as an opposite edge of a different output
-    edges
-        .iter()
-        .filter(|(_, edge)| !opposite_edges.iter().map(|(_, e)| *e).any(|e| &e == edge))
-        .map(|(o, _)| o.clone())
+fn segment_rect(edge: Edge, segment: EdgeSegment) -> Rect {
+    match edge {
+        Edge::Left | Edge::Right => Rect {
+            x: segment.edge_coordinate,
+            y: segment.cross_start,
+            width: 1,
+            height: segment.cross_end - segment.cross_start,
+        },
+        Edge::Top | Edge::Bottom => Rect {
+            x: segment.cross_start,
+            y: segment.edge_coordinate,
+            width: segment.cross_end - segment.cross_start,
+            height: 1,
+        },
+    }
+}
+
+fn get_output_configuration(state: &State, pos: Position) -> Vec<(Output, Rect, Rect)> {
+    let edge = edge(pos);
+    let rectangles = state.outputs.iter().filter_map(|output| {
+        output.info.as_ref().map(|info| Rect {
+            x: info.position.0,
+            y: info.position.1,
+            width: info.size.0,
+            height: info.size.1,
+        })
+    });
+    let segments = EdgeSegments::from_rectangles(edge, rectangles)
+        .segments()
+        .collect::<Vec<_>>();
+
+    segments
+        .into_iter()
+        .flat_map(|segment| {
+            state.outputs.iter().filter_map(move |output| {
+                output.info.as_ref().and_then(|info| {
+                    let output_rect = Rect {
+                        x: info.position.0,
+                        y: info.position.1,
+                        width: info.size.0,
+                        height: info.size.1,
+                    };
+                    let (edge_coordinate, cross_start, cross_end) = match edge {
+                        Edge::Left => (
+                            info.position.0,
+                            info.position.1,
+                            info.position.1 + info.size.1,
+                        ),
+                        Edge::Right => (
+                            info.position.0 + info.size.0 - 1,
+                            info.position.1,
+                            info.position.1 + info.size.1,
+                        ),
+                        Edge::Top => (
+                            info.position.1,
+                            info.position.0,
+                            info.position.0 + info.size.0,
+                        ),
+                        Edge::Bottom => (
+                            info.position.1 + info.size.1 - 1,
+                            info.position.0,
+                            info.position.0 + info.size.0,
+                        ),
+                    };
+                    if segment.edge_coordinate != edge_coordinate {
+                        return None;
+                    }
+                    let cross_start = segment.cross_start.max(cross_start);
+                    let cross_end = segment.cross_end.min(cross_end);
+                    (cross_start < cross_end).then(|| {
+                        (
+                            output.clone(),
+                            output_rect,
+                            segment_rect(
+                                edge,
+                                EdgeSegment {
+                                    edge_coordinate,
+                                    cross_start,
+                                    cross_end,
+                                },
+                            ),
+                        )
+                    })
+                })
+            })
+        })
         .collect()
 }
 
@@ -514,19 +620,17 @@ impl State {
             "adding capture for position {pos} - using outputs: {:?}",
             outputs
                 .iter()
-                .map(|o| o
+                .map(|(o, _, _)| o
                     .info
                     .as_ref()
                     .map(|i| i.name.to_owned())
                     .unwrap_or("unknown output".to_owned()))
                 .collect::<Vec<_>>()
         );
-        outputs.iter().for_each(|o| {
-            if let Some(info) = o.info.as_ref() {
-                let window = Window::new(self, &self.qh, &o.wl_output, pos, info.size);
-                let window = Arc::new(window);
-                self.active_windows.push(window);
-            }
+        outputs.iter().for_each(|(output, output_rect, rect)| {
+            let window = Window::new(self, &self.qh, &output.wl_output, pos, *output_rect, *rect);
+            let window = Arc::new(window);
+            self.active_windows.push(window);
         });
     }
 
@@ -721,8 +825,8 @@ impl Dispatch<WlPointer, ()> for State {
             wl_pointer::Event::Enter {
                 serial,
                 surface,
-                surface_x: _,
-                surface_y: _,
+                surface_x,
+                surface_y,
             } => {
                 // get client corresponding to the focused surface
                 {
@@ -733,14 +837,27 @@ impl Dispatch<WlPointer, ()> for State {
                         return;
                     }
                 }
-                let pos = app
+                let window = app
                     .active_windows
                     .iter()
                     .find(|w| w.surface == surface)
-                    .map(|w| w.pos)
+                    .cloned()
                     .unwrap();
+                let rectangles = app
+                    .outputs
+                    .iter()
+                    .filter_map(|output| {
+                        output.info.as_ref().map(|info| Rect {
+                            x: info.position.0,
+                            y: info.position.1,
+                            width: info.size.0,
+                            height: info.size.1,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let cross_axis = cursor_cross_axis(&window, &rectangles, surface_x, surface_y);
                 app.pending_events
-                    .push_back((pos, CaptureEvent::Begin { cross_axis: None }));
+                    .push_back((window.pos, CaptureEvent::Begin { cross_axis }));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/layer_shell.rs
+++ b/input-capture/src/layer_shell.rs
@@ -739,7 +739,8 @@ impl Dispatch<WlPointer, ()> for State {
                     .find(|w| w.surface == surface)
                     .map(|w| w.pos)
                     .unwrap();
-                app.pending_events.push_back((pos, CaptureEvent::Begin));
+                app.pending_events
+                    .push_back((pos, CaptureEvent::Begin { cross_axis: None }));
             }
             wl_pointer::Event::Leave { .. } => {
                 /* There are rare cases, where when a window is opened in

--- a/input-capture/src/lib.rs
+++ b/input-capture/src/lib.rs
@@ -38,7 +38,7 @@ pub type CaptureHandle = u64;
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CaptureEvent {
     /// capture on this capture handle is now active
-    Begin,
+    Begin { cross_axis: Option<f32> },
     /// input event coming from capture handle
     Input(Event),
 }
@@ -46,7 +46,9 @@ pub enum CaptureEvent {
 impl Display for CaptureEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CaptureEvent::Begin => write!(f, "begin capture"),
+            CaptureEvent::Begin { cross_axis } => {
+                write!(f, "begin capture ({cross_axis:?})")
+            }
             CaptureEvent::Input(e) => write!(f, "{e}"),
         }
     }

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -3,7 +3,7 @@ use ashpd::{
         Session,
         input_capture::{
             Activated, ActivatedBarrier, Barrier, BarrierID, Capabilities, CreateSessionOptions,
-            InputCapture, Region, ReleaseOptions, Zones,
+            InputCapture, ReleaseOptions,
         },
     },
     enumflags2::BitFlags,
@@ -37,7 +37,10 @@ use tokio_util::sync::CancellationToken;
 
 use futures_core::Stream;
 
-use input_event::Event;
+use input_event::{
+    Event,
+    screen::{Edge, EdgeSegment, EdgeSegments, Rect},
+};
 
 use crate::CaptureEvent;
 
@@ -87,15 +90,41 @@ pub struct LibeiInputCapture {
     terminated: bool,
 }
 
-/// returns (start pos, end pos), inclusive
-fn pos_to_barrier(r: &Region, pos: Position) -> (i32, i32, i32, i32) {
-    let (x, y) = (r.x_offset(), r.y_offset());
-    let (w, h) = (r.width() as i32, r.height() as i32);
+fn edge(pos: Position) -> Edge {
     match pos {
-        Position::Left => (x, y, x, y + h - 1),
-        Position::Right => (x + w, y, x + w, y + h - 1),
-        Position::Top => (x, y, x + w - 1, y),
-        Position::Bottom => (x, y + h, x + w - 1, y + h),
+        Position::Left => Edge::Left,
+        Position::Right => Edge::Right,
+        Position::Top => Edge::Top,
+        Position::Bottom => Edge::Bottom,
+    }
+}
+
+fn segment_to_barrier(segment: EdgeSegment, pos: Position) -> (i32, i32, i32, i32) {
+    match pos {
+        Position::Left => (
+            segment.edge_coordinate,
+            segment.cross_start,
+            segment.edge_coordinate,
+            segment.cross_end - 1,
+        ),
+        Position::Right => (
+            segment.edge_coordinate + 1,
+            segment.cross_start,
+            segment.edge_coordinate + 1,
+            segment.cross_end - 1,
+        ),
+        Position::Top => (
+            segment.cross_start,
+            segment.edge_coordinate,
+            segment.cross_end - 1,
+            segment.edge_coordinate,
+        ),
+        Position::Bottom => (
+            segment.cross_start,
+            segment.edge_coordinate + 1,
+            segment.cross_end - 1,
+            segment.edge_coordinate + 1,
+        ),
     }
 }
 
@@ -122,7 +151,7 @@ impl From<ICBarrier> for Barrier {
 }
 
 fn select_barriers(
-    zones: &Zones,
+    rectangles: &[Rect],
     clients: &[Position],
     next_barrier_id: &mut NonZeroU32,
 ) -> (Vec<ICBarrier>, HashMap<BarrierID, Position>) {
@@ -130,19 +159,19 @@ fn select_barriers(
     let mut barriers: Vec<ICBarrier> = vec![];
 
     for pos in clients {
-        let mut client_barriers = zones
-            .regions()
-            .iter()
-            .map(|r| {
-                let id = *next_barrier_id;
-                *next_barrier_id = next_barrier_id
-                    .checked_add(1)
-                    .expect("barrier id out of range");
-                let position = pos_to_barrier(r, *pos);
-                pos_for_barrier.insert(id, *pos);
-                ICBarrier::new(id, position)
-            })
-            .collect();
+        let mut client_barriers =
+            EdgeSegments::from_rectangles(edge(*pos), rectangles.iter().copied())
+                .segments()
+                .map(|segment| {
+                    let id = *next_barrier_id;
+                    *next_barrier_id = next_barrier_id
+                        .checked_add(1)
+                        .expect("barrier id out of range");
+                    let position = segment_to_barrier(segment, *pos);
+                    pos_for_barrier.insert(id, *pos);
+                    ICBarrier::new(id, position)
+                })
+                .collect();
         barriers.append(&mut client_barriers);
     }
     (barriers, pos_for_barrier)
@@ -153,14 +182,24 @@ async fn update_barriers(
     session: &Session<InputCapture>,
     active_clients: &[Position],
     next_barrier_id: &mut NonZeroU32,
-) -> Result<(Vec<ICBarrier>, HashMap<BarrierID, Position>), ashpd::Error> {
+) -> Result<(Vec<Rect>, Vec<ICBarrier>, HashMap<BarrierID, Position>), ashpd::Error> {
     let zones = input_capture
         .zones(session, Default::default())
         .await?
         .response()?;
     log::debug!("zones: {zones:?}");
+    let rectangles: Vec<Rect> = zones
+        .regions()
+        .iter()
+        .map(|region| Rect {
+            x: region.x_offset(),
+            y: region.y_offset(),
+            width: region.width() as i32,
+            height: region.height() as i32,
+        })
+        .collect();
 
-    let (barriers, id_map) = select_barriers(&zones, active_clients, next_barrier_id);
+    let (barriers, id_map) = select_barriers(&rectangles, active_clients, next_barrier_id);
     log::debug!("barriers: {barriers:?}");
     log::debug!("client for barrier id: {id_map:?}");
 
@@ -175,7 +214,7 @@ async fn update_barriers(
         .await?;
     let response = response.response()?;
     log::debug!("{response:?}");
-    Ok((barriers, id_map))
+    Ok((rectangles, barriers, id_map))
 }
 
 async fn create_session(
@@ -381,7 +420,7 @@ async fn do_capture_session(
     let (context, _conn, ei_event_stream) = connect_to_eis(input_capture, session).await?;
 
     // set barriers
-    let (barriers, pos_for_barrier_id) =
+    let (rectangles, barriers, pos_for_barrier_id) =
         update_barriers(input_capture, session, active_clients, next_barrier_id).await?;
 
     log::debug!("enabling session");
@@ -425,27 +464,30 @@ async fn do_capture_session(
                     log::debug!("activated: {activated:?}");
 
                     // get barrier id from activation
-                    let barrier_id = match activated.barrier_id() {
+                    let activated_barrier_id = match activated.barrier_id() {
                         Some(ActivatedBarrier::Barrier(id)) => id,
                         // workaround for KDE plasma not reporting barrier ids
                         Some(ActivatedBarrier::UnknownBarrier) | None => find_corresponding_client(&barriers, activated.cursor_position().expect("no cursor position reported by compositor")),
                     };
 
                     // find client corresponding to barrier
-                    let pos = match pos_for_barrier_id.get(&barrier_id) {
-                        Some(id) => *id,
+                    let pos = match pos_for_barrier_id.get(&activated_barrier_id) {
+                        Some(pos) => *pos,
                         None => {
-                            log::warn!("INVALID BARRIER ID: Id {barrier_id} does not exist!");
+                            log::warn!("INVALID BARRIER ID: Id {activated_barrier_id} does not exist!");
                             let id = find_corresponding_client(&barriers, activated.cursor_position().expect("no cursor position reported by compositor"));
-                            let pos = *pos_for_barrier_id.get(&id).expect("invalid barrier id");
-                            pos
+                            *pos_for_barrier_id.get(&id).expect("invalid barrier id")
                         },
                     };
                     current_pos.replace(Some(pos));
 
+                    let cross_axis = activated.cursor_position().and_then(|cursor| {
+                        normalized_cross_axis(pos, &rectangles, cursor)
+                    });
+
                     // client entered => send event
                     event_tx
-                        .send((pos, CaptureEvent::Begin { cross_axis: None }))
+                        .send((pos, CaptureEvent::Begin { cross_axis }))
                         .await
                         .expect("no channel");
 
@@ -502,6 +544,18 @@ async fn do_capture_session(
     Ok(())
 }
 
+fn normalized_cross_axis(pos: Position, rectangles: &[Rect], cursor: (f32, f32)) -> Option<f32> {
+    let edge = edge(pos);
+    let (edge_coordinate, cross_coordinate) = match edge {
+        Edge::Left => (cursor.0.floor() as i32, cursor.1.floor() as i32),
+        Edge::Right => (cursor.0.floor() as i32 - 1, cursor.1.floor() as i32),
+        Edge::Top => (cursor.1.floor() as i32, cursor.0.floor() as i32),
+        Edge::Bottom => (cursor.1.floor() as i32 - 1, cursor.0.floor() as i32),
+    };
+    EdgeSegments::from_rectangles(edge, rectangles.iter().copied())
+        .normalize(edge_coordinate, cross_coordinate)
+}
+
 async fn release_capture(
     input_capture: &InputCapture,
     session: &Session<InputCapture>,
@@ -535,28 +589,27 @@ fn find_corresponding_client(barriers: &[ICBarrier], pos: (f32, f32)) -> Barrier
     barriers
         .iter()
         .copied()
-        .min_by_key(|b| {
-            let (x1, y1, x2, y2) = b.position;
-            let (x1, y1, x2, y2) = (x1 as f32, y1 as f32, x2 as f32, y2 as f32);
-            distance_to_line(((x1, y1), (x2, y2)), pos) as i32
+        .min_by(|left, right| {
+            let distance = |barrier: &ICBarrier| {
+                let (x1, y1, x2, y2) = barrier.position;
+                distance_to_segment(((x1 as f32, y1 as f32), (x2 as f32, y2 as f32)), pos)
+            };
+            distance(left).total_cmp(&distance(right))
         })
         .expect("could not find barrier corresponding to client")
         .barrier_id
 }
 
-fn distance_to_line(line: ((f32, f32), (f32, f32)), p: (f32, f32)) -> f32 {
+fn distance_to_segment(line: ((f32, f32), (f32, f32)), p: (f32, f32)) -> f32 {
     let ((x1, y1), (x2, y2)) = line;
     let (x0, y0) = p;
-    /*
-     * we use the fact that for the triangle spanned by the line and p,
-     * the height of the triangle is the desired distance and can be calculated by
-     * h = 2A / b with b being the line_length and
-     */
-    let double_triangle_area = ((y2 - y1) * x0 - (x2 - x1) * y0 + x2 * y1 - y2 * x1).abs();
-    let line_length = ((y2 - y1).powf(2.0) + (x2 - x1).powf(2.0)).sqrt();
-    let distance = double_triangle_area / line_length;
-    log::debug!("distance to line({line:?}, {p:?}) = {distance}");
-    distance
+    let (dx, dy) = (x2 - x1, y2 - y1);
+    let length_squared = dx.mul_add(dx, dy * dy);
+    if length_squared == 0.0 {
+        return (x0 - x1).hypot(y0 - y1);
+    }
+    let t = ((x0 - x1).mul_add(dx, (y0 - y1) * dy) / length_squared).clamp(0.0, 1.0);
+    (x0 - (x1 + t * dx)).hypot(y0 - (y1 + t * dy))
 }
 
 async fn handle_ei_event(
@@ -668,5 +721,104 @@ impl Stream for LibeiInputCapture {
             },
             Poll::Pending => self.event_rx.poll_recv(cx).map(|e| e.map(Result::Ok)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::{
+        ICBarrier, Position, Rect, distance_to_segment, find_corresponding_client,
+        normalized_cross_axis, select_barriers,
+    };
+
+    fn rect(x: i32, y: i32, width: i32, height: i32) -> Rect {
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn left_geometry_ignores_right_barriers() {
+        let rectangles = [rect(0, 0, 1920, 1080), rect(1920, 0, 1920, 1080)];
+        assert_eq!(
+            normalized_cross_axis(Position::Left, &rectangles, (0.0, 1079.0)),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn multi_monitor_geometry_uses_the_exposed_edge() {
+        let rectangles = [rect(100, 0, 1920, 100), rect(0, 100, 1920, 100)];
+        assert_eq!(
+            normalized_cross_axis(Position::Left, &rectangles, (0.0, 150.0)),
+            Some(150.0 / 199.0)
+        );
+    }
+
+    #[test]
+    fn barriers_cover_only_exposed_left_and_right_segments() {
+        let rectangles = [rect(0, 0, 1920, 100), rect(1920, 100, 1920, 100)];
+        let mut next_id = NonZeroU32::new(1).unwrap();
+        let (barriers, positions) = select_barriers(
+            &rectangles,
+            &[Position::Left, Position::Right],
+            &mut next_id,
+        );
+
+        assert_eq!(barriers.len(), 4);
+        assert_eq!(positions.len(), 4);
+    }
+
+    #[test]
+    fn distance_to_segment_clamps_to_the_nearest_endpoint() {
+        assert_eq!(
+            distance_to_segment(((0.0, 0.0), (0.0, 10.0)), (0.0, 15.0)),
+            5.0
+        );
+        assert_eq!(
+            distance_to_segment(((0.0, 0.0), (10.0, 0.0)), (5.0, 3.0)),
+            3.0
+        );
+    }
+
+    #[test]
+    fn distance_to_segment_distinguishes_separated_collinear_barriers() {
+        assert_eq!(
+            distance_to_segment(((0.0, 0.0), (0.0, 5.0)), (0.0, 9.0)),
+            4.0
+        );
+        assert_eq!(
+            distance_to_segment(((0.0, 7.0), (0.0, 12.0)), (0.0, 9.0)),
+            0.0
+        );
+    }
+
+    #[test]
+    fn corresponding_barrier_keeps_subpixel_precision() {
+        let farther = ICBarrier::new(NonZeroU32::new(1).unwrap(), (0, 0, 10, 0));
+        let nearer = ICBarrier::new(NonZeroU32::new(2).unwrap(), (0, 1, 10, 1));
+        assert_eq!(
+            find_corresponding_client(&[farther, nearer], (5.0, 0.9)),
+            nearer.barrier_id
+        );
+        assert_eq!(
+            find_corresponding_client(&[nearer, farther], (5.0, 0.9)),
+            nearer.barrier_id
+        );
+    }
+
+    #[test]
+    fn corresponding_barrier_breaks_equal_distances_by_input_order() {
+        let first = ICBarrier::new(NonZeroU32::new(1).unwrap(), (0, 0, 10, 0));
+        let second = ICBarrier::new(NonZeroU32::new(2).unwrap(), (0, 2, 10, 2));
+        assert_eq!(
+            find_corresponding_client(&[first, second], (5.0, 1.0)),
+            first.barrier_id
+        );
     }
 }

--- a/input-capture/src/libei.rs
+++ b/input-capture/src/libei.rs
@@ -444,7 +444,10 @@ async fn do_capture_session(
                     current_pos.replace(Some(pos));
 
                     // client entered => send event
-                    event_tx.send((pos, CaptureEvent::Begin)).await.expect("no channel");
+                    event_tx
+                        .send((pos, CaptureEvent::Begin { cross_axis: None }))
+                        .await
+                        .expect("no channel");
 
                     tokio::select! {
                         _ = notify_release.notified() => { /* capture release */

--- a/input-capture/src/macos.rs
+++ b/input-capture/src/macos.rs
@@ -522,7 +522,7 @@ fn create_event_tap<'a>(
                 state
                     .start_capture(cg_ev, new_pos)
                     .unwrap_or_else(|e| log::warn!("{e}"));
-                res_events.push(CaptureEvent::Begin);
+                res_events.push(CaptureEvent::Begin { cross_axis: None });
                 notify_tx
                     .blocking_send(ProducerEvent::Grab(new_pos))
                     .expect("Failed to send notification");

--- a/input-capture/src/windows/display_util.rs
+++ b/input-capture/src/windows/display_util.rs
@@ -1,27 +1,8 @@
 use windows::Win32::Foundation::RECT;
 
+use input_event::screen::{CrossedEdge, Rect, crossed_exposed_edge};
+
 use crate::Position;
-
-fn is_within_dp_region(point: (i32, i32), display: &RECT) -> bool {
-    [
-        Position::Left,
-        Position::Right,
-        Position::Top,
-        Position::Bottom,
-    ]
-    .iter()
-    .all(|&pos| is_within_dp_boundary(point, display, pos))
-}
-
-fn is_within_dp_boundary(point: (i32, i32), display: &RECT, pos: Position) -> bool {
-    let (x, y) = point;
-    match pos {
-        Position::Left => display.left <= x,
-        Position::Right => display.right > x,
-        Position::Top => display.top <= y,
-        Position::Bottom => display.bottom > y,
-    }
-}
 
 /// returns whether the given position is within the display bounds with respect to the given
 /// barrier position
@@ -35,65 +16,30 @@ fn is_within_dp_boundary(point: (i32, i32), display: &RECT, pos: Position) -> bo
 ///
 /// returns: bool
 ///
-fn in_bounds(point: (i32, i32), displays: &[RECT], pos: Position) -> bool {
-    displays
-        .iter()
-        .any(|d| is_within_dp_boundary(point, d, pos))
-}
-
-fn in_display_region(point: (i32, i32), displays: &[RECT]) -> bool {
-    displays.iter().any(|d| is_within_dp_region(point, d))
-}
-
-fn moved_across_boundary(
-    prev_pos: (i32, i32),
-    curr_pos: (i32, i32),
-    displays: &[RECT],
-    pos: Position,
-) -> bool {
-    /* was within bounds, but is not anymore */
-    in_display_region(prev_pos, displays) && !in_bounds(curr_pos, displays, pos)
-}
-
 pub(crate) fn entered_barrier(
     prev_pos: (i32, i32),
     curr_pos: (i32, i32),
     displays: &[RECT],
-) -> Option<Position> {
-    [
-        Position::Left,
-        Position::Right,
-        Position::Top,
-        Position::Bottom,
-    ]
-    .into_iter()
-    .find(|&pos| moved_across_boundary(prev_pos, curr_pos, displays, pos))
-}
-
-///
-/// clamp point to display bounds
-///
-/// # Arguments
-///
-/// * `prev_point`: coordinates, the cursor was before entering, within bounds of a display
-/// * `entry_point`: point to clamp
-///
-/// returns: (i32, i32), the corrected entry point
-///
-pub(crate) fn clamp_to_display_bounds(
-    display_regions: &[RECT],
-    prev_point: (i32, i32),
-    point: (i32, i32),
-) -> (i32, i32) {
-    /* find display where movement came from */
-    let display = display_regions
-        .iter()
-        .find(|&d| is_within_dp_region(prev_point, d))
-        .unwrap();
-
-    /* clamp to bounds (inclusive) */
-    let (x, y) = point;
-    let (min_x, max_x) = (display.left, display.right - 1);
-    let (min_y, max_y) = (display.top, display.bottom - 1);
-    (x.clamp(min_x, max_x), y.clamp(min_y, max_y))
+) -> Option<(Position, (i32, i32))> {
+    crossed_exposed_edge(
+        prev_pos,
+        curr_pos,
+        displays.iter().map(|display| Rect {
+            x: display.left,
+            y: display.top,
+            width: display.right.saturating_sub(display.left),
+            height: display.bottom.saturating_sub(display.top),
+        }),
+    )
+    .map(|CrossedEdge { edge, point }| {
+        (
+            match edge {
+                input_event::screen::Edge::Left => Position::Left,
+                input_event::screen::Edge::Right => Position::Right,
+                input_event::screen::Edge::Top => Position::Top,
+                input_event::screen::Edge::Bottom => Position::Bottom,
+            },
+            point,
+        )
+    })
 }

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -29,6 +29,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 use input_event::{
     BTN_BACK, BTN_FORWARD, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT, Event, KeyboardEvent, PointerEvent,
     scancode::{self, Linux},
+    screen::{Edge, EdgeSegments, Rect},
 };
 
 use super::{CaptureEvent, Position, display_util};
@@ -280,7 +281,7 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
         display_util::entered_barrier(prev_pos, curr_pos, displays)
     });
 
-    let Some(pos) = entered else {
+    let Some((pos, entry_point)) = entered else {
         return ret;
     };
 
@@ -291,15 +292,31 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
 
     /* update active client and entry point */
     ACTIVE_CLIENT.replace(Some(pos));
-    let entry_point = DISPLAYS.with_borrow(|(displays, _)| {
-        display_util::clamp_to_display_bounds(displays, prev_pos, curr_pos)
-    });
     ENTRY_POINT.replace(entry_point);
 
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
     let active = ACTIVE_CLIENT.get().expect("active client");
-    blocking_send_event(active, CaptureEvent::Begin { cross_axis: None });
+    let cross_axis = DISPLAYS.with_borrow(|(displays, _)| {
+        let edge = match active {
+            Position::Left => Edge::Left,
+            Position::Right => Edge::Right,
+            Position::Top => Edge::Top,
+            Position::Bottom => Edge::Bottom,
+        };
+        let rectangles = displays.iter().map(|display| Rect {
+            x: display.left,
+            y: display.top,
+            width: display.right.saturating_sub(display.left),
+            height: display.bottom.saturating_sub(display.top),
+        });
+        let (edge_coordinate, cross_coordinate) = match edge {
+            Edge::Left | Edge::Right => (entry_point.0, entry_point.1),
+            Edge::Top | Edge::Bottom => (entry_point.1, entry_point.0),
+        };
+        EdgeSegments::from_rectangles(edge, rectangles).normalize(edge_coordinate, cross_coordinate)
+    });
+    blocking_send_event(active, CaptureEvent::Begin { cross_axis });
 
     ret
 }

--- a/input-capture/src/windows/event_thread.rs
+++ b/input-capture/src/windows/event_thread.rs
@@ -299,7 +299,7 @@ fn check_client_activation(wparam: WPARAM, lparam: LPARAM) -> bool {
     /* notify main thread */
     log::debug!("ENTERED @ {prev_pos:?} -> {curr_pos:?}");
     let active = ACTIVE_CLIENT.get().expect("active client");
-    blocking_send_event(active, CaptureEvent::Begin);
+    blocking_send_event(active, CaptureEvent::Begin { cross_axis: None });
 
     ret
 }

--- a/input-emulation/src/lib.rs
+++ b/input-emulation/src/lib.rs
@@ -8,6 +8,15 @@ use input_event::{Event, KeyboardEvent};
 
 pub use self::error::{EmulationCreationError, EmulationError, InputEmulationError};
 
+/// Edge used to place the cursor when a peer enters this device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WarpPosition {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
 #[cfg(windows)]
 mod windows;
 
@@ -178,6 +187,15 @@ impl InputEmulation {
         self.emulation.terminate().await
     }
 
+    pub async fn warp_cursor(
+        &mut self,
+        handle: EmulationHandle,
+        pos: WarpPosition,
+        cross_axis: f32,
+    ) -> Result<(), EmulationError> {
+        self.emulation.warp_cursor(handle, pos, cross_axis).await
+    }
+
     pub async fn release_keys(&mut self, handle: EmulationHandle) -> Result<(), EmulationError> {
         if let Some(keys) = self.pressed_keys.get_mut(&handle) {
             let keys = keys.drain().collect::<Vec<_>>();
@@ -237,4 +255,12 @@ trait Emulation: Send {
     async fn create(&mut self, handle: EmulationHandle);
     async fn destroy(&mut self, handle: EmulationHandle);
     async fn terminate(&mut self);
+    async fn warp_cursor(
+        &mut self,
+        _handle: EmulationHandle,
+        _pos: WarpPosition,
+        _cross_axis: f32,
+    ) -> Result<(), EmulationError> {
+        Ok(())
+    }
 }

--- a/input-emulation/src/libei.rs
+++ b/input-emulation/src/libei.rs
@@ -19,22 +19,26 @@ use async_trait::async_trait;
 
 use reis::{
     ei::{
-        self, Button, Keyboard, Pointer, Scroll, button::ButtonState, handshake::ContextType,
-        keyboard::KeyState,
+        self, Button, Keyboard, Pointer, PointerAbsolute, Scroll, button::ButtonState,
+        handshake::ContextType, keyboard::KeyState,
     },
     event::{self, Connection, DeviceCapability, DeviceEvent, EiEvent, SeatEvent},
     tokio::EiConvertEventStream,
 };
 
-use input_event::{Event, KeyboardEvent, PointerEvent};
+use input_event::{
+    Event, KeyboardEvent, PointerEvent,
+    screen::{Edge, EdgeSegments, Rect},
+};
 
 use crate::error::EmulationError;
 
-use super::{Emulation, EmulationHandle, error::LibeiEmulationCreationError};
+use super::{Emulation, EmulationHandle, WarpPosition, error::LibeiEmulationCreationError};
 
 #[derive(Clone, Default)]
 struct Devices {
     pointer: Arc<RwLock<Option<(ei::Device, ei::Pointer)>>>,
+    pointer_absolute: Arc<RwLock<Vec<(event::Device, ei::PointerAbsolute)>>>,
     scroll: Arc<RwLock<Option<(ei::Device, ei::Scroll)>>>,
     button: Arc<RwLock<Option<(ei::Device, ei::Button)>>>,
     keyboard: Arc<RwLock<Option<(ei::Device, ei::Keyboard)>>>,
@@ -261,6 +265,69 @@ impl Emulation for LibeiEmulation {
         let _ = self.session.close().await;
         self.ei_task.abort();
     }
+
+    async fn warp_cursor(
+        &mut self,
+        _handle: EmulationHandle,
+        pos: WarpPosition,
+        cross_axis: f32,
+    ) -> Result<(), EmulationError> {
+        if !cross_axis.is_finite() {
+            return Ok(());
+        }
+        let pointer_absolute = self.devices.pointer_absolute.read().unwrap();
+        let rectangles = pointer_absolute
+            .iter()
+            .flat_map(|(device, _)| device.regions())
+            .filter_map(|region| {
+                Some(Rect {
+                    x: i32::try_from(region.x).ok()?,
+                    y: i32::try_from(region.y).ok()?,
+                    width: i32::try_from(region.width).ok()?,
+                    height: i32::try_from(region.height).ok()?,
+                })
+            })
+            .collect::<Vec<_>>();
+        let edge = match pos {
+            WarpPosition::Left => Edge::Left,
+            WarpPosition::Right => Edge::Right,
+            WarpPosition::Top => Edge::Top,
+            WarpPosition::Bottom => Edge::Bottom,
+        };
+        let Some((edge_coordinate, cross_coordinate)) =
+            EdgeSegments::from_rectangles(edge, rectangles).denormalize(cross_axis)
+        else {
+            return Ok(());
+        };
+        let (x, y) = match edge {
+            Edge::Left | Edge::Right => (edge_coordinate, cross_coordinate),
+            Edge::Top | Edge::Bottom => (cross_coordinate, edge_coordinate),
+        };
+        let (x, y) = match (u32::try_from(x), u32::try_from(y)) {
+            (Ok(x), Ok(y)) => (x, y),
+            _ => return Ok(()),
+        };
+        let Some((device, pointer_absolute)) = pointer_absolute.iter().find(|(device, _)| {
+            device.regions().iter().any(|region| {
+                x >= region.x
+                    && x < region.x + region.width
+                    && y >= region.y
+                    && y < region.y + region.height
+            })
+        }) else {
+            return Ok(());
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        pointer_absolute.motion_absolute(x as f32, y as f32);
+        device.device().frame(self.conn.serial(), now);
+        self.context
+            .flush()
+            .map_err(|e| io::Error::new(e.kind(), e))?;
+        Ok(())
+    }
 }
 
 async fn ei_task(
@@ -282,6 +349,10 @@ async fn ei_task(
             }
         }
     }
+}
+
+fn remove_device<D: PartialEq, T>(devices: &mut Vec<(D, T)>, removed_device: &D) {
+    devices.retain(|(device, _)| device != removed_device);
 }
 
 async fn ei_event_handler(
@@ -320,6 +391,13 @@ async fn ei_event_handler(
                         .unwrap()
                         .replace((device.device().clone(), pointer));
                 }
+                if let Some(pointer_absolute) = e.device().interface::<PointerAbsolute>() {
+                    devices
+                        .pointer_absolute
+                        .write()
+                        .unwrap()
+                        .push((device.clone(), pointer_absolute));
+                }
                 if let Some(keyboard) = e.device().interface::<Keyboard>() {
                     devices
                         .keyboard
@@ -344,6 +422,7 @@ async fn ei_event_handler(
             }
             EiEvent::DeviceRemoved(e) => {
                 log::debug!("device removed: {:?}", e.device().device_type());
+                remove_device(&mut devices.pointer_absolute.write().unwrap(), e.device());
             }
             EiEvent::DevicePaused(e) => {
                 log::debug!("device paused: {:?}", e.device().device_type());
@@ -373,5 +452,20 @@ async fn ei_event_handler(
             _ => unreachable!("unexpected ei event"),
         }
         context.flush().map_err(|e| io::Error::new(e.kind(), e))?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remove_device;
+
+    #[test]
+    fn removing_a_device_discards_only_its_absolute_pointer() {
+        let removed_device = 1;
+        let mut pointers = vec![(1, "removed"), (2, "retained")];
+
+        remove_device(&mut pointers, &removed_device);
+
+        assert_eq!(pointers, vec![(2, "retained")]);
     }
 }

--- a/input-emulation/src/windows.rs
+++ b/input-emulation/src/windows.rs
@@ -2,12 +2,18 @@ use super::error::{EmulationError, WindowsEmulationCreationError};
 use input_event::{
     BTN_BACK, BTN_FORWARD, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT, Event, KeyboardEvent, PointerEvent,
     scancode,
+    screen::{Edge, EdgeSegments, Rect},
 };
 
 use async_trait::async_trait;
 use std::ops::BitOrAssign;
 use std::time::Duration;
 use tokio::task::AbortHandle;
+use windows::Win32::Foundation::{FALSE, RECT};
+use windows::Win32::Graphics::Gdi::{
+    DEVMODEW, DISPLAY_DEVICE_ATTACHED_TO_DESKTOP, DISPLAY_DEVICEW, ENUM_CURRENT_SETTINGS,
+    EnumDisplayDevicesW, EnumDisplaySettingsW,
+};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE,
     MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
@@ -17,9 +23,10 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     INPUT_0, KEYEVENTF_EXTENDEDKEY, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, SendInput,
 };
-use windows::Win32::UI::WindowsAndMessaging::{XBUTTON1, XBUTTON2};
+use windows::Win32::UI::WindowsAndMessaging::{SetCursorPos, XBUTTON1, XBUTTON2};
+use windows::core::PCWSTR;
 
-use super::{Emulation, EmulationHandle};
+use super::{Emulation, EmulationHandle, WarpPosition};
 
 const DEFAULT_REPEAT_DELAY: Duration = Duration::from_millis(500);
 const DEFAULT_REPEAT_INTERVAL: Duration = Duration::from_millis(32);
@@ -80,6 +87,87 @@ impl Emulation for WindowsEmulation {
     async fn destroy(&mut self, _handle: EmulationHandle) {}
 
     async fn terminate(&mut self) {}
+
+    async fn warp_cursor(
+        &mut self,
+        _handle: EmulationHandle,
+        pos: WarpPosition,
+        cross_axis: f32,
+    ) -> Result<(), EmulationError> {
+        if !cross_axis.is_finite() {
+            return Ok(());
+        }
+        let edge = edge_for_position(pos);
+        let Some((edge_coordinate, cross_coordinate)) =
+            EdgeSegments::from_rectangles(edge, display_rectangles()).denormalize(cross_axis)
+        else {
+            return Ok(());
+        };
+        let (x, y) = match edge {
+            Edge::Left | Edge::Right => (edge_coordinate, cross_coordinate),
+            Edge::Top | Edge::Bottom => (cross_coordinate, edge_coordinate),
+        };
+        unsafe {
+            let _ = SetCursorPos(x, y);
+        }
+        Ok(())
+    }
+}
+
+fn edge_for_position(pos: WarpPosition) -> Edge {
+    match pos {
+        WarpPosition::Left => Edge::Left,
+        WarpPosition::Right => Edge::Right,
+        WarpPosition::Top => Edge::Top,
+        WarpPosition::Bottom => Edge::Bottom,
+    }
+}
+
+fn display_rectangles() -> Vec<Rect> {
+    let mut display_rects = Vec::<RECT>::new();
+    unsafe {
+        let mut devices = Vec::new();
+        for index in 0.. {
+            let mut device: DISPLAY_DEVICEW = std::mem::zeroed();
+            device.cb = std::mem::size_of::<DISPLAY_DEVICEW>() as u32;
+            if EnumDisplayDevicesW(None, index, &mut device, Default::default()) == FALSE {
+                break;
+            }
+            if device
+                .StateFlags
+                .contains(DISPLAY_DEVICE_ATTACHED_TO_DESKTOP)
+            {
+                devices.push(device.DeviceName);
+            }
+        }
+        for device in devices {
+            let mut mode: DEVMODEW = std::mem::zeroed();
+            mode.dmSize = std::mem::size_of::<DEVMODEW>() as u16;
+            if EnumDisplaySettingsW(
+                PCWSTR::from_raw(&device as *const _),
+                ENUM_CURRENT_SETTINGS,
+                &mut mode,
+            ) != FALSE
+            {
+                let position = mode.Anonymous1.Anonymous2.dmPosition;
+                display_rects.push(RECT {
+                    left: position.x,
+                    top: position.y,
+                    right: position.x.saturating_add(mode.dmPelsWidth as i32),
+                    bottom: position.y.saturating_add(mode.dmPelsHeight as i32),
+                });
+            }
+        }
+    }
+    display_rects
+        .into_iter()
+        .map(|display| Rect {
+            x: display.left,
+            y: display.top,
+            width: display.right.saturating_sub(display.left),
+            height: display.bottom.saturating_sub(display.top),
+        })
+        .collect()
 }
 
 impl WindowsEmulation {

--- a/input-emulation/src/wlroots.rs
+++ b/input-emulation/src/wlroots.rs
@@ -32,8 +32,8 @@ use wayland_client::{
 
 use input_event::{Event, KeyboardEvent, PointerEvent, scancode};
 
-use super::EmulationHandle;
 use super::error::WaylandBindError;
+use super::{EmulationHandle, WarpPosition};
 
 struct State {
     keymap: Option<(u32, OwnedFd, u32)>,
@@ -173,6 +173,41 @@ impl Emulation for WlrootsEmulation {
     }
     async fn terminate(&mut self) {
         /* nothing to do */
+    }
+
+    async fn warp_cursor(
+        &mut self,
+        handle: EmulationHandle,
+        pos: WarpPosition,
+        cross_axis: f32,
+    ) -> Result<(), EmulationError> {
+        if !cross_axis.is_finite() {
+            return Ok(());
+        }
+
+        const EXTENT: u32 = 1_000_000;
+        const EDGE_INSET: u32 = EXTENT / 200;
+        let cross_axis = (cross_axis.clamp(0.0, 1.0) * (EXTENT - 1) as f32).round() as u32;
+        let (x, y) = match pos {
+            WarpPosition::Left => (EDGE_INSET, cross_axis),
+            WarpPosition::Right => (EXTENT - EDGE_INSET, cross_axis),
+            WarpPosition::Top => (cross_axis, EDGE_INSET),
+            WarpPosition::Bottom => (cross_axis, EXTENT - EDGE_INSET),
+        };
+
+        if let Some(virtual_input) = self.state.input_for_client.get(&handle) {
+            let time = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u32;
+            virtual_input
+                .pointer
+                .motion_absolute(time, x, y, EXTENT, EXTENT);
+            virtual_input.pointer.frame();
+            self.queue.flush()?;
+        }
+
+        Ok(())
     }
 }
 

--- a/input-event/src/lib.rs
+++ b/input-event/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display};
 
 pub mod error;
 pub mod scancode;
+pub mod screen;
 
 #[cfg(all(unix, feature = "libei", not(target_os = "macos")))]
 mod libei;

--- a/input-event/src/screen.rs
+++ b/input-event/src/screen.rs
@@ -1,0 +1,1137 @@
+/// A display rectangle in compositor or desktop pixel coordinates.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl Rect {
+    fn contains_point(self, (x, y): (i32, i32)) -> bool {
+        x >= self.x
+            && x < self.x.saturating_add(self.width)
+            && y >= self.y
+            && y < self.y.saturating_add(self.height)
+    }
+    fn contains_cross_axis(self, edge: Edge, coordinate: i32) -> bool {
+        let (start, end) = self.cross_axis_range(edge);
+        coordinate >= start && coordinate < end
+    }
+
+    fn cross_axis_range(self, edge: Edge) -> (i32, i32) {
+        match edge {
+            Edge::Left | Edge::Right => (self.y, self.y.saturating_add(self.height)),
+            Edge::Top | Edge::Bottom => (self.x, self.x.saturating_add(self.width)),
+        }
+    }
+
+    fn edge_coordinate(self, edge: Edge) -> i32 {
+        match edge {
+            Edge::Left => self.x,
+            Edge::Right => self.x.saturating_add(self.width).saturating_sub(1),
+            Edge::Top => self.y,
+            Edge::Bottom => self.y.saturating_add(self.height).saturating_sub(1),
+        }
+    }
+
+    fn is_valid(self) -> bool {
+        self.width > 0 && self.height > 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CrossedEdge {
+    pub edge: Edge,
+    pub point: (i32, i32),
+}
+
+pub fn crossed_exposed_edge(
+    previous: (i32, i32),
+    current: (i32, i32),
+    rectangles: impl IntoIterator<Item = Rect>,
+) -> Option<CrossedEdge> {
+    let rectangles: Vec<_> = rectangles
+        .into_iter()
+        .filter(|rect| rect.is_valid())
+        .collect();
+    let source = rectangles
+        .iter()
+        .copied()
+        .find(|rect| rect.contains_point(previous))?;
+    [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom]
+        .into_iter()
+        .enumerate()
+        .filter_map(|(order, edge)| {
+            let (
+                edge_coordinate,
+                boundary_adjustment,
+                cross_start,
+                cross_end,
+                previous_axis,
+                previous_cross,
+                axis_delta,
+                cross_delta,
+            ) = match edge {
+                Edge::Left | Edge::Right => (
+                    source.edge_coordinate(edge),
+                    if matches!(edge, Edge::Left) { -1 } else { 1 },
+                    source.y,
+                    source.y + source.height - 1,
+                    previous.0,
+                    previous.1,
+                    i128::from(current.0) - i128::from(previous.0),
+                    i128::from(current.1) - i128::from(previous.1),
+                ),
+                Edge::Top | Edge::Bottom => (
+                    source.edge_coordinate(edge),
+                    if matches!(edge, Edge::Top) { -1 } else { 1 },
+                    source.x,
+                    source.x + source.width - 1,
+                    previous.1,
+                    previous.0,
+                    i128::from(current.1) - i128::from(previous.1),
+                    i128::from(current.0) - i128::from(previous.0),
+                ),
+            };
+            if axis_delta == 0 {
+                return None;
+            }
+            let mut t_num = i128::from(edge_coordinate) * 2 + i128::from(boundary_adjustment)
+                - i128::from(previous_axis) * 2;
+            let mut t_den = axis_delta * 2;
+            if t_den < 0 {
+                t_num = -t_num;
+                t_den = -t_den;
+            }
+            // `t_num == t_den` (t == 1) cannot occur for i32 pixel centers:
+            // physical boundaries are N ± 0.5, so t_num is always odd and
+            // t_den is always even. Keep `<=` so a sample that did land on
+            // the boundary would still count as a crossing.
+            if !(t_num > 0 && t_num <= t_den) {
+                return None;
+            }
+            let cross_num = i128::from(previous_cross) * t_den + t_num * cross_delta;
+            if 2 * cross_num < (i128::from(cross_start) * 2 - 1) * t_den
+                || 2 * cross_num > (i128::from(cross_end) * 2 + 1) * t_den
+            {
+                return None;
+            }
+            let rounded = round_ratio_away_from_zero(cross_num, t_den)?;
+            endpoint_owners(cross_num, t_den)
+                .unwrap_or([rounded, rounded])
+                .into_iter()
+                .map(|coordinate| coordinate.clamp(cross_start, cross_end))
+                .find(|&cross_coordinate| {
+                    let outside = match edge {
+                        Edge::Left => (edge_coordinate - 1, cross_coordinate),
+                        Edge::Right => (edge_coordinate + 1, cross_coordinate),
+                        Edge::Top => (cross_coordinate, edge_coordinate - 1),
+                        Edge::Bottom => (cross_coordinate, edge_coordinate + 1),
+                    };
+                    !rectangles.iter().any(|rect| rect.contains_point(outside))
+                })
+                .map(|cross_coordinate| {
+                    (
+                        t_num,
+                        t_den,
+                        order,
+                        CrossedEdge {
+                            edge,
+                            point: match edge {
+                                Edge::Left | Edge::Right => (edge_coordinate, cross_coordinate),
+                                Edge::Top | Edge::Bottom => (cross_coordinate, edge_coordinate),
+                            },
+                        },
+                    )
+                })
+        })
+        .min_by(|left, right| {
+            (left.0 * right.1)
+                .cmp(&(right.0 * left.1))
+                .then(left.2.cmp(&right.2))
+        })
+        .map(|(_, _, _, crossed)| crossed)
+}
+
+/// A physical desktop edge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Edge {
+    Left,
+    Right,
+    Top,
+    Bottom,
+}
+
+fn round_ratio_away_from_zero(numerator: i128, denominator: i128) -> Option<i32> {
+    if denominator <= 0 {
+        return None;
+    }
+    let floor = numerator.div_euclid(denominator);
+    let remainder = numerator.rem_euclid(denominator);
+    let rounded = match (remainder * 2).cmp(&denominator) {
+        std::cmp::Ordering::Less => floor,
+        std::cmp::Ordering::Greater => floor.checked_add(1)?,
+        std::cmp::Ordering::Equal if numerator < 0 => floor,
+        std::cmp::Ordering::Equal => floor.checked_add(1)?,
+    };
+    i32::try_from(rounded).ok()
+}
+
+fn endpoint_owners(cross_num: i128, cross_den: i128) -> Option<[i32; 2]> {
+    if cross_den <= 0 || (cross_num * 2) % cross_den != 0 {
+        return None;
+    }
+    let doubled_cross = cross_num * 2 / cross_den;
+    if doubled_cross % 2 == 0 {
+        return None;
+    }
+    let floor = i32::try_from(doubled_cross.div_euclid(2)).ok()?;
+    let ceiling = floor.checked_add(1)?;
+    Some(if doubled_cross > 0 {
+        [ceiling, floor]
+    } else {
+        [floor, ceiling]
+    })
+}
+
+/// A contiguous, usable portion of one desktop edge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EdgeSegment {
+    pub edge_coordinate: i32,
+    pub cross_start: i32,
+    pub cross_end: i32,
+}
+
+impl EdgeSegment {
+    fn len(self) -> u32 {
+        self.cross_end.saturating_sub(self.cross_start) as u32
+    }
+
+    fn contains(self, edge_coordinate: i32, cross_coordinate: i32) -> bool {
+        self.edge_coordinate == edge_coordinate
+            && cross_coordinate >= self.cross_start
+            && cross_coordinate < self.cross_end
+    }
+}
+
+/// The exposed outer edge of a non-rectangular desktop.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EdgeSegments(Vec<EdgeSegment>);
+
+impl EdgeSegments {
+    pub fn from_segments(segments: impl IntoIterator<Item = EdgeSegment>) -> Self {
+        let mut segments: Vec<_> = segments
+            .into_iter()
+            .filter(|segment| segment.cross_start < segment.cross_end)
+            .collect();
+        segments.sort_unstable_by_key(|segment| (segment.cross_start, segment.edge_coordinate));
+        Self(segments)
+    }
+
+    /// Finds only the physical portions that face outside the desktop. Gaps are
+    /// intentionally omitted from the normalized coordinate space.
+    pub fn from_rectangles(edge: Edge, rectangles: impl IntoIterator<Item = Rect>) -> Self {
+        let rectangles: Vec<_> = rectangles
+            .into_iter()
+            .filter(|rect| rect.is_valid())
+            .collect();
+        let mut boundaries: Vec<_> = rectangles
+            .iter()
+            .flat_map(|rect| {
+                let (start, end) = rect.cross_axis_range(edge);
+                [start, end]
+            })
+            .collect();
+        boundaries.sort_unstable();
+        boundaries.dedup();
+
+        let mut segments: Vec<EdgeSegment> = Vec::new();
+        for window in boundaries.windows(2) {
+            let (start, end) = (window[0], window[1]);
+            if start == end {
+                continue;
+            }
+            let exposed = rectangles
+                .iter()
+                .filter(|rect| rect.contains_cross_axis(edge, start))
+                .map(|rect| rect.edge_coordinate(edge))
+                .reduce(|current, candidate| match edge {
+                    Edge::Left | Edge::Top => current.min(candidate),
+                    Edge::Right | Edge::Bottom => current.max(candidate),
+                });
+            let Some(edge_coordinate) = exposed else {
+                continue;
+            };
+            if let Some(previous) = segments.last_mut() {
+                if previous.edge_coordinate == edge_coordinate && previous.cross_end == start {
+                    previous.cross_end = end;
+                    continue;
+                }
+            }
+            {
+                segments.push(EdgeSegment {
+                    edge_coordinate,
+                    cross_start: start,
+                    cross_end: end,
+                });
+            }
+        }
+        Self::from_segments(segments)
+    }
+
+    pub fn normalize(&self, edge_coordinate: i32, cross_coordinate: i32) -> Option<f32> {
+        let total = self.0.iter().map(|segment| segment.len()).sum::<u32>();
+        if total == 0 {
+            return None;
+        }
+        let mut offset = 0u32;
+        for segment in &self.0 {
+            if segment.contains(edge_coordinate, cross_coordinate) {
+                offset += (cross_coordinate - segment.cross_start) as u32;
+                return Some(if total == 1 {
+                    0.0
+                } else {
+                    offset as f32 / (total - 1) as f32
+                });
+            }
+            offset += segment.len();
+        }
+        None
+    }
+
+    pub fn denormalize(&self, normalized: f32) -> Option<(i32, i32)> {
+        if !normalized.is_finite() {
+            return None;
+        }
+        let total = self.0.iter().map(|segment| segment.len()).sum::<u32>();
+        if total == 0 {
+            return None;
+        }
+        let target = if total == 1 {
+            0
+        } else {
+            (normalized.clamp(0.0, 1.0) * (total - 1) as f32).round() as u32
+        };
+        let mut offset = 0u32;
+        for segment in &self.0 {
+            let end = offset + segment.len();
+            if target < end {
+                return Some((
+                    segment.edge_coordinate,
+                    segment.cross_start + (target - offset) as i32,
+                ));
+            }
+            offset = end;
+        }
+        None
+    }
+
+    pub fn segments(&self) -> impl Iterator<Item = EdgeSegment> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CrossedEdge, Edge, EdgeSegments, Rect, crossed_exposed_edge};
+    use std::collections::HashSet;
+
+    fn rect(x: i32, y: i32, width: i32, height: i32) -> Rect {
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn single_monitor_preserves_every_pixel() {
+        let segments = EdgeSegments::from_rectangles(Edge::Left, [rect(0, 0, 1920, 1080)]);
+        assert_eq!(segments.normalize(0, 0), Some(0.0));
+        assert_eq!(segments.normalize(0, 1079), Some(1.0));
+        assert_eq!(segments.denormalize(0.5), Some((0, 540)));
+    }
+
+    #[test]
+    fn stacked_monitors_share_one_continuous_edge() {
+        let segments = EdgeSegments::from_rectangles(
+            Edge::Left,
+            [rect(0, 0, 1920, 1080), rect(0, 1080, 1920, 1080)],
+        );
+        assert_eq!(segments.normalize(0, 1620), Some(1620.0 / 2159.0));
+        assert_eq!(segments.denormalize(1620.0 / 2159.0), Some((0, 1620)));
+    }
+
+    #[test]
+    fn side_by_side_monitors_keep_only_outer_edges() {
+        let segments = EdgeSegments::from_rectangles(
+            Edge::Left,
+            [rect(0, 0, 1920, 1080), rect(1920, 0, 1920, 1080)],
+        );
+        assert_eq!(segments.normalize(0, 540), Some(540.0 / 1079.0));
+        assert_eq!(segments.normalize(1920, 540), None);
+    }
+
+    #[test]
+    fn different_sizes_contribute_only_the_exposed_portions() {
+        let segments = EdgeSegments::from_rectangles(
+            Edge::Right,
+            [rect(0, 0, 1920, 1080), rect(1920, 0, 2560, 1440)],
+        );
+        assert_eq!(segments.normalize(4479, 1439), Some(1.0));
+    }
+
+    #[test]
+    fn gaps_are_compacted_out_of_the_edge_coordinate_space() {
+        let segments = EdgeSegments::from_rectangles(
+            Edge::Left,
+            [rect(0, 0, 1920, 100), rect(0, 200, 1920, 100)],
+        );
+        assert_eq!(segments.normalize(0, 99), Some(99.0 / 199.0));
+        assert_eq!(segments.denormalize(100.0 / 199.0), Some((0, 200)));
+    }
+
+    #[test]
+    fn stepped_edge_uses_each_outer_segment() {
+        let segments = EdgeSegments::from_rectangles(
+            Edge::Left,
+            [rect(100, 0, 1920, 100), rect(0, 100, 1920, 100)],
+        );
+        assert_eq!(segments.normalize(100, 50), Some(50.0 / 199.0));
+        assert_eq!(segments.normalize(0, 150), Some(150.0 / 199.0));
+    }
+
+    #[test]
+    fn normalization_and_denormalization_are_symmetric_for_every_pixel() {
+        let segments =
+            EdgeSegments::from_rectangles(Edge::Left, [rect(0, 0, 1920, 3), rect(0, 5, 1920, 2)]);
+        for coordinate in [0, 1, 2, 5, 6] {
+            let normalized = segments.normalize(0, coordinate).unwrap();
+            assert_eq!(segments.denormalize(normalized), Some((0, coordinate)));
+        }
+    }
+
+    #[test]
+    fn crossed_edge_uses_only_exposed_segments() {
+        let rectangles = [rect(0, 0, 100, 100), rect(100, 100, 100, 100)];
+        assert_eq!(
+            crossed_exposed_edge((99, 50), (100, 50), rectangles).map(|crossed| crossed.edge),
+            Some(Edge::Right)
+        );
+        let overlapping = [rect(0, 0, 100, 100), rect(100, 50, 100, 100)];
+        assert_eq!(crossed_exposed_edge((99, 75), (100, 75), overlapping), None);
+    }
+
+    #[test]
+    fn crossed_edge_rejects_internal_and_gap_transitions() {
+        let aligned = [rect(0, 0, 100, 100), rect(100, 0, 100, 100)];
+        assert_eq!(crossed_exposed_edge((99, 50), (100, 50), aligned), None);
+
+        let gap = [rect(0, 0, 100, 100), rect(200, 0, 100, 100)];
+        assert_eq!(
+            crossed_exposed_edge((99, 50), (100, 50), gap).map(|crossed| crossed.edge),
+            Some(Edge::Right)
+        );
+    }
+
+    #[test]
+    fn crossed_edge_uses_the_first_diagonal_intersection() {
+        let rectangles = [rect(0, 0, 100, 100)];
+        assert_eq!(
+            crossed_exposed_edge((50, 50), (150, -100), rectangles),
+            Some(CrossedEdge {
+                edge: Edge::Top,
+                point: (84, 0)
+            })
+        );
+        assert_eq!(
+            crossed_exposed_edge((50, 50), (150, -25), rectangles),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (99, 13)
+            })
+        );
+    }
+
+    #[test]
+    fn crossed_edge_resolves_every_exact_corner_deterministically() {
+        let rectangles = [rect(0, 0, 100, 100)];
+        for (previous, current) in [
+            ((99, 0), (100, -1)),
+            ((0, 0), (-1, -1)),
+            ((99, 99), (100, 100)),
+            ((0, 99), (-1, 100)),
+        ] {
+            let crossed = crossed_exposed_edge(previous, current, rectangles).unwrap();
+            assert!(crossed.point.0 >= 0 && crossed.point.0 < 100);
+            assert!(crossed.point.1 >= 0 && crossed.point.1 < 100);
+        }
+    }
+
+    #[test]
+    fn crossed_edge_chooses_an_exposed_endpoint_owner() {
+        let positive = [rect(0, 0, 3, 4), rect(3, 2, 2, 3)];
+        assert_eq!(
+            crossed_exposed_edge((0, 0), (5, 3), positive),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (2, 1),
+            })
+        );
+
+        let negative = [rect(0, -4, 3, 4), rect(3, -3, 2, 1)];
+        assert_eq!(
+            crossed_exposed_edge((0, -4), (5, -1), negative),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (2, -2),
+            })
+        );
+    }
+
+    #[test]
+    fn crossed_edge_handles_endpoint_after_inexact_division() {
+        let rectangles = [rect(0, 0, 8, 12), rect(8, 7, 1, 1)];
+
+        assert_eq!(
+            crossed_exposed_edge((0, 0), (11, 11), rectangles),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (7, 8),
+            })
+        );
+
+        let negative = [rect(0, -12, 8, 12), rect(8, -5, 1, 1)];
+        assert_eq!(
+            crossed_exposed_edge((0, -12), (11, -1), negative),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (7, -4),
+            })
+        );
+    }
+
+    #[test]
+    fn crossed_edge_handles_inexact_exact_corner() {
+        assert_eq!(
+            crossed_exposed_edge((0, 3), (25, -22), [rect(0, 0, 4, 4)]),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (3, 0),
+            })
+        );
+    }
+
+    type CornerCase = (Rect, (i32, i32), (i32, i32), CrossedEdge);
+
+    fn nontrivial_corner_cases() -> [CornerCase; 4] {
+        [
+            (
+                rect(0, 0, 1, 2),
+                (0, 1),
+                (7, -20),
+                CrossedEdge {
+                    edge: Edge::Right,
+                    point: (0, 0),
+                },
+            ),
+            (
+                rect(0, 0, 2, 2),
+                (1, 1),
+                (-10, -10),
+                CrossedEdge {
+                    edge: Edge::Left,
+                    point: (0, 0),
+                },
+            ),
+            (
+                rect(0, 0, 2, 2),
+                (0, 0),
+                (13, 13),
+                CrossedEdge {
+                    edge: Edge::Right,
+                    point: (1, 1),
+                },
+            ),
+            (
+                rect(0, 0, 2, 2),
+                (1, 0),
+                (-24, 25),
+                CrossedEdge {
+                    edge: Edge::Left,
+                    point: (0, 1),
+                },
+            ),
+        ]
+    }
+
+    #[test]
+    fn crossed_edge_handles_all_corners_with_nontrivial_divisions() {
+        for (display, previous, current, expected) in nontrivial_corner_cases() {
+            assert_eq!(
+                crossed_exposed_edge(previous, current, [display]),
+                Some(expected),
+                "display={display:?}, previous={previous:?}, current={current:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn crossed_edge_corner_crossings_are_translation_invariant() {
+        for offset in [(10_000, 10_000), (-10_000, -10_000), (30_000, -20_000)] {
+            for (display, previous, current, expected) in nontrivial_corner_cases() {
+                let translated = Rect {
+                    x: display.x + offset.0,
+                    y: display.y + offset.1,
+                    ..display
+                };
+                assert_eq!(
+                    crossed_exposed_edge(
+                        (previous.0 + offset.0, previous.1 + offset.1),
+                        (current.0 + offset.0, current.1 + offset.1),
+                        [translated],
+                    ),
+                    Some(CrossedEdge {
+                        edge: expected.edge,
+                        point: (expected.point.0 + offset.0, expected.point.1 + offset.1),
+                    }),
+                    "offset={offset:?}, display={display:?}, previous={previous:?}, current={current:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn crossed_edge_handles_very_shallow_and_steep_diagonals() {
+        let display = rect(0, 0, 10, 10);
+        assert_eq!(
+            crossed_exposed_edge((5, 5), (1_005, 6), [display]),
+            Some(CrossedEdge {
+                edge: Edge::Right,
+                point: (9, 5),
+            })
+        );
+        assert_eq!(
+            crossed_exposed_edge((5, 5), (6, 1_005), [display]),
+            Some(CrossedEdge {
+                edge: Edge::Bottom,
+                point: (5, 9),
+            })
+        );
+    }
+
+    #[test]
+    fn crossed_edge_handles_exact_endpoints_for_positive_and_negative_coordinates() {
+        for denominator in [7, 11, 13, 25] {
+            assert_eq!(
+                crossed_exposed_edge(
+                    (0, 0),
+                    (denominator, denominator),
+                    [rect(0, 0, 1, 2), rect(1, 1, 1, 1)],
+                ),
+                Some(CrossedEdge {
+                    edge: Edge::Right,
+                    point: (0, 0),
+                }),
+                "positive denominator={denominator}"
+            );
+            assert_eq!(
+                crossed_exposed_edge(
+                    (0, -2),
+                    (denominator, denominator - 2),
+                    [rect(0, -2, 1, 2), rect(1, -2, 1, 1)],
+                ),
+                Some(CrossedEdge {
+                    edge: Edge::Right,
+                    point: (0, -1),
+                }),
+                "negative denominator={denominator}"
+            );
+        }
+    }
+
+    #[test]
+    fn crossed_edge_endpoint_ownership_is_translation_invariant() {
+        let rectangles = [rect(0, 0, 8, 12), rect(8, 7, 1, 1)];
+        for offset in [(10_000, 10_000), (-10_000, -10_000), (30_000, -20_000)] {
+            let translated = rectangles.map(|display| Rect {
+                x: display.x + offset.0,
+                y: display.y + offset.1,
+                ..display
+            });
+            assert_eq!(
+                crossed_exposed_edge(
+                    (offset.0, offset.1),
+                    (offset.0 + 11, offset.1 + 11),
+                    translated
+                ),
+                Some(CrossedEdge {
+                    edge: Edge::Right,
+                    point: (offset.0 + 7, offset.1 + 8),
+                }),
+                "offset={offset:?}"
+            );
+        }
+    }
+
+    fn contains(rect: Rect, point: (i32, i32)) -> bool {
+        point.0 >= rect.x
+            && point.0 < rect.x + rect.width
+            && point.1 >= rect.y
+            && point.1 < rect.y + rect.height
+    }
+
+    #[derive(Clone, Copy)]
+    struct ReferenceEdgeSegment {
+        edge: Edge,
+        pixel: (i32, i32),
+    }
+
+    fn occupied_pixels(rectangles: &[Rect]) -> HashSet<(i32, i32)> {
+        rectangles
+            .iter()
+            .flat_map(|rect| {
+                (rect.x..rect.x + rect.width)
+                    .flat_map(move |x| (rect.y..rect.y + rect.height).map(move |y| (x, y)))
+            })
+            .collect()
+    }
+
+    fn reference_segments(
+        source: Rect,
+        occupied: &HashSet<(i32, i32)>,
+    ) -> Vec<ReferenceEdgeSegment> {
+        let mut segments = Vec::new();
+        for x in source.x..source.x + source.width {
+            for y in source.y..source.y + source.height {
+                for (edge, neighbor) in [
+                    (Edge::Left, (x - 1, y)),
+                    (Edge::Right, (x + 1, y)),
+                    (Edge::Top, (x, y - 1)),
+                    (Edge::Bottom, (x, y + 1)),
+                ] {
+                    if !occupied.contains(&neighbor) {
+                        segments.push(ReferenceEdgeSegment {
+                            edge,
+                            pixel: (x, y),
+                        });
+                    }
+                }
+            }
+        }
+        segments
+    }
+
+    fn reference_crossed_edge(
+        previous: (i32, i32),
+        current: (i32, i32),
+        rectangles: &[Rect],
+    ) -> Option<CrossedEdge> {
+        let source = rectangles
+            .iter()
+            .copied()
+            .find(|rect| contains(*rect, previous))?;
+        let occupied = occupied_pixels(rectangles);
+        reference_segments(source, &occupied)
+            .into_iter()
+            .filter_map(|segment| {
+                let (
+                    boundary2,
+                    previous_axis,
+                    previous_cross,
+                    axis_delta,
+                    cross_delta,
+                    low2,
+                    high2,
+                    pixel_cross,
+                ) = match segment.edge {
+                    Edge::Left => (
+                        i128::from(segment.pixel.0) * 2 - 1,
+                        previous.0,
+                        previous.1,
+                        i128::from(current.0) - i128::from(previous.0),
+                        i128::from(current.1) - i128::from(previous.1),
+                        i128::from(segment.pixel.1) * 2 - 1,
+                        i128::from(segment.pixel.1) * 2 + 1,
+                        segment.pixel.1,
+                    ),
+                    Edge::Right => (
+                        i128::from(segment.pixel.0) * 2 + 1,
+                        previous.0,
+                        previous.1,
+                        i128::from(current.0) - i128::from(previous.0),
+                        i128::from(current.1) - i128::from(previous.1),
+                        i128::from(segment.pixel.1) * 2 - 1,
+                        i128::from(segment.pixel.1) * 2 + 1,
+                        segment.pixel.1,
+                    ),
+                    Edge::Top => (
+                        i128::from(segment.pixel.1) * 2 - 1,
+                        previous.1,
+                        previous.0,
+                        i128::from(current.1) - i128::from(previous.1),
+                        i128::from(current.0) - i128::from(previous.0),
+                        i128::from(segment.pixel.0) * 2 - 1,
+                        i128::from(segment.pixel.0) * 2 + 1,
+                        segment.pixel.0,
+                    ),
+                    Edge::Bottom => (
+                        i128::from(segment.pixel.1) * 2 + 1,
+                        previous.1,
+                        previous.0,
+                        i128::from(current.1) - i128::from(previous.1),
+                        i128::from(current.0) - i128::from(previous.0),
+                        i128::from(segment.pixel.0) * 2 - 1,
+                        i128::from(segment.pixel.0) * 2 + 1,
+                        segment.pixel.0,
+                    ),
+                };
+                if axis_delta == 0 {
+                    return None;
+                }
+                let mut t_num = boundary2 - i128::from(previous_axis) * 2;
+                let mut t_den = axis_delta * 2;
+                if t_den < 0 {
+                    t_num = -t_num;
+                    t_den = -t_den;
+                }
+                if !(t_num > 0 && t_num <= t_den) {
+                    return None;
+                }
+                let cross_num = i128::from(previous_cross) * t_den + t_num * cross_delta;
+                if 2 * cross_num < low2 * t_den || 2 * cross_num > high2 * t_den {
+                    return None;
+                }
+                let order = match segment.edge {
+                    Edge::Left => 0,
+                    Edge::Right => 1,
+                    Edge::Top => 2,
+                    Edge::Bottom => 3,
+                };
+                let owner_rank = usize::from(
+                    pixel_cross != reference_round_ratio_away_from_zero(cross_num, t_den)?,
+                );
+                Some((
+                    t_num,
+                    t_den,
+                    order,
+                    owner_rank,
+                    CrossedEdge {
+                        edge: segment.edge,
+                        point: segment.pixel,
+                    },
+                ))
+            })
+            .min_by(|left, right| {
+                (left.0 * right.1)
+                    .cmp(&(right.0 * left.1))
+                    .then(left.2.cmp(&right.2))
+                    .then(left.3.cmp(&right.3))
+            })
+            .map(|(_, _, _, _, crossed)| crossed)
+    }
+
+    fn reference_round_ratio_away_from_zero(numerator: i128, denominator: i128) -> Option<i32> {
+        if denominator <= 0 {
+            return None;
+        }
+        let floor = numerator.div_euclid(denominator);
+        let remainder = numerator.rem_euclid(denominator);
+        let rounded = match (remainder * 2).cmp(&denominator) {
+            std::cmp::Ordering::Less => floor,
+            std::cmp::Ordering::Greater => floor.checked_add(1)?,
+            std::cmp::Ordering::Equal if numerator < 0 => floor,
+            std::cmp::Ordering::Equal => floor.checked_add(1)?,
+        };
+        i32::try_from(rounded).ok()
+    }
+
+    fn verification_layouts() -> Vec<Vec<Rect>> {
+        vec![
+            vec![rect(0, 0, 1, 1)],
+            vec![rect(-2, -1, 3, 4)],
+            vec![rect(0, 0, 3, 3), rect(3, 0, 2, 4)],
+            vec![rect(0, 0, 3, 3), rect(0, 3, 4, 2)],
+            vec![rect(0, 0, 3, 4), rect(3, 2, 2, 3)],
+            vec![rect(0, 0, 3, 3), rect(5, 0, 2, 2)],
+            vec![rect(-2, -2, 4, 2), rect(2, 0, 3, 4)],
+            vec![rect(0, 0, 3, 3), rect(3, 3, 2, 2)],
+            vec![rect(0, 0, 4, 4), rect(2, 1, 3, 2)],
+            vec![rect(0, 0, 2, 3), rect(2, 0, 2, 3), rect(4, 0, 2, 3)],
+            vec![rect(0, 0, 3, 2), rect(0, 2, 3, 2), rect(0, 4, 3, 2)],
+            vec![rect(0, 0, 2, 2), rect(2, 1, 2, 2), rect(4, 2, 2, 2)],
+            vec![rect(0, 1, 2, 2), rect(2, 0, 2, 4), rect(4, 1, 2, 2)],
+            vec![rect(-3, 0, 2, 2), rect(-1, 0, 3, 3), rect(2, 1, 2, 2)],
+        ]
+    }
+
+    fn generated_two_monitor_layouts() -> Vec<Vec<Rect>> {
+        const OFFSETS: [i32; 4] = [-2, 0, 2, 4];
+
+        let mut layouts = Vec::new();
+        for primary_width in 1..=3 {
+            for primary_height in 1..=3 {
+                let primary = rect(0, 0, primary_width, primary_height);
+                for secondary_width in 1..=3 {
+                    for secondary_height in 1..=3 {
+                        for offset_x in OFFSETS {
+                            for offset_y in OFFSETS {
+                                layouts.push(vec![
+                                    primary,
+                                    rect(offset_x, offset_y, secondary_width, secondary_height),
+                                ]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        layouts
+    }
+
+    fn desktop_bounds(rectangles: &[Rect], padding: i32) -> (i32, i32, i32, i32) {
+        (
+            rectangles.iter().map(|rect| rect.x).min().unwrap() - padding,
+            rectangles
+                .iter()
+                .map(|rect| rect.x + rect.width)
+                .max()
+                .unwrap()
+                + padding,
+            rectangles.iter().map(|rect| rect.y).min().unwrap() - padding,
+            rectangles
+                .iter()
+                .map(|rect| rect.y + rect.height)
+                .max()
+                .unwrap()
+                + padding,
+        )
+    }
+
+    #[test]
+    fn crossing_matches_the_cell_oracle_for_small_layouts() {
+        let layouts = verification_layouts();
+        for rectangles in &layouts {
+            let min_x = rectangles.iter().map(|rect| rect.x).min().unwrap() - 3;
+            let max_x = rectangles
+                .iter()
+                .map(|rect| rect.x + rect.width)
+                .max()
+                .unwrap()
+                + 3;
+            let min_y = rectangles.iter().map(|rect| rect.y).min().unwrap() - 3;
+            let max_y = rectangles
+                .iter()
+                .map(|rect| rect.y + rect.height)
+                .max()
+                .unwrap()
+                + 3;
+            for previous in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                if !rectangles.iter().any(|rect| contains(*rect, previous)) {
+                    continue;
+                }
+                for current in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                    let production = crossed_exposed_edge(previous, current, rectangles.clone());
+                    let oracle = reference_crossed_edge(previous, current, rectangles);
+                    assert_eq!(
+                        production, oracle,
+                        "rectangles={rectangles:?}, previous={previous:?}, current={current:?}, production={production:?}, oracle={oracle:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn generated_crossings_match_the_cell_oracle() {
+        let layouts = generated_two_monitor_layouts();
+        for rectangles in &layouts {
+            let (min_x, max_x, min_y, max_y) = desktop_bounds(rectangles, 1);
+            for previous in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                if !rectangles.iter().any(|rect| contains(*rect, previous)) {
+                    continue;
+                }
+                for current in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                    let production = crossed_exposed_edge(previous, current, rectangles.clone());
+                    let oracle = reference_crossed_edge(previous, current, rectangles);
+                    assert_eq!(
+                        production, oracle,
+                        "rectangles={rectangles:?}, previous={previous:?}, current={current:?}, production={production:?}, oracle={oracle:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn normalization_round_trips_every_exposed_pixel_and_ignores_rectangle_order() {
+        for rectangles in verification_layouts() {
+            let mut reversed = rectangles.clone();
+            reversed.reverse();
+            for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+                let segments = EdgeSegments::from_rectangles(edge, rectangles.clone());
+                let reversed_segments = EdgeSegments::from_rectangles(edge, reversed.clone());
+                assert_eq!(
+                    segments, reversed_segments,
+                    "rectangles={rectangles:?}, edge={edge:?}"
+                );
+                let pixels = segments
+                    .segments()
+                    .flat_map(|segment| {
+                        (segment.cross_start..segment.cross_end)
+                            .map(move |cross| (segment.edge_coordinate, cross))
+                    })
+                    .collect::<Vec<_>>();
+                for (index, pixel) in pixels.iter().copied().enumerate() {
+                    let normalized = segments.normalize(pixel.0, pixel.1).unwrap();
+                    assert!((0.0..=1.0).contains(&normalized));
+                    assert_eq!(segments.denormalize(normalized), Some(pixel));
+                    if pixels.len() > 1 && index == 0 {
+                        assert_eq!(normalized, 0.0);
+                    }
+                    if pixels.len() > 1 && index + 1 == pixels.len() {
+                        assert_eq!(normalized, 1.0);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn edge_segments_match_the_outer_pixels_of_the_grid() {
+        for rectangles in verification_layouts()
+            .into_iter()
+            .chain(generated_two_monitor_layouts())
+        {
+            let occupied = occupied_pixels(&rectangles);
+            for edge in [Edge::Left, Edge::Right, Edge::Top, Edge::Bottom] {
+                let mut expected = Vec::new();
+                let cross_values = match edge {
+                    Edge::Left | Edge::Right => {
+                        occupied.iter().map(|(_, y)| *y).collect::<HashSet<_>>()
+                    }
+                    Edge::Top | Edge::Bottom => {
+                        occupied.iter().map(|(x, _)| *x).collect::<HashSet<_>>()
+                    }
+                };
+                for cross in cross_values {
+                    let edge_coordinate = match edge {
+                        Edge::Left => occupied
+                            .iter()
+                            .filter(|(_, y)| *y == cross)
+                            .map(|(x, _)| *x)
+                            .min(),
+                        Edge::Right => occupied
+                            .iter()
+                            .filter(|(_, y)| *y == cross)
+                            .map(|(x, _)| *x)
+                            .max(),
+                        Edge::Top => occupied
+                            .iter()
+                            .filter(|(x, _)| *x == cross)
+                            .map(|(_, y)| *y)
+                            .min(),
+                        Edge::Bottom => occupied
+                            .iter()
+                            .filter(|(x, _)| *x == cross)
+                            .map(|(_, y)| *y)
+                            .max(),
+                    }
+                    .unwrap();
+                    expected.push((edge_coordinate, cross));
+                }
+                expected.sort_unstable_by_key(|(_, cross)| *cross);
+                let actual = EdgeSegments::from_rectangles(edge, rectangles.clone())
+                    .segments()
+                    .flat_map(|segment| {
+                        (segment.cross_start..segment.cross_end)
+                            .map(move |cross| (segment.edge_coordinate, cross))
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(actual, expected, "rectangles={rectangles:?}, edge={edge:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn crossing_is_invariant_under_rectangle_permutations_when_source_is_unique() {
+        for rectangles in verification_layouts()
+            .into_iter()
+            .filter(|layout| layout.len() >= 2)
+        {
+            let mut orders = vec![rectangles.clone()];
+            let mut reversed = rectangles.clone();
+            reversed.reverse();
+            orders.push(reversed);
+            if rectangles.len() == 3 {
+                for order in [[0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]] {
+                    orders.push(order.into_iter().map(|index| rectangles[index]).collect());
+                }
+            }
+            let min_x = rectangles.iter().map(|rect| rect.x).min().unwrap() - 1;
+            let max_x = rectangles
+                .iter()
+                .map(|rect| rect.x + rect.width)
+                .max()
+                .unwrap()
+                + 1;
+            let min_y = rectangles.iter().map(|rect| rect.y).min().unwrap() - 1;
+            let max_y = rectangles
+                .iter()
+                .map(|rect| rect.y + rect.height)
+                .max()
+                .unwrap()
+                + 1;
+            for previous in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                if rectangles
+                    .iter()
+                    .filter(|rect| contains(**rect, previous))
+                    .count()
+                    != 1
+                {
+                    continue;
+                }
+                for current in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                    let expected = crossed_exposed_edge(previous, current, rectangles.clone());
+                    for order in &orders {
+                        assert_eq!(
+                            crossed_exposed_edge(previous, current, order.clone()),
+                            expected,
+                            "rectangles={rectangles:?}, previous={previous:?}, current={current:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn generated_crossings_are_invariant_under_rectangle_order_when_source_is_unique() {
+        let layouts = generated_two_monitor_layouts();
+        for rectangles in &layouts {
+            let mut reversed = rectangles.clone();
+            reversed.reverse();
+            let (min_x, max_x, min_y, max_y) = desktop_bounds(rectangles, 1);
+            for previous in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                if rectangles
+                    .iter()
+                    .filter(|rect| contains(**rect, previous))
+                    .count()
+                    != 1
+                {
+                    continue;
+                }
+                for current in (min_x..max_x).flat_map(|x| (min_y..max_y).map(move |y| (x, y))) {
+                    let expected = crossed_exposed_edge(previous, current, rectangles.clone());
+                    assert_eq!(
+                        crossed_exposed_edge(previous, current, reversed.clone()),
+                        expected,
+                        "rectangles={rectangles:?}, previous={previous:?}, current={current:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/lan-mouse-ipc/src/lib.rs
+++ b/lan-mouse-ipc/src/lib.rs
@@ -182,6 +182,7 @@ pub struct ClientState {
     /// that predates the Hello event. The frontend uses this to
     /// soft-warn on version mismatch.
     pub peer_commit: Option<[u8; 8]>,
+    pub peer_supports_enter_with_position: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lan-mouse-proto/src/lib.rs
+++ b/lan-mouse-proto/src/lib.rs
@@ -21,6 +21,8 @@ pub enum ProtocolError {
     /// position type does not exist
     #[error("invalid event id: `{0}`")]
     InvalidPosition(#[from] TryFromPrimitiveError<Position>),
+    #[error("invalid cross-axis presence: `{0}`")]
+    InvalidCrossAxisPresence(u8),
 }
 
 /// Position of a client
@@ -71,7 +73,21 @@ pub enum ProtoEvent {
     /// `shadow_rs`'s `SHORT_COMMIT`. Old peers that don't
     /// recognize the event type silently skip it per the
     /// forward-compat handling in the receive loop.
-    Hello { commit: [u8; 8] },
+    Hello {
+        commit: [u8; 8],
+    },
+    Capabilities {
+        enter_with_position: bool,
+    },
+    /// Atomically enter a peer and place the cursor on its corresponding
+    /// physical edge. `serial` makes retries idempotent and rejects stale
+    /// transitions.
+    EnterWithPosition {
+        pos: Position,
+        cross_axis: Option<f32>,
+        epoch: u64,
+        serial: u32,
+    },
 }
 
 impl Display for ProtoEvent {
@@ -93,6 +109,22 @@ impl Display for ProtoEvent {
                 let s = std::str::from_utf8(commit).unwrap_or("????????");
                 write!(f, "Hello({s})")
             }
+            ProtoEvent::Capabilities {
+                enter_with_position,
+            } => {
+                write!(f, "Capabilities({enter_with_position})")
+            }
+            ProtoEvent::EnterWithPosition {
+                pos,
+                cross_axis,
+                epoch,
+                serial,
+            } => {
+                write!(
+                    f,
+                    "EnterWithPosition({pos}, {cross_axis:?}, {epoch}, {serial})"
+                )
+            }
         }
     }
 }
@@ -112,6 +144,8 @@ pub enum EventType {
     Leave,
     Ack,
     Hello,
+    Capabilities,
+    EnterWithPosition,
 }
 
 impl ProtoEvent {
@@ -135,6 +169,8 @@ impl ProtoEvent {
             ProtoEvent::Leave(_) => EventType::Leave,
             ProtoEvent::Ack(_) => EventType::Ack,
             ProtoEvent::Hello { .. } => EventType::Hello,
+            ProtoEvent::Capabilities { .. } => EventType::Capabilities,
+            ProtoEvent::EnterWithPosition { .. } => EventType::EnterWithPosition,
         }
     }
 }
@@ -196,6 +232,19 @@ impl TryFrom<[u8; MAX_EVENT_SIZE]> for ProtoEvent {
                 }
                 Ok(Self::Hello { commit })
             }
+            EventType::Capabilities => Ok(Self::Capabilities {
+                enter_with_position: decode_u8(&mut buf)? != 0,
+            }),
+            EventType::EnterWithPosition => Ok(Self::EnterWithPosition {
+                pos: decode_u8(&mut buf)?.try_into()?,
+                cross_axis: match decode_u8(&mut buf)? {
+                    0 => None,
+                    1 => Some(decode_f32(&mut buf)?),
+                    present => return Err(ProtocolError::InvalidCrossAxisPresence(present)),
+                },
+                epoch: decode_u64(&mut buf)?,
+                serial: decode_u32(&mut buf)?,
+            }),
         }
     }
 }
@@ -265,6 +314,23 @@ impl From<ProtoEvent> for ([u8; MAX_EVENT_SIZE], usize) {
                         encode_u8(buf, len, *b);
                     }
                 }
+                ProtoEvent::Capabilities {
+                    enter_with_position,
+                } => encode_u8(buf, len, enter_with_position as u8),
+                ProtoEvent::EnterWithPosition {
+                    pos,
+                    cross_axis,
+                    epoch,
+                    serial,
+                } => {
+                    encode_u8(buf, len, pos as u8);
+                    encode_u8(buf, len, cross_axis.is_some() as u8);
+                    if let Some(cross_axis) = cross_axis {
+                        encode_f32(buf, len, cross_axis);
+                    }
+                    encode_u64(buf, len, epoch);
+                    encode_u32(buf, len, serial);
+                }
             }
         }
         (buf, len)
@@ -285,7 +351,9 @@ macro_rules! decode_impl {
 
 decode_impl!(u8);
 decode_impl!(u32);
+decode_impl!(u64);
 decode_impl!(i32);
+decode_impl!(f32);
 decode_impl!(f64);
 
 macro_rules! encode_impl {
@@ -305,5 +373,78 @@ macro_rules! encode_impl {
 
 encode_impl!(u8);
 encode_impl!(u32);
+encode_impl!(u64);
 encode_impl!(i32);
+encode_impl!(f32);
 encode_impl!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::{Position, ProtoEvent};
+
+    #[test]
+    fn enter_with_position_round_trips_the_transition() {
+        // Given: a transition near the bottom of the source edge.
+        let event = ProtoEvent::EnterWithPosition {
+            pos: Position::Left,
+            cross_axis: Some(0.73),
+            epoch: 17,
+            serial: 42,
+        };
+
+        // When: the event crosses the protocol serialization boundary.
+        let (encoded, _) = event.into();
+        let decoded = ProtoEvent::try_from(encoded).expect("valid enter-with-position event");
+
+        // Then: the receiving peer sees the same edge and proportion.
+        match decoded {
+            ProtoEvent::EnterWithPosition {
+                pos,
+                cross_axis,
+                epoch,
+                serial,
+            } => {
+                assert!(matches!(pos, Position::Left));
+                assert_eq!(cross_axis, Some(0.73));
+                assert_eq!(epoch, 17);
+                assert_eq!(serial, 42);
+            }
+            _ => panic!("decoded the wrong event type"),
+        }
+    }
+
+    #[test]
+    fn enter_with_position_round_trips_without_a_cross_axis() {
+        let event = ProtoEvent::EnterWithPosition {
+            pos: Position::Right,
+            cross_axis: None,
+            epoch: 17,
+            serial: 43,
+        };
+
+        let (encoded, _) = event.into();
+        let decoded = ProtoEvent::try_from(encoded).expect("valid enter-with-position event");
+
+        match decoded {
+            ProtoEvent::EnterWithPosition { cross_axis, .. } => assert_eq!(cross_axis, None),
+            _ => panic!("decoded the wrong event type"),
+        }
+    }
+
+    #[test]
+    fn capabilities_round_trip_without_changing_hello() {
+        let event = ProtoEvent::Capabilities {
+            enter_with_position: true,
+        };
+
+        let (encoded, _) = event.into();
+        let decoded = ProtoEvent::try_from(encoded).expect("valid capabilities event");
+
+        match decoded {
+            ProtoEvent::Capabilities {
+                enter_with_position,
+            } => assert!(enter_with_position),
+            _ => panic!("decoded the wrong event type"),
+        }
+    }
+}

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::{Cell, RefCell},
     rc::Rc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use futures::StreamExt;
@@ -82,6 +82,8 @@ impl Capture {
             request_rx,
             release_bind: Rc::new(RefCell::new(release_bind)),
             state: Default::default(),
+            transition_epoch: transition_epoch(),
+            next_transition_serial: 1,
         };
         let task = spawn_local(capture_task.run());
         Self {
@@ -166,6 +168,8 @@ struct CaptureTask {
     release_bind: Rc<RefCell<Vec<scancode::Linux>>>,
     request_rx: Receiver<CaptureRequest>,
     state: State,
+    transition_epoch: u64,
+    next_transition_serial: u32,
 }
 
 impl CaptureTask {
@@ -281,7 +285,7 @@ impl CaptureTask {
 
                     match event {
                         // connection acknowlegded => set state to Sending
-                        ProtoEvent::Ack(_) => {
+                        ProtoEvent::Ack(serial) if self.state.acknowledges(serial) => {
                             log::info!("client {handle} acknowledged the connection!");
                             self.state = State::Sending;
                         }
@@ -327,7 +331,7 @@ impl CaptureTask {
             return self.release_capture(capture).await;
         }
 
-        if event == CaptureEvent::Begin {
+        if matches!(event, CaptureEvent::Begin { .. }) {
             self.event_tx
                 .send(ICaptureEvent::CaptureBegin(handle))
                 .expect("channel closed");
@@ -346,8 +350,7 @@ impl CaptureTask {
         }
 
         // activated a new client
-        if event == CaptureEvent::Begin && Some(handle) != self.active_client {
-            self.state = State::WaitingForAck;
+        if matches!(event, CaptureEvent::Begin { .. }) && Some(handle) != self.active_client {
             self.active_client.replace(handle);
             self.event_tx
                 .send(ICaptureEvent::ClientEntered(handle))
@@ -357,10 +360,28 @@ impl CaptureTask {
         let opposite_pos = to_proto_pos(self.get_pos(handle).opposite());
 
         let event = match event {
-            CaptureEvent::Begin => ProtoEvent::Enter(opposite_pos),
+            CaptureEvent::Begin { cross_axis } => {
+                let serial = self.next_transition_serial;
+                self.next_transition_serial = self.next_transition_serial.wrapping_add(1).max(1);
+                let event = if self.conn.supports_enter_with_position(handle) {
+                    ProtoEvent::EnterWithPosition {
+                        pos: opposite_pos,
+                        cross_axis,
+                        epoch: self.transition_epoch,
+                        serial,
+                    }
+                } else {
+                    ProtoEvent::Enter(opposite_pos)
+                };
+                let serial = matches!(event, ProtoEvent::EnterWithPosition { .. })
+                    .then_some(serial)
+                    .unwrap_or(0);
+                self.state = State::WaitingForAck { serial, event };
+                event
+            }
             CaptureEvent::Input(e) => match self.state {
                 // connection not acknowledged, repeat `Enter` event
-                State::WaitingForAck => ProtoEvent::Enter(opposite_pos),
+                State::WaitingForAck { event, .. } => event,
                 State::Sending => ProtoEvent::Input(e),
             },
         };
@@ -424,11 +445,25 @@ thread_local! {
     static PREV_LOG: Cell<Option<Instant>> = const { Cell::new(None) };
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 enum State {
-    #[default]
-    WaitingForAck,
+    WaitingForAck { serial: u32, event: ProtoEvent },
     Sending,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::WaitingForAck {
+            serial: 0,
+            event: ProtoEvent::Enter(lan_mouse_proto::Position::Left),
+        }
+    }
+}
+
+impl State {
+    fn acknowledges(self, serial: u32) -> bool {
+        matches!(self, Self::WaitingForAck { serial: expected, .. } if serial == expected)
+    }
 }
 
 fn to_capture_pos(pos: lan_mouse_ipc::Position) -> input_capture::Position {
@@ -438,6 +473,13 @@ fn to_capture_pos(pos: lan_mouse_ipc::Position) -> input_capture::Position {
         lan_mouse_ipc::Position::Top => input_capture::Position::Top,
         lan_mouse_ipc::Position::Bottom => input_capture::Position::Bottom,
     }
+}
+
+fn transition_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
 }
 
 fn to_proto_pos(pos: input_capture::Position) -> lan_mouse_proto::Position {
@@ -467,5 +509,27 @@ impl<T> Drop for DropGuard<T> {
         self.tx
             .send(self.on_drop.take().expect("item"))
             .expect("channel closed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::State;
+    use lan_mouse_proto::{Position, ProtoEvent};
+
+    #[test]
+    fn waiting_for_ack_only_accepts_the_pending_transition() {
+        let state = State::WaitingForAck {
+            serial: 9,
+            event: ProtoEvent::EnterWithPosition {
+                pos: Position::Left,
+                cross_axis: Some(0.5),
+                epoch: 1,
+                serial: 9,
+            },
+        };
+
+        assert!(state.acknowledges(9));
+        assert!(!state.acknowledges(8));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -288,6 +288,23 @@ impl ClientManager {
         }
     }
 
+    pub(crate) fn set_peer_protocol_capabilities(
+        &self,
+        handle: ClientHandle,
+        enter_with_position: bool,
+    ) {
+        if let Some((_, state)) = self.clients.borrow_mut().get_mut(handle as usize) {
+            state.peer_supports_enter_with_position = enter_with_position;
+        }
+    }
+
+    pub(crate) fn supports_enter_with_position(&self, handle: ClientHandle) -> bool {
+        self.clients
+            .borrow()
+            .get(handle as usize)
+            .is_some_and(|(_, state)| state.peer_supports_enter_with_position)
+    }
+
     pub(crate) fn active_addr(&self, handle: ClientHandle) -> Option<SocketAddr> {
         self.clients
             .borrow()
@@ -315,5 +332,22 @@ impl ClientManager {
             .borrow()
             .get(handle as usize)
             .map(|(_, s)| s.ips.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientManager;
+
+    #[test]
+    fn reconnect_requires_a_new_capability_advertisement() {
+        let clients = ClientManager::default();
+        let handle = clients.add_client();
+
+        clients.set_peer_protocol_capabilities(handle, true);
+        assert!(clients.supports_enter_with_position(handle));
+
+        clients.set_peer_protocol_capabilities(handle, false);
+        assert!(!clients.supports_enter_with_position(handle));
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -120,6 +120,10 @@ impl LanMouseConnection {
         self.recv_rx.recv().await.expect("channel closed")
     }
 
+    pub(crate) fn supports_enter_with_position(&self, handle: ClientHandle) -> bool {
+        self.client_manager.supports_enter_with_position(handle)
+    }
+
     pub(crate) async fn send(
         &self,
         event: ProtoEvent,
@@ -177,6 +181,7 @@ async fn connect_to_handle(
     ping_response: Rc<RefCell<HashSet<SocketAddr>>>,
 ) -> Result<(), LanMouseConnectionError> {
     log::info!("client {handle} connecting ...");
+    client_manager.set_peer_protocol_capabilities(handle, false);
     // sending did not work, figure out active conn.
     if let Some(addrs) = client_manager.get_ips(handle) {
         let port = client_manager.get_port(handle).unwrap_or(DEFAULT_PORT);
@@ -210,9 +215,22 @@ async fn connect_to_handle(
         if let Err(e) = conn.send(&buf[..len]).await {
             log::debug!("hello send to {addr} failed: {e}");
         }
+        let (buf, len) = ProtoEvent::Capabilities {
+            enter_with_position: true,
+        }
+        .into();
+        if let Err(e) = conn.send(&buf[..len]).await {
+            log::debug!("capabilities send to {addr} failed: {e}");
+        }
 
         // poll connection for active
-        spawn_local(ping_pong(addr, conn.clone(), ping_response.clone()));
+        spawn_local(ping_pong(
+            addr,
+            conn.clone(),
+            ping_response.clone(),
+            client_manager.clone(),
+            handle,
+        ));
 
         // receiver
         spawn_local(receive_loop(
@@ -234,8 +252,21 @@ async fn ping_pong(
     addr: SocketAddr,
     conn: Arc<dyn Conn + Send + Sync>,
     ping_response: Rc<RefCell<HashSet<SocketAddr>>>,
+    client_manager: ClientManager,
+    handle: ClientHandle,
 ) {
     loop {
+        if !client_manager.supports_enter_with_position(handle) {
+            let (buf, len) = ProtoEvent::Capabilities {
+                enter_with_position: true,
+            }
+            .into();
+            if let Err(e) = conn.send(&buf[..len]).await {
+                log::warn!("{addr}: capability send error `{e}`, closing connection");
+                let _ = conn.close().await;
+                return;
+            }
+        }
         let (buf, len) = ProtoEvent::Ping.into();
 
         // send 4 pings, at least one must be answered
@@ -281,6 +312,11 @@ async fn receive_loop(
                     ProtoEvent::Hello { commit } => {
                         client_manager.set_peer_commit(handle, Some(commit));
                     }
+                    ProtoEvent::Capabilities {
+                        enter_with_position,
+                    } => {
+                        client_manager.set_peer_protocol_capabilities(handle, enter_with_position);
+                    }
                     event => tx.send((handle, event)).expect("channel closed"),
                 }
             }
@@ -305,6 +341,7 @@ async fn disconnect(
     conns.lock().await.remove(&addr);
     client_manager.set_active_addr(handle, None);
     client_manager.set_peer_commit(handle, None);
+    client_manager.set_peer_protocol_capabilities(handle, false);
     let active: Vec<SocketAddr> = conns.lock().await.keys().copied().collect();
     log::info!("active connections: {active:?}");
 }

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -1,7 +1,7 @@
 use crate::config::local_commit;
 use crate::listen::{LanMouseListener, ListenEvent, ListenerCreationError};
 use futures::StreamExt;
-use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError};
+use input_emulation::{EmulationHandle, InputEmulation, InputEmulationError, WarpPosition};
 use input_event::Event;
 use lan_mouse_proto::{Position, ProtoEvent};
 use local_channel::mpsc::{Receiver, Sender, channel};
@@ -86,6 +86,7 @@ impl Emulation {
             emulation_proxy,
             request_rx,
             event_tx,
+            transitions: Default::default(),
         };
         let task = spawn_local(emulation_task.run());
         Self {
@@ -134,6 +135,25 @@ struct ListenTask {
     emulation_proxy: EmulationProxy,
     request_rx: Receiver<EmulationRequest>,
     event_tx: Sender<EmulationEvent>,
+    transitions: HashMap<SocketAddr, IncomingTransition>,
+}
+
+#[derive(Clone, Copy)]
+enum IncomingTransition {
+    Legacy,
+    Modern { epoch: u64, serial: u32 },
+}
+
+impl IncomingTransition {
+    fn accepts(self, epoch: u64, serial: u32) -> bool {
+        match self {
+            Self::Legacy => true,
+            Self::Modern {
+                epoch: current_epoch,
+                serial: current_serial,
+            } => epoch > current_epoch || (epoch == current_epoch && serial > current_serial),
+        }
+    }
 }
 
 impl ListenTask {
@@ -149,11 +169,39 @@ impl ListenTask {
                         last_response.insert(addr, Instant::now());
                         match event {
                             ProtoEvent::Enter(pos) => {
+                                if matches!(self.transitions.get(&addr), Some(IncomingTransition::Modern { .. })) {
+                                    self.listener.reply(addr, ProtoEvent::Ack(0)).await;
+                                    continue;
+                                }
                                 if let Some(fingerprint) = self.listener.get_certificate_fingerprint(addr).await {
                                     log::info!("releasing capture: {addr} entered this device");
                                     self.event_tx.send(EmulationEvent::ReleaseNotify).expect("channel closed");
                                     self.listener.reply(addr, ProtoEvent::Ack(0)).await;
+                                    self.transitions.insert(addr, IncomingTransition::Legacy);
                                     self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
+                                }
+                            }
+                            ProtoEvent::EnterWithPosition { pos, cross_axis, epoch, serial } => {
+                                match self.transitions.get(&addr).copied() {
+                                    Some(current) if !current.accepts(epoch, serial) => {
+                                        self.listener.reply(addr, ProtoEvent::Ack(serial)).await;
+                                    }
+                                    _ => {
+                                        if let Some(fingerprint) = self.listener.get_certificate_fingerprint(addr).await {
+                                            log::info!("releasing capture: {addr} entered this device");
+                                            self.event_tx.send(EmulationEvent::ReleaseNotify).expect("channel closed");
+                                            if let Some(cross_axis) = cross_axis {
+                                                self.emulation_proxy.warp_cursor(
+                                                    to_warp_position(pos),
+                                                    cross_axis,
+                                                    addr,
+                                                );
+                                            }
+                                            self.listener.reply(addr, ProtoEvent::Ack(serial)).await;
+                                            self.transitions.insert(addr, IncomingTransition::Modern { epoch, serial });
+                                            self.event_tx.send(EmulationEvent::Entered{addr, pos: to_ipc_pos(pos), fingerprint}).expect("channel closed");
+                                        }
+                                    }
                                 }
                             }
                             ProtoEvent::Leave(_) => {
@@ -177,10 +225,14 @@ impl ListenTask {
                                 self.listener.reply(addr, ProtoEvent::Hello { commit: local_commit() }).await;
                                 self.event_tx.send(EmulationEvent::PeerHello { addr, commit }).expect("channel closed");
                             }
+                            ProtoEvent::Capabilities { .. } => {
+                                self.listener.reply(addr, ProtoEvent::Capabilities { enter_with_position: true }).await;
+                            }
                             _ => {}
                         }
                     }
                     Some(ListenEvent::Accept { addr, fingerprint }) => {
+                        self.transitions.remove(&addr);
                         self.event_tx.send(EmulationEvent::Connected { addr, fingerprint }).expect("channel closed");
                     }
                     Some(ListenEvent::Rejected { fingerprint }) => {
@@ -212,6 +264,7 @@ impl ListenTask {
                             log::warn!("releasing keys: {addr} not responding!");
                             self.emulation_proxy.remove(addr);
                             self.event_tx.send(EmulationEvent::Disconnected { addr }).expect("channel closed");
+                            self.transitions.remove(&addr);
                             false
                         } else {
                             true
@@ -237,6 +290,7 @@ pub(crate) struct EmulationProxy {
 
 enum ProxyRequest {
     Input(Event, SocketAddr),
+    WarpCursor(WarpPosition, f32, SocketAddr),
     Remove(SocketAddr),
     Terminate,
     Reenable,
@@ -286,6 +340,14 @@ impl EmulationProxy {
         }
     }
 
+    fn warp_cursor(&self, pos: WarpPosition, cross_axis: f32, addr: SocketAddr) {
+        if self.emulation_active.get() {
+            self.request_tx
+                .send(ProxyRequest::WarpCursor(pos, cross_axis, addr))
+                .expect("channel closed");
+        }
+    }
+
     fn remove(&self, addr: SocketAddr) {
         self.request_tx
             .send(ProxyRequest::Remove(addr))
@@ -331,6 +393,7 @@ impl EmulationTask {
                     ProxyRequest::Reenable => break,
                     ProxyRequest::Terminate => return,
                     ProxyRequest::Input(..) => { /* emulation inactive => ignore */ }
+                    ProxyRequest::WarpCursor(..) => {}
                     ProxyRequest::Remove(..) => { /* emulation inactive => ignore */ }
                 }
             }
@@ -397,6 +460,15 @@ impl EmulationTask {
                         };
                         emulation.consume(event, handle).await?;
                     },
+                    ProxyRequest::WarpCursor(pos, cross_axis, addr) => {
+                        if !self.handles.contains_key(&addr) {
+                            let handle = self.next_id;
+                            self.next_id += 1;
+                            emulation.create(handle).await;
+                            self.handles.insert(addr, handle);
+                        }
+                        emulation.warp_cursor(self.handles[&addr], pos, cross_axis).await?;
+                    }
                     ProxyRequest::Remove(addr) => {
                         if let Some(handle) = self.handles.remove(&addr) {
                             emulation.destroy(handle).await;
@@ -407,6 +479,15 @@ impl EmulationTask {
                 },
             }
         }
+    }
+}
+
+fn to_warp_position(pos: Position) -> WarpPosition {
+    match pos {
+        Position::Left => WarpPosition::Left,
+        Position::Right => WarpPosition::Right,
+        Position::Top => WarpPosition::Top,
+        Position::Bottom => WarpPosition::Bottom,
     }
 }
 
@@ -424,6 +505,7 @@ async fn wait_for_termination(rx: &mut Receiver<ProxyRequest>) {
         match rx.recv().await.expect("channel closed") {
             ProxyRequest::Terminate => return,
             ProxyRequest::Input(_, _) => continue,
+            ProxyRequest::WarpCursor(_, _, _) => continue,
             ProxyRequest::Remove(_) => continue,
             ProxyRequest::Reenable => continue,
         }
@@ -448,5 +530,64 @@ impl<T> Drop for DropGuard<T> {
         self.tx
             .send(self.on_drop.take().expect("item"))
             .expect("channel closed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncomingTransition;
+
+    #[test]
+    fn transition_accepts_a_new_serial_after_a_retry() {
+        assert!(
+            IncomingTransition::Modern {
+                epoch: 1,
+                serial: 7
+            }
+            .accepts(1, 8)
+        );
+    }
+
+    #[test]
+    fn transition_rejects_a_duplicate_serial() {
+        assert!(
+            !IncomingTransition::Modern {
+                epoch: 1,
+                serial: 7
+            }
+            .accepts(1, 7)
+        );
+    }
+
+    #[test]
+    fn transition_rejects_a_stale_serial() {
+        assert!(
+            !IncomingTransition::Modern {
+                epoch: 1,
+                serial: 7
+            }
+            .accepts(1, 6)
+        );
+    }
+
+    #[test]
+    fn transition_rejects_packets_from_a_previous_session() {
+        assert!(
+            !IncomingTransition::Modern {
+                epoch: 2,
+                serial: 1
+            }
+            .accepts(1, 99)
+        );
+    }
+
+    #[test]
+    fn transition_accepts_the_first_packet_after_a_reconnect() {
+        assert!(IncomingTransition::Legacy.accepts(1, 1));
+    }
+
+    #[test]
+    fn legacy_transition_accepts_the_first_modern_serial() {
+        assert!(IncomingTransition::Legacy.accepts(1, 1));
     }
 }


### PR DESCRIPTION
Addresses #230.

When moving the cursor from one machine to another, Lan Mouse currently only tells the receiving peer which edge was crossed.

It does not tell it **where along that edge** the cursor crossed, so the receiver can keep its previous cursor position instead. For example, crossing the right edge near the top of one screen may make the cursor appear at a completely different height on the other machine.

This PR makes the cursor enter the destination at the corresponding position along the edge.

## How it works

The source sends a normalized position (`Option<f32>`, `0.0..=1.0`) along the crossed edge:

* left/right crossings preserve the vertical position
* top/bottom crossings preserve the horizontal position

For a single monitor this is straightforward.

Multi-monitor layouts need a little more care. Using the percentage of the whole virtual desktop does not work well when monitors have different sizes, are stacked or offset, or have gaps between them.

Instead, Lan Mouse builds the parts of each desktop edge that are actually exposed to the outside and maps the cursor position across those edges. Internal borders between monitors and empty gaps are not counted.

This keeps the mapping based on the physical edge the cursor can actually cross.

## Protocol compatibility

The new `Capabilities` event lets peers advertise support for positioned transitions.

When both peers support it, the sender uses `EnterWithPosition`, which includes the edge, the optional cross-axis position, and transition identifiers: `epoch` (set once at startup, so the receiver can tell transitions from a previous process lifetime apart) plus `serial` (per-transition).

When the other peer does not support it, Lan Mouse keeps using the existing `Enter` event, so mixed old/new setups keep the previous behavior.

The existing protocol event IDs are unchanged; the new event types are appended after them. Unknown events are already ignored by the receive loop instead of closing the connection.

`EnterWithPosition` is also retried while waiting for its ACK. Its `epoch` and `serial` let the receiver recognize retries and stale transitions, so the same handoff is not applied multiple times.

## Backend support

Capture backends that currently provide the crossing position:

* libei (`InputCapturePortal`)
* layer-shell
* Windows

macOS and dummy capture currently send no position (`None`); macOS only for lack of a Mac to test against.

On the receiving side, cursor positioning is implemented for:

* Windows
* libei
* wlroots

Other emulation backends (X11, macOS, xdg-desktop-portal) keep their existing behavior.

macOS cursor positioning is left as a follow-up: the CoreGraphics pieces (display bounds, warp) are all available in the existing backend, but I have no Mac available to test against.

## Testing

The shared screen geometry is tested with:

* single and multi-monitor layouts
* different monitor sizes
* stacked and stepped layouts
* gaps and internal monitor edges
* negative coordinates
* normalization/denormalization round trips

The edge calculations are also checked against a separate grid-based model rather than only testing the implementation against itself. Generated coverage exercises 1,296 two-monitor layouts.

Protocol tests cover positioned transitions both with and without a cursor position, plus capability serialization.

Local verification on Linux:

* `cargo fmt --check`
* `cargo test -p input-event` — 25/25 passed
* `cargo test --workspace`
* `cargo clippy --workspace --all-targets -- -D warnings`

Runtime test on a real two-machine setup (Linux host on the left, Windows 11 client on the right): crossing at various heights lands at the corresponding height on the peer.

Note: the Windows build used for testing was compiled with `cargo build --no-default-features` (no GTK frontend), which is sufficient for daemon mode.
