### PR TITLE
nix(chore): set nixpkgs to nixos-26.05, update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "lastModified": 1788405554,
+        "narHash": "sha256-r2f1oUwixlgq9zOdYLqJLfS/lWBT60/IITjhTKI59JU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "rev": "a5cc6f2c37bf518436dc8d1c288ccd0c43c2f4c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025773,
-        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
+        "lastModified": 1788505699,
+        "narHash": "sha256-PSPDCdbEBEbSDCWcqv5GkbyD2ACQ9Diz6vmEbWdy4dM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
+        "rev": "9eccf73c5b810052f08aa77ae0548c383259f17f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Nix Flake for lan-mouse";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # 26.05 used here to keep allowing builds on x86_64-darwin, bump this to unstable once they deprecate 26.05
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -30,7 +31,24 @@
             let
               pkgs = import nixpkgs {
                 inherit system;
-                overlays = [ rust-overlay.overlays.default ];
+                overlays = [
+                  rust-overlay.overlays.default
+
+                  #NOTE: appstream's meson build injects the literal string
+                  # "none required" into linker flags on 'aarch64-darwin', causing clang to fail.
+                  # remove this overlay once we bump nixpkgs to unstable branch
+                  (
+                    final: prev:
+                    lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+                      appstream = prev.appstream.overrideAttrs (old: {
+                        postConfigure = (old.postConfigure or "") + ''
+                          substituteInPlace build.ninja \
+                            --replace-fail "none required" ""
+                        '';
+                      });
+                    }
+                  )
+                ];
               };
               # Default toolchain for devshell
               rustToolchain = pkgs.rust-bin.stable.latest.default.override {
@@ -80,7 +98,7 @@
                 libadwaita
                 librsvg
               ]
-              ++ lib.optionals pkgs.stdenv.isLinux [
+              ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
                 libX11
                 libXtst
               ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage {
     libadwaita
     librsvg
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libX11
     libXtst
   ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -23,12 +23,12 @@ in {
     };
     systemd = mkOption {
       type = types.bool;
-      default = pkgs.stdenv.isLinux;
+      default = pkgs.stdenv.hostPlatform.isLinux;
       description = "Whether to enable to systemd service for lan-mouse on linux.";
     };
     launchd = mkOption {
       type = types.bool;
-      default = pkgs.stdenv.isDarwin;
+      default = pkgs.stdenv.hostPlatform.isDarwin;
       description = "Whether to enable to launchd service for lan-mouse on macOS.";
     };
     settings = lib.mkOption {


### PR DESCRIPTION
Closes #492

Switched the `nixpkgs` input to `nixos-26.05`. I chose this version because it's the latest stable release and the last one that supports `x86_64-darwin` (unfortunately, 26.11 sunsets support for `x86_64-darwin` builds).

Bumped the flake inputs using `nix flake update`

I ran the build locally on my x86_64-linux machine it complied successfully and it works.
